### PR TITLE
Add DTOFactory

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -468,7 +468,7 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydantic-factories"
-version = "1.2.0"
+version = "1.2.1"
 description = "Mock data generation for pydantic based models"
 category = "main"
 optional = false
@@ -1207,8 +1207,8 @@ pydantic = [
     {file = "pydantic-1.9.0.tar.gz", hash = "sha256:742645059757a56ecd886faf4ed2441b9c0cd406079c2b4bee51bcc3fbcd510a"},
 ]
 pydantic-factories = [
-    {file = "pydantic-factories-1.2.0.tar.gz", hash = "sha256:ff82bcf7e8249e375541ff66e5ee959909da4a39ba702e7ed11e5be8842cd9c2"},
-    {file = "pydantic_factories-1.2.0-py3-none-any.whl", hash = "sha256:5fd712b6a6de92e992d756a37333a5d750d04beeb94b919ac9d324b1dedc9c37"},
+    {file = "pydantic-factories-1.2.1.tar.gz", hash = "sha256:12eed8a664d1d888f7f2b7fd86a384d22dc83c0706e30f62b022a094cdc18d46"},
+    {file = "pydantic_factories-1.2.1-py3-none-any.whl", hash = "sha256:7d360ce8f333ab302e9e0d3955cf6165e965f48054d59fdc70b2406cbf9b4222"},
 ]
 pygments = [
     {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},

--- a/starlite/__init__.py
+++ b/starlite/__init__.py
@@ -2,6 +2,7 @@
 from .app import Starlite
 from .config import CORSConfig, OpenAPIConfig
 from .controller import Controller
+from .dto import DTOFactory
 from .enums import (
     HttpMethod,
     MediaType,
@@ -52,6 +53,7 @@ __all__ = [
     "Body",
     "CORSConfig",
     "Controller",
+    "DTOFactory",
     "File",
     "HTTPException",
     "HTTPRoute",

--- a/starlite/dto.py
+++ b/starlite/dto.py
@@ -1,0 +1,89 @@
+from dataclasses import is_dataclass
+from typing import Any, Dict, ForwardRef, List, Optional, Tuple, Union, cast
+
+from pydantic import BaseModel, create_model
+from pydantic.fields import ModelField, Undefined
+from typing_extensions import Type
+
+from starlite.exceptions import ImproperlyConfiguredException
+from starlite.plugins import PluginProtocol, get_plugin_for_value
+from starlite.utils import convert_dataclass_to_model
+
+
+class DTOFactory:
+    def __init__(self, plugins: Optional[List[PluginProtocol]] = None):
+        self.plugins = plugins or []
+
+    def __call__(
+        self,
+        name: str,
+        source: Any,
+        exclude: Optional[List[str]] = None,
+        field_mapping: Optional[Dict[str, Union[str, Tuple[str, Any]]]] = None,
+    ) -> Type[BaseModel]:
+        """
+        Given a supported model class - either pydantic, dataclass or a class supported via plugins,
+        create a DTO pydantic model class.
+
+        An instance of the factory must first be created, passing any plugins to it.
+        It can then be used to create a DTO by calling the instance like a function. Additionally, it can exclude (drop)
+        attributes specifies in the 'exclude' list and remap field names and/or field types.
+
+        For example, given a pydantic model
+
+            class MyClass(BaseModel):
+                first: int
+                second: int
+
+            MyClassDTO = DTOFactory()(MyClass, exclude=["first"], field_mapping={"second": ("third", float)})
+
+        `MyClassDTO` is now equal to this:
+            class MyClassDTO(BaseModel):
+                third: float
+
+        It can be used as a regular pydantic model:
+
+            @post(path="/my-path)
+            def create_obj(data: MyClassDTO) -> MyClass:
+                ...
+
+        This will affect parsing, validation and how OpenAPI schema is generated exactly like when using a pydantic model.
+
+        Note: Although the value generated is a pydantic factory, because it is being generated programmaticaly,
+        it's currently not possible to extend editor auto-complete for the DTO properties - it will be typed as a
+        Pydantic BaseModel, but no attributes will be inferred in the editor.
+        """
+        fields: Dict[str, ModelField]
+        exclude = exclude or []
+        field_mapping = field_mapping or {}
+        field_definitions: Dict[str, Tuple[Any, Any]] = {}
+        if issubclass(source, BaseModel):
+            source.update_forward_refs()
+            fields = source.__fields__
+        elif is_dataclass(source):
+            fields = convert_dataclass_to_model(source).__fields__
+        else:
+            plugin = get_plugin_for_value(value=source, plugins=self.plugins)
+            if not plugin:
+                raise ImproperlyConfiguredException(
+                    f"No supported plugin found for value {source} - cannot create value"
+                )
+            model = plugin.to_pydantic_model_class(model_class=source)
+            fields = model.__fields__
+        for field_name, model_field in fields.items():
+            if field_name not in exclude:
+                outer_type = model_field.outer_type_
+                field_type = outer_type if not isinstance(outer_type, ForwardRef) else model_field.type_
+                if field_name in field_mapping:
+                    mapping = field_mapping[field_name]
+                    if isinstance(mapping, tuple):
+                        field_name, field_type = mapping
+                    else:
+                        field_name = mapping
+                if model_field.field_info.default is not Undefined:
+                    field_definitions[field_name] = (field_type, model_field.default)
+                elif not model_field.allow_none:
+                    field_definitions[field_name] = (field_type, ...)
+                else:
+                    field_definitions[field_name] = (field_type, None)
+        return cast(Type[BaseModel], create_model(name, **field_definitions))  # type: ignore

--- a/starlite/plugins/sql_alchemy.py
+++ b/starlite/plugins/sql_alchemy.py
@@ -1,6 +1,5 @@
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-from enum import Enum
 from inspect import isclass
 from ipaddress import IPv4Network, IPv6Network
 from typing import Any, Callable, Dict, List, Tuple, Union
@@ -82,6 +81,12 @@ class SQLAlchemyPlugin(PluginProtocol[Union[DeclarativeMeta, Table]]):
         types = [self.get_pydantic_type(column_type=t) for t in column_type.types]
         return Tuple[tuple(types)]
 
+    def handle_enum(self, column_type: Union[sqlalchemy_type.Enum, mysql.ENUM, postgresql.ENUM]) -> Any:
+        """
+        Handles the SQLAlchemy Enum types
+        """
+        return column_type.enum_class
+
     @property
     def providers_map(self) -> Dict[Type[TypeEngine], Callable[[Union[TypeEngine, Type[TypeEngine]]], Any]]:
         """
@@ -104,7 +109,7 @@ class SQLAlchemyPlugin(PluginProtocol[Union[DeclarativeMeta, Table]]):
             sqlalchemy_type.DECIMAL: self.handle_numeric_type,
             sqlalchemy_type.Date: lambda x: date,
             sqlalchemy_type.DateTime: lambda x: datetime,
-            sqlalchemy_type.Enum: lambda x: Enum,
+            sqlalchemy_type.Enum: self.handle_enum,
             sqlalchemy_type.FLOAT: self.handle_numeric_type,
             sqlalchemy_type.Float: self.handle_numeric_type,
             sqlalchemy_type.INT: lambda x: int,
@@ -157,7 +162,7 @@ class SQLAlchemyPlugin(PluginProtocol[Union[DeclarativeMeta, Table]]):
             mysql.DATETIME: lambda x: datetime,
             mysql.DECIMAL: self.handle_numeric_type,
             mysql.DOUBLE: self.handle_numeric_type,
-            mysql.ENUM: lambda x: Enum,
+            mysql.ENUM: self.handle_enum,
             mysql.FLOAT: self.handle_numeric_type,
             mysql.INTEGER: lambda x: int,
             mysql.JSON: lambda x: Json,
@@ -200,7 +205,7 @@ class SQLAlchemyPlugin(PluginProtocol[Union[DeclarativeMeta, Table]]):
             postgresql.CIDR: lambda x: Union[IPv4Network, IPv6Network],
             postgresql.DATERANGE: lambda x: Tuple[date, date],
             postgresql.DOUBLE_PRECISION: self.handle_numeric_type,
-            postgresql.ENUM: lambda x: Enum,
+            postgresql.ENUM: self.handle_enum,
             postgresql.HSTORE: lambda x: Dict[str, str],
             postgresql.INET: lambda x: Union[IPv4Network, IPv6Network],
             postgresql.INT4RANGE: lambda x: Tuple[int, int],

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass as vanilla_dataclass
 from enum import Enum
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic_factories import ModelFactory
 
@@ -16,7 +16,7 @@ class Species(str, Enum):
 
 class Pet(BaseModel):
     name: str
-    species: Species
+    species: Species = Field(default=Species.MONKEY)
     age: float
 
 

--- a/tests/plugins/sql_alchemy_plugin/__init__.py
+++ b/tests/plugins/sql_alchemy_plugin/__init__.py
@@ -1,5 +1,7 @@
-from sqlalchemy import Column
-from sqlalchemy.orm import as_declarative, declared_attr
+from sqlalchemy import Column, Enum, Float, ForeignKey, Integer, String, Table
+from sqlalchemy.orm import as_declarative, declared_attr, relationship
+
+from tests import Species
 
 
 @as_declarative()
@@ -10,3 +12,49 @@ class SQLAlchemyBase:
     @declared_attr
     def __tablename__(cls):
         return cls.__name__.lower()
+
+
+association_table = Table(
+    "association",
+    SQLAlchemyBase.metadata,
+    Column("pet_id", ForeignKey("pet.id")),
+    Column("user_id", ForeignKey("user.id")),
+)
+friendship_table = Table(
+    "friendships",
+    SQLAlchemyBase.metadata,
+    Column("friend_a_id", Integer, ForeignKey("user.id"), primary_key=True),
+    Column("friend_b_id", Integer, ForeignKey("user.id"), primary_key=True),
+)
+
+
+class Pet(SQLAlchemyBase):
+    id = Column(Integer, primary_key=True)
+    species = Column(Enum(Species))
+    name = Column(String)
+    age = Column(Float)
+    owner_id = Column(Integer, ForeignKey("user.id"))
+    owner = relationship("User", back_populates="pets")
+
+
+class Company(SQLAlchemyBase):
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    worth = Column(Float)
+
+
+class User(SQLAlchemyBase):
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    pets = relationship(
+        "Pet",
+        back_populates="owner",
+    )
+    friends = relationship(
+        "User",
+        secondary=friendship_table,
+        primaryjoin=id == friendship_table.c.friend_a_id,
+        secondaryjoin=id == friendship_table.c.friend_b_id,
+    )
+    company_id = Column(Integer, ForeignKey("company.id"))
+    company = relationship("Company")

--- a/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_plugin_integration.py
+++ b/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_plugin_integration.py
@@ -4,19 +4,11 @@ from pydantic_factories.value_generators.primitives import (
     create_random_float,
     create_random_string,
 )
-from sqlalchemy import Column, Float, Integer, String
 from starlette.status import HTTP_200_OK, HTTP_201_CREATED
 
 from starlite import create_test_client, get, post
 from starlite.plugins.sql_alchemy import SQLAlchemyPlugin
-from tests.plugins.sql_alchemy_plugin import SQLAlchemyBase
-
-
-class Company(SQLAlchemyBase):
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
-    worth = Column(Float)
-
+from tests.plugins.sql_alchemy_plugin import Company
 
 companies = [
     Company(id=i, name=create_random_string(min_length=5, max_length=20), worth=create_random_float(minimum=1))

--- a/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_relationships.py
+++ b/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_relationships.py
@@ -1,55 +1,8 @@
 from pydantic import BaseModel
-from sqlalchemy import Column, Enum, Float, ForeignKey, Integer, String, Table
-from sqlalchemy.orm import relationship
 from typing_extensions import get_args
 
 from starlite.plugins.sql_alchemy import SQLAlchemyPlugin
-from tests import Species
-from tests.plugins.sql_alchemy_plugin import SQLAlchemyBase
-
-association_table = Table(
-    "association",
-    SQLAlchemyBase.metadata,
-    Column("pet_id", ForeignKey("pet.id")),
-    Column("user_id", ForeignKey("user.id")),
-)
-
-friendship_table = Table(
-    "friendships",
-    SQLAlchemyBase.metadata,
-    Column("friend_a_id", Integer, ForeignKey("user.id"), primary_key=True),
-    Column("friend_b_id", Integer, ForeignKey("user.id"), primary_key=True),
-)
-
-
-class Pet(SQLAlchemyBase):
-    id = Column(Integer, primary_key=True)
-    species = Column(Enum(Species))
-    name = Column(String)
-    age = Column(Float)
-    owner_id = Column(Integer, ForeignKey("user.id"))
-    owner = relationship("User", back_populates="pets")
-
-
-class Firm(SQLAlchemyBase):
-    id = Column(Integer, primary_key=True)
-
-
-class User(SQLAlchemyBase):
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
-    pets = relationship(
-        "Pet",
-        back_populates="owner",
-    )
-    friends = relationship(
-        "User",
-        secondary=friendship_table,
-        primaryjoin=id == friendship_table.c.friend_a_id,
-        secondaryjoin=id == friendship_table.c.friend_b_id,
-    )
-    firm_id = Column(Integer, ForeignKey("firm.id"))
-    firm = relationship("Firm")
+from tests.plugins.sql_alchemy_plugin import Pet, User
 
 
 def test_relationship():
@@ -64,9 +17,9 @@ def test_relationship():
     assert get_args(pets.outer_type_)  # we assert this is a List[]
     assert issubclass(pets.type_, BaseModel)
     assert pets.type_.__fields__["owner"].type_ is result
-    firm = fields["firm"]
-    assert not get_args(firm.outer_type_)
-    assert issubclass(firm.type_, BaseModel)
+    company = fields["company"]
+    assert not get_args(company.outer_type_)
+    assert issubclass(company.type_, BaseModel)
 
 
 def test_table_name():

--- a/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_table_types.py
+++ b/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_table_types.py
@@ -60,6 +60,7 @@ from sqlalchemy.sql.functions import now
 
 from starlite import ImproperlyConfiguredException
 from starlite.plugins.sql_alchemy import SQLAlchemyPlugin
+from tests import Species
 from tests.plugins.sql_alchemy_plugin import SQLAlchemyBase
 
 plugin = SQLAlchemyPlugin()
@@ -85,7 +86,7 @@ class DeclarativeModel(SQLAlchemyBase):
     DECIMAL_column = Column(DECIMAL)
     Date_column = Column(Date)
     DateTime_column = Column(DateTime, default=now)
-    Enum_column = Column(Enum)
+    Enum_column = Column(Enum(Species))
     FLOAT_column = Column(FLOAT(asdecimal=True))
     Float_column = Column(Float)
     INT_column = Column(INT)
@@ -138,7 +139,7 @@ class DeclarativeModel(SQLAlchemyBase):
     mysql_DATETIME_column = Column(mysql.DATETIME)
     mysql_DECIMAL_column = Column(mysql.DECIMAL)
     mysql_DOUBLE_column = Column(mysql.DOUBLE)
-    mysql_ENUM_column = Column(mysql.ENUM)
+    mysql_ENUM_column = Column(mysql.ENUM(Species))
     mysql_FLOAT_column = Column(mysql.FLOAT)
     mysql_INTEGER_column = Column(mysql.INTEGER)
     mysql_JSON_column = Column(mysql.JSON)
@@ -181,7 +182,7 @@ class DeclarativeModel(SQLAlchemyBase):
     postgresql_CIDR_column = Column(postgresql.CIDR)
     postgresql_DATERANGE_column = Column(postgresql.DATERANGE)
     postgresql_DOUBLE_PRECISION_column = Column(postgresql.DOUBLE_PRECISION)
-    postgresql_ENUM_column = Column(postgresql.ENUM)
+    postgresql_ENUM_column = Column(postgresql.ENUM(Species))
     postgresql_HSTORE_column = Column(postgresql.HSTORE)
     postgresql_INET_column = Column(postgresql.INET)
     postgresql_INT4RANGE_column = Column(postgresql.INT4RANGE)

--- a/tests/test_dto.py
+++ b/tests/test_dto.py
@@ -1,0 +1,94 @@
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+from pydantic_factories import ModelFactory
+from starlette.status import HTTP_200_OK, HTTP_201_CREATED
+
+from starlite import (
+    DTOFactory,
+    ImproperlyConfiguredException,
+    SQLAlchemyPlugin,
+    create_test_client,
+    get,
+    post,
+)
+from tests import Person
+from tests import Pet as PydanticPet
+from tests import Species, VanillaDataClassPerson
+from tests.plugins.sql_alchemy_plugin import Pet
+
+
+@pytest.mark.parametrize(
+    "model, exclude, field_mapping, plugins",
+    [
+        [Person, ["id"], {"complex": "ultra"}, []],
+        [VanillaDataClassPerson, ["id"], {"complex": "ultra"}, []],
+        [Pet, ["age"], {"species": "kind"}, [SQLAlchemyPlugin()]],
+    ],
+)
+def test_dto_factory(model: Any, exclude: list, field_mapping: dict, plugins: list):
+    dto = DTOFactory(plugins=plugins)("MyDTO", model, exclude=exclude, field_mapping=field_mapping)
+    assert issubclass(dto, BaseModel)
+    assert dto.__name__ == "MyDTO"
+    assert not any(excluded_key in dto.__fields__ for excluded_key in exclude)
+    assert all(remapped_key in dto.__fields__ for remapped_key in field_mapping.values())
+
+
+def test_dto_factory_type_remap():
+    dto = DTOFactory(plugins=[])(
+        "PersonDTO", Person, field_mapping={"id": ("id", int), "optional": ("required", str), "complex": "simple"}
+    )
+    assert issubclass(dto, BaseModel)
+    fields = dto.__fields__
+    assert fields["id"].type_ is int
+    assert fields["required"].type_ is str
+    assert fields["simple"].type_ == Person.__fields__["complex"].type_
+
+
+def test_dto_factory_handle_of_default_values():
+    dto = DTOFactory(plugins=[])("PetFactory", PydanticPet)
+    assert issubclass(dto, BaseModel)
+    fields = dto.__fields__
+    assert fields["species"].default is Species.MONKEY
+
+
+def test_dto_factory_validation():
+    class MyClass:
+        name: str
+
+    with pytest.raises(ImproperlyConfiguredException):
+        DTOFactory(plugins=[])("MyDTO", MyClass)
+
+
+@pytest.mark.parametrize(
+    "model, exclude, field_mapping, plugins",
+    [
+        [Person, ["id"], {"complex": "ultra"}, []],
+        [VanillaDataClassPerson, ["id"], {"complex": "ultra"}, []],
+        [Pet, ["owner"], {"species": "kind"}, [SQLAlchemyPlugin()]],
+    ],
+)
+def test_dto_integration(model: Any, exclude: list, field_mapping: dict, plugins: list):
+    dto = DTOFactory(plugins=plugins)("MyDTO", model, exclude=exclude, field_mapping=field_mapping)
+
+    class DTOModelFactory(ModelFactory):
+        __model__ = dto
+
+    dto_instance = DTOModelFactory.build().dict()
+
+    @post(path="/")
+    def post_handler(data: dto) -> None:
+        assert isinstance(data, dto)
+        assert data == dto_instance
+
+    @get(path="/")
+    def get_handler() -> dto:
+        return dto_instance
+
+    with create_test_client(route_handlers=[post_handler, get_handler]) as client:
+        post_response = client.post("/", json=dto_instance)
+        assert post_response.status_code == HTTP_201_CREATED
+        get_response = client.get("/")
+        assert get_response.status_code == HTTP_200_OK
+        assert get_response.json() == dto_instance

--- a/tests/utils/test_model.py
+++ b/tests/utils/test_model.py
@@ -1,32 +1,10 @@
 from functools import lru_cache
-from typing import Optional
 
 import pytest
 from starlette.status import HTTP_204_NO_CONTENT
 
 from starlite import ImproperlyConfiguredException, get
 from starlite.utils import create_function_signature_model
-
-
-def test_create_function_signature_model_parameter_parsing():
-    @get()
-    def my_fn(a: int, b: str, c: Optional[bytes], d: bytes = b"123", e: Optional[dict] = None) -> None:
-        pass
-
-    model = create_function_signature_model(my_fn.fn, [])
-    fields = model.__fields__
-    assert fields.get("a").type_ == int
-    assert fields.get("a").required
-    assert fields.get("b").type_ == str
-    assert fields.get("b").required
-    assert fields.get("c").type_ == bytes
-    assert fields.get("c").allow_none
-    assert fields.get("c").default is None
-    assert fields.get("d").type_ == bytes
-    assert fields.get("d").default == b"123"
-    assert fields.get("e").type_ == dict
-    assert fields.get("e").allow_none
-    assert fields.get("e").default is None
 
 
 def test_create_function_signature_model_ignore_return_annotation():

--- a/tests/utils/test_signature.py
+++ b/tests/utils/test_signature.py
@@ -1,0 +1,25 @@
+from typing import Optional
+
+from starlite import get
+from starlite.utils import create_function_signature_model
+
+
+def test_create_function_signature_model_parameter_parsing():
+    @get()
+    def my_fn(a: int, b: str, c: Optional[bytes], d: bytes = b"123", e: Optional[dict] = None) -> None:
+        pass
+
+    model = create_function_signature_model(my_fn.fn, [])
+    fields = model.__fields__
+    assert fields.get("a").type_ == int
+    assert fields.get("a").required
+    assert fields.get("b").type_ == str
+    assert fields.get("b").required
+    assert fields.get("c").type_ == bytes
+    assert fields.get("c").allow_none
+    assert fields.get("c").default is None
+    assert fields.get("d").type_ == bytes
+    assert fields.get("d").default == b"123"
+    assert fields.get("e").type_ == dict
+    assert fields.get("e").allow_none
+    assert fields.get("e").default is None


### PR DESCRIPTION
This PR adds a DTOFactory class.

This class can be used to create DTOs from pydantic models, dataclasses and any other class supported via plugins:

Given a supported model class - either pydantic, dataclass or a class supported via plugins, create a DTO pydantic model class.

An instance of the factory must first be created, passing any plugins to it. It can then be used to create a DTO by calling the instance like a function. Additionally, it can exclude (drop) attributes specifies in the 'exclude' list and remap field names and/or field types.

For example, given a pydantic model
```python
class MyClass(BaseModel):
    first: int
    second: int

MyClassDTO = DTOFactory()(MyClass, exclude=["first"], field_mapping={"second": ("third", float)})
```

`MyClassDTO` is now equal to this:

```python
class MyClassDTO(BaseModel):
    third: float
````

It can be used as a regular pydantic model:

```python            
@post(path="/my-path)
def create_obj(data: MyClassDTO) -> MyClass:
    ...
```
                
This will affect parsing, validation and how OpenAPI schema is generated exactly like when using a pydantic model.

Note: Although the value generated is a pydantic factory, because it is being generated programmaticaly, 
it's currently not possible to extend editor auto-complete for the DTO properties - it will be typed as a 
Pydantic BaseModel, but no attributes will be inferred in the editor.