### PR TITLE
update orjson import to work with orjson <3.6

### DIFF
--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -1,5 +1,5 @@
 from openapi_schema_pydantic import OpenAPI
-from orjson.orjson import OPT_INDENT_2, dumps
+from orjson import OPT_INDENT_2, dumps
 
 from starlite.controller import Controller
 from starlite.enums import MediaType, OpenAPIMediaType


### PR DESCRIPTION
👋 First let me tell that `Starlite` is a really exciting project.

While working on a new project I found a small `bug` when working with `old` **orjson** version (which is pinned somewhere in my env 🤷‍♂️)

It seems that the new orjson version (>=3.6) enable import like `from orison.orjson import ...` but earlier version doesn't work.

with orjson <3.6 
```python
import orjson
orjson.__version__
>>> '3.5.2'

from orjson.orjson import OPT_INDENT_2, dumps
----> 1 from orjson.orjson import OPT_INDENT_2, dumps
ModuleNotFoundError: No module named 'orjson.orjson'; 'orjson' is not a package

from orjson import OPT_INDENT_2, dumps
print(OPT_INDENT_2)
>>> 1
```

with orjson >= 3.6 
```python
import orjson
orjson.__version__
>>> '3.6.5'

from orjson.orjson import OPT_INDENT_2, dumps
print(OPT_INDENT_2)
>>> 1
```
