### PR TITLE
ci: only allow sonarqube on pull requests from starlite-api branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,7 @@ jobs:
       - name: Test
         run: poetry run pytest --cov=. --cov-report=xml
       - name: SonarCloud Scan
+        if: github.repository_owner == 'starlite-api'  # do not run workflow on PRs from forks
         uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I'm pretty sure this should work..