### PR TITLE
Update OpenAPI default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,11 @@
 
 [0.2.1]
 - fix regression in handler validation
+
+
+[0.3.0]
+- updated openapi configuration:
+1. OpenAPI schema generation is now enabled by default
+2. The `OpenAPIController` is now part of the `OpenAPIConfig`
+3. The default schema download path changed from `/schema` to `/schema/openapi.json`
+4. Added a `/schema/openapi.yaml` route to the `OpenAPIController`

--- a/docs/usage/10-openapi.md
+++ b/docs/usage/10-openapi.md
@@ -16,7 +16,7 @@ specs version [3.1.0 - the latest version of the specification](https://spec.ope
 OpenAPI schema generation is enabled by default. To configure it you can pass an instance
 of `starlite.config.OpenAPIConfig` to the Starlite constructor using the `openapi_config` kwarg:
 
-```python
+```python title="my_app/main.py"
 from starlite import Starlite, OpenAPIConfig
 
 app = Starlite(
@@ -44,6 +44,20 @@ Aside from `title` and `version`, both of which are **required** kwargs, you can
 !!! note
     All models listed above are exported from [openapi-schema-pydantic](https://github.com/kuimono/openapi-schema-pydantic)
     rather than Starlite.
+
+#### Disable Schema Generation
+
+If you wish to disable schema generation and not include the schema endpoints in your API, simply pass `None` as the
+value for `openapi_config`:
+
+```python title="my_app/main.py"
+from starlite import Starlite, OpenAPIConfig
+
+app = Starlite(
+    route_handlers=[...], openapi_config=None
+)
+```
+
 
 ### Route Handler Configuration
 

--- a/docs/usage/10-openapi.md
+++ b/docs/usage/10-openapi.md
@@ -113,6 +113,9 @@ Starlite includes a pre-configured controller called `OpenAPIController` which e
    the `application/vnd.oai.openapi+json` Content-Type.
 3. `/schema/redoc`, which serves a [Redoc](https://github.com/Redocly/redoc) UI static website for the OpenAPI docs.
 
+!!! important
+    prior to version 0.3.0 there was only a single download endpoint by default and its path was `/schema`
+
 If you would like to modify the endpoints, add new endpoints, change the styling of redoc etc., you can subclass the
 `OpenAPIController` and then pass your subclass to the `OpenAPIConfig`.
 

--- a/docs/usage/10-openapi.md
+++ b/docs/usage/10-openapi.md
@@ -2,7 +2,7 @@
 
 Starlite has first class OpenAPI support offering the following features:
 
-1. extensive OpenAPI spec generation
+1. extensive OpenAPI 3.1.0 spec generation
 2. integrated [Redoc](https://github.com/Redocly/redoc) UI
 
 ## Spec Generation
@@ -13,8 +13,8 @@ specs version [3.1.0 - the latest version of the specification](https://spec.ope
 
 ### App Level Configuration
 
-To enable OpenAPI schema generation you need to pass an instance of `OpenAPIConfig` to the Starlite constructor using
-the `openapi_config` kwarg:
+OpenAPI schema generation is enabled by default. To configure it you can pass an instance
+of `starlite.config.OpenAPIConfig` to the Starlite constructor using the `openapi_config` kwarg:
 
 ```python
 from starlite import Starlite, OpenAPIConfig
@@ -26,22 +26,23 @@ app = Starlite(
 
 Aside from `title` and `version`, both of which are **required** kwargs, you can pass the following optional kwargs:
 
-* `create_examples`: Boolean flag dictating whether examples will be auto-generated using
+- `create_examples`: Boolean flag dictating whether examples will be auto-generated using
   the [pydantic-factories](https://github.com/starlite-api/pydantic-factories) library. Defaults to `False`.
-* `contact`: An instance of the `Contact` model.
-* `description`: Description text.
-* `external_docs`: An instance of the `ExternalDocumentation` model.
-* `license`: An instance of the `License` model.
-* `security`: An instance of the `SecurityRequirement` model.
-* `servers`: A list of `Server` model instances. defaults to `[Server("/")]`
-* `summary`: Summary text.
-* `tags`: A list of `Tag` model instances.
-* `terms_of_service`: A url to a page containing the terms of service.
-* `webhooks`: A string keyed dictionary of `PathItem` model instances.
+- `openapi_controller`: The controller class to use for the openapi to generate the openapi related routes. Must be a
+  subclass of [the openapi controller class](#the-openapi-controller).
+- `contact`: An instance of the `Contact` model.
+- `description`: Description text.
+- `external_docs`: An instance of the `ExternalDocumentation` model.
+- `license`: An instance of the `License` model.
+- `security`: An instance of the `SecurityRequirement` model.
+- `servers`: A list of `Server` model instances. defaults to `[Server("/")]`
+- `summary`: Summary text.
+- `tags`: A list of `Tag` model instances.
+- `terms_of_service`: A url to a page containing the terms of service.
+- `webhooks`: A string keyed dictionary of `PathItem` model instances.
 
 !!! note
-    All models listed above are exported
-    from [openapi-schema-pydantic](https://github.com/kuimono/openapi-schema-pydantic)
+    All models listed above are exported from [openapi-schema-pydantic](https://github.com/kuimono/openapi-schema-pydantic)
     rather than Starlite.
 
 ### Route Handler Configuration
@@ -71,12 +72,12 @@ You can also affect the schema by enriching and/or modifying it using the follow
   to `False`.
 - `raises`: A list of exception classes extending from `starlite.HttpException`. This list should describe all
   exceptions raised within the route handler's function/method. The Starlite `ValidationException` will be added
-  automatically for the schema if any validation is involved (e.g. there are parameters specified in the method/function).
+  automatically for the schema if any validation is involved (e.g. there are parameters specified in the
+  method/function).
 
-## Accessing the Schema
+## Accessing the OpenAPI Schema
 
-Once you enable OpenAPI schema generation by passing a config object to the Starlite constructor, the generated schema
-will become accessible in any route handler:
+The generated schema is an instance of the `OpenAPI` pydantic model, and you can access it in any route handler like so:
 
 ```python
 from starlite import Request, get
@@ -88,59 +89,38 @@ def my_route_handler(request: Request) -> None:
     ...
 ```
 
-The schema in the above is an instance of the `OpenAPI` pydantic model, and you can interact with it as you would with
-any other pydantic model
-
 ### The OpenAPI Controller
 
-Starlite includes a pre-configured controller called `OpenAPIController` which exposes two endpoints:
+Starlite includes a pre-configured controller called `OpenAPIController` which exposes three endpoints:
 
-1. a schema download endpoint with the default path - `/schema`
-2. an HTML endpoint that serves a Redoc UI for the schema with the default path - `/schema/redoc`
+1. `/schema/openapi.yaml`, allowing for download of the OpenAPI schema as YAML, using the `application/vnd.oai.openapi`
+   Content-Type.
+2. `/schema/openapi.json`, allowing for download of the OpenAPI schema as JSON, using
+   the `application/vnd.oai.openapi+json` Content-Type.
+3. `/schema/redoc`, which serves a [Redoc](https://github.com/Redocly/redoc) UI static website for the OpenAPI docs.
 
-To enable this controller simply add it to the app route handlers or a router, e.g.:
+If you would like to modify the endpoints, add new endpoints, change the styling of redoc etc., you can subclass the
+`OpenAPIController` and then pass your subclass to the `OpenAPIConfig`.
 
-```python
-from starlite import OpenAPIController, Starlite
-
-app = Starlite(route_handlers=[OpenAPIController])
-```
-
-The defaults for this controller are:
-
-1. path = `/schema`
-2. schema is sent using the `application/vnd.oai.openapi+json` Content-Type header
-3. there is no styling of Redoc and no favicon for it
-
-For example, lets say we wanted to serve the schema using the `application/vnd.oai.openapi` Content-Type, which is the
-convention for YAML, rather than using JSON. In this case we would do this:
+For example, lets say we wanted to change the base path from "/schema" to "/api-docs":
 
 ```python title="my_app/openapi.py"
-from openapi_schema_pydantic import OpenAPI
-from starlite import OpenAPIController, OpenAPIMediaType, Request, get
+from starlite import OpenAPIController
 
 
 class MyOpenAPIController(OpenAPIController):
-    @get(media_type=OpenAPIMediaType.OPENAPI_YAML, include_in_schema=False)
-    def retrieve_schema(self, request: Request) -> OpenAPI:
-        """Returns the openapi schema"""
-        return self.schema_from_request(request)
+    path = "/api-docs"
 ```
 
-And then we would use this controller our app instead:
+We would then use the subclassed controller like so:
 
 ```python
-from starlite import Starlite
+from starlite import Starlite, OpenAPIConfig
 
 from my_app.openapi import MyOpenAPIController
 
-app = Starlite(route_handlers=[MyOpenAPIController])
+app = Starlite(
+    route_handlers=[...],
+    openapi_config=OpenAPIConfig(openapI_controller=MyOpenAPIController),
+)
 ```
-
-### Redoc
-
-As mentioned previously the Starlite `OpenAPIController` comes with a Redoc UI endpoint. Once you enable the controller
-you can access the endpoint at `/schema/redoc` - by default. You can of course modify this path as you see fit.
-
-Redoc is served using a basic HTML template with no additional styling and no favicon. If you want to change this, you
-can easily do so by subclassing the controller and modifying the template.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "starlite"
-version = "0.2.1"
+version = "0.3.0"
 description = "Light-weight and flexible ASGI API Framework"
 authors = ["Na'aman Hirschfeld <nhirschfeld@gmail.com>"]
 maintainers = ["Na'aman Hirschfeld <nhirschfeld@gmail.com>"]

--- a/starlite/config.py
+++ b/starlite/config.py
@@ -13,6 +13,9 @@ from openapi_schema_pydantic import (
     Tag,
 )
 from pydantic import AnyUrl, BaseModel
+from typing_extensions import Type
+
+from starlite.openapi.controller import OpenAPIController
 
 
 class CORSConfig(BaseModel):
@@ -29,6 +32,7 @@ class OpenAPIConfig(BaseModel):
     """Class containing Settings and Schema Properties"""
 
     create_examples: bool = False
+    openapi_controller: Type[OpenAPIController] = OpenAPIController
 
     title: str
     version: str

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -3,6 +3,7 @@ from orjson.orjson import OPT_INDENT_2, dumps
 
 from starlite.controller import Controller
 from starlite.enums import MediaType, OpenAPIMediaType
+from starlite.exceptions import ImproperlyConfiguredException
 from starlite.handlers import get
 from starlite.request import Request
 
@@ -17,11 +18,17 @@ class OpenAPIController(Controller):
     @staticmethod
     def schema_from_request(request: Request) -> OpenAPI:
         """Returns the openapi schema"""
-        assert request.app.openapi_schema, "Starlite has not been instantiated with OpenAPIConfig"
+        if not request.app.openapi_schema:  # pragma: no cover
+            raise ImproperlyConfiguredException("Starlite has not been instantiated with OpenAPIConfig")
         return request.app.openapi_schema
 
-    @get(media_type=OpenAPIMediaType.OPENAPI_JSON, include_in_schema=False)
-    def retrieve_schema(self, request: Request) -> OpenAPI:
+    @get(path="/openapi.yaml", media_type=OpenAPIMediaType.OPENAPI_YAML, include_in_schema=False)
+    def retrieve_schema_yaml(self, request: Request) -> OpenAPI:
+        """Returns the openapi schema"""
+        return self.schema_from_request(request)
+
+    @get(path="/openapi.json", media_type=OpenAPIMediaType.OPENAPI_JSON, include_in_schema=False)
+    def retrieve_schema_json(self, request: Request) -> OpenAPI:
         """Returns the openapi schema"""
         return self.schema_from_request(request)
 

--- a/tests/openapi/test_integration.py
+++ b/tests/openapi/test_integration.py
@@ -1,34 +1,23 @@
 from typing import cast
 
 import yaml
-from openapi_schema_pydantic import OpenAPI
 from openapi_schema_pydantic.util import construct_open_api_with_schema_class
 from orjson import loads
 from starlette.status import HTTP_200_OK
 
-from starlite import OpenAPIController, Starlite, create_test_client, get
-from starlite.config import OpenAPIConfig
+from starlite import Starlite, create_test_client
+from starlite.app import DEFAULT_OPENAPI_CONFIG
 from starlite.enums import OpenAPIMediaType
-from starlite.request import Request
 from tests.openapi.utils import PersonController, PetController
 
 
-class OpenAPIControllerWithYaml(OpenAPIController):
-    @get(media_type=OpenAPIMediaType.OPENAPI_YAML, include_in_schema=False)
-    def retrieve_schema(self, request: Request) -> OpenAPI:
-        return self.schema_from_request(request)
-
-
 def test_openapi_yaml():
-    with create_test_client(
-        [PersonController, PetController, OpenAPIControllerWithYaml],
-        openapi_config=OpenAPIConfig(title="starlite", version="1"),
-    ) as client:
-        app = cast(Starlite, client.app)
+    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+        app = client.app
         assert app.openapi_schema
         openapi_schema = app.openapi_schema
         assert openapi_schema.paths
-        response = client.get("/schema")
+        response = client.get("/schema/openapi.yaml")
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"] == OpenAPIMediaType.OPENAPI_YAML.value
         assert yaml.safe_load(response.content) == construct_open_api_with_schema_class(app.openapi_schema).dict(
@@ -37,15 +26,12 @@ def test_openapi_yaml():
 
 
 def test_openapi_json():
-    with create_test_client(
-        [PersonController, PetController, OpenAPIController],
-        openapi_config=OpenAPIConfig(title="starlite", version="1"),
-    ) as client:
+    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
         app = cast(Starlite, client.app)
         assert app.openapi_schema
         openapi_schema = app.openapi_schema
         assert openapi_schema.paths
-        response = client.get("/schema")
+        response = client.get("/schema/openapi.json")
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"] == OpenAPIMediaType.OPENAPI_JSON.value
         assert response.json() == loads(

--- a/tests/test_dependency_injection.py
+++ b/tests/test_dependency_injection.py
@@ -124,12 +124,10 @@ def test_dependency_validation():
     def test_function(first: int, second: str, third: int) -> None:
         pass
 
-    app = Starlite(
-        route_handlers=[test_function],
-        dependencies={
-            "third": Provide(local_method_first_dependency),
-        },
-    )
-
     with pytest.raises(ImproperlyConfiguredException):
-        list(app.routes[0].route_handler_map.values())[0].resolve_dependencies()
+        Starlite(
+            route_handlers=[test_function],
+            dependencies={
+                "third": Provide(local_method_first_dependency),
+            },
+        )


### PR DESCRIPTION
This PR does the following:

1. enables OpenAPI by default
2. adds the OpenAPIController to the OpenAPIConfig so it no longer needs to be passed separately
3. simplifies the docs