### PR TITLE
Add support for "before_request" and "after_request" hooks

### DIFF
--- a/starlite/app.py
+++ b/starlite/app.py
@@ -28,6 +28,8 @@ from starlite.request import Request
 from starlite.response import Response
 from starlite.routing import HTTPRoute, Router
 from starlite.types import (
+    AFTER_REQUEST_HANDLER,
+    BEFORE_REQUEST_HANDLER,
     ControllerRouterHandler,
     ExceptionHandler,
     Guard,
@@ -40,6 +42,25 @@ DEFAULT_OPENAPI_CONFIG = OpenAPIConfig(title="Starlite API", version="1.0.0")
 
 
 class Starlite(Router):
+    __slots__ = (
+        "after_request",
+        "asgi_router",
+        "before_request",
+        "debug",
+        "dependencies",
+        "exception_handlers",
+        "guards",
+        "middleware_stack",
+        "openapi_schema",
+        "owner",
+        "path",
+        "plugins",
+        "response_class",
+        "response_headers",
+        "routes",
+        "state",
+    )
+
     @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
@@ -58,7 +79,10 @@ class Starlite(Router):
         redirect_slashes: bool = True,
         response_class: Optional[Type[Response]] = None,
         response_headers: Optional[Dict[str, ResponseHeader]] = None,
-        plugins: Optional[List[PluginProtocol]] = None
+        plugins: Optional[List[PluginProtocol]] = None,
+        # connection-lifecycle hook handlers
+        before_request: Optional[BEFORE_REQUEST_HANDLER] = None,
+        after_request: Optional[AFTER_REQUEST_HANDLER] = None,
     ):
         self.debug = debug
         self.state = State()
@@ -70,6 +94,8 @@ class Starlite(Router):
             response_class=response_class,
             response_headers=response_headers,
             route_handlers=route_handlers,
+            before_request=before_request,
+            after_request=after_request,
         )
         self.asgi_router: StarletteRouter = StarletteRouter(
             redirect_slashes=redirect_slashes,

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -43,22 +43,15 @@ DEFAULT_OPENAPI_CONFIG = OpenAPIConfig(title="Starlite API", version="1.0.0")
 
 class Starlite(Router):
     __slots__ = (
-        "after_request",
         "asgi_router",
-        "before_request",
         "debug",
-        "dependencies",
         "exception_handlers",
-        "guards",
         "middleware_stack",
         "openapi_schema",
-        "owner",
-        "path",
         "plugins",
-        "response_class",
-        "response_headers",
-        "routes",
         "state",
+        # the rest of __slots__ are defined in Router and should not be duplicated
+        # see: https://stackoverflow.com/questions/472000/usage-of-slots
     )
 
     @validate_arguments(config={"arbitrary_types_allowed": True})

--- a/starlite/controller.py
+++ b/starlite/controller.py
@@ -4,7 +4,12 @@ from typing_extensions import Type
 
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.response import Response
-from starlite.types import Guard, ResponseHeader
+from starlite.types import (
+    AFTER_REQUEST_HANDLER,
+    BEFORE_REQUEST_HANDLER,
+    Guard,
+    ResponseHeader,
+)
 from starlite.utils import normalize_path
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -14,7 +19,15 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class Controller:
-    __slots__ = ("dependencies", "owner", "path", "response_headers", "response_class")
+    __slots__ = (
+        "dependencies",
+        "owner",
+        "path",
+        "response_headers",
+        "response_class",
+        "before_request",
+        "after_request",
+    )
 
     dependencies: Optional[Dict[str, "Provide"]]
     owner: "Router"
@@ -22,12 +35,24 @@ class Controller:
     response_headers: Optional[Dict[str, ResponseHeader]]
     response_class: Optional[Type[Response]]
     guards: Optional[List[Guard]]
+    # connection-lifecycle hook handlers
+    before_request: Optional[BEFORE_REQUEST_HANDLER]
+    after_request: Optional[AFTER_REQUEST_HANDLER]
 
     def __init__(self, owner: "Router"):
         if not hasattr(self, "path") or not self.path:
             raise ImproperlyConfiguredException("Controller subclasses must set a path attribute")
 
-        for key in ["dependencies", "response_headers", "response_class", "guards"]:
+        for key in [
+            "dependencies",
+            "response_headers",
+            "response_class",
+            "guards",
+            "before_request",
+            "before_websocket",
+            "after_request",
+            "after_websocket",
+        ]:
             if not hasattr(self, key):
                 setattr(self, key, None)
 

--- a/starlite/controller.py
+++ b/starlite/controller.py
@@ -49,9 +49,7 @@ class Controller:
             "response_class",
             "guards",
             "before_request",
-            "before_websocket",
             "after_request",
-            "after_websocket",
         ]:
             if not hasattr(self, key):
                 setattr(self, key, None)

--- a/starlite/controller.py
+++ b/starlite/controller.py
@@ -25,6 +25,7 @@ class Controller:
         "path",
         "response_headers",
         "response_class",
+        "guards",
         "before_request",
         "after_request",
     )

--- a/starlite/handlers.py
+++ b/starlite/handlers.py
@@ -1,7 +1,17 @@
 from contextlib import suppress
 from enum import Enum
 from inspect import Signature, isawaitable, isclass
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Generator,
+    List,
+    Optional,
+    Type,
+    Union,
+    cast,
+)
 
 from pydantic import BaseModel, Extra, Field, ValidationError, validator
 from pydantic.error_wrappers import display_errors
@@ -25,7 +35,15 @@ from starlite.plugins.base import PluginMapping, get_plugin_for_value
 from starlite.provide import Provide
 from starlite.request import Request, WebSocket, get_model_kwargs_from_connection
 from starlite.response import Response
-from starlite.types import File, Guard, Redirect, ResponseHeader, Stream
+from starlite.types import (
+    AFTER_REQUEST_HANDLER,
+    BEFORE_REQUEST_HANDLER,
+    File,
+    Guard,
+    Redirect,
+    ResponseHeader,
+    Stream,
+)
 from starlite.utils import SignatureModel
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -62,15 +80,25 @@ class BaseRouteHandler(BaseModel):
     resolved_guards: Union[List[Guard], Type[_empty]] = _empty
     signature_model: Optional[Type[SignatureModel]] = None
 
+    def ownership_layers(self) -> Generator[Union["BaseRouteHandler", Controller, "Router"], None, None]:
+        """
+        Returns all the handler and then all owners up to the app level
+
+        handler -> ... -> App
+        """
+        cur: Any = self
+        while cur:
+            value = cur
+            cur = cur.owner
+            yield value
+
     def resolve_guards(self) -> List[Guard]:
         """Returns all guards in the handlers scope, starting from highest to current layer"""
         if self.resolved_guards is _empty:
             resolved_guards: List[Guard] = []
-            cur: Any = self
-            while cur is not None:
-                if cur.guards:
-                    resolved_guards.extend(cur.guards)
-                cur = cur.owner
+            for layer in self.ownership_layers():
+                if layer.guards:
+                    resolved_guards.extend(layer.guards)
             # we reverse the list to ensure that the highest level guards are called first
             self.resolved_guards = list(reversed(resolved_guards))
         return cast(List[Guard], self.resolved_guards)
@@ -84,13 +112,11 @@ class BaseRouteHandler(BaseModel):
         if self.resolved_dependencies is _empty:
             field_names = list(self.signature_model.__fields__.keys())
             dependencies: Dict[str, Provide] = {}
-            cur: Any = self
-            while cur is not None:
-                for key, value in (cur.dependencies or {}).items():
+            for layer in self.ownership_layers():
+                for key, value in (layer.dependencies or {}).items():
                     self.validate_dependency_is_unique(dependencies=dependencies, key=key, provider=value)
                     if key in field_names and key not in dependencies:
                         dependencies[key] = value
-                cur = cur.owner
             self.resolved_dependencies = dependencies
         return cast(Dict[str, Provide], self.resolved_dependencies)
 
@@ -181,13 +207,17 @@ class HTTPRouteHandler(BaseRouteHandler):
 
     resolved_headers: Union[Dict[str, ResponseHeader], Type[_empty]] = _empty
     resolved_response_class: Union[Type[Response], Type[_empty]] = _empty
-
+    # connection-lifecycle hook handlers
+    after_request: Optional[AFTER_REQUEST_HANDLER] = None
+    before_request: Optional[BEFORE_REQUEST_HANDLER] = None
+    resolved_after_request: Union[Optional[BEFORE_REQUEST_HANDLER], Type[_empty]] = _empty
+    resolved_before_request: Union[Optional[BEFORE_REQUEST_HANDLER], Type[_empty]] = _empty
     # OpenAPI related attributes
-    include_in_schema: bool = True
     content_encoding: Optional[str] = None
     content_media_type: Optional[str] = None
     deprecated: bool = False
     description: Optional[str] = None
+    include_in_schema: bool = True
     operation_id: Optional[str] = None
     raises: Optional[List[Type[HTTPException]]] = None
     response_description: Optional[str] = None
@@ -202,16 +232,22 @@ class HTTPRouteHandler(BaseRouteHandler):
         self.validate_handler_function()
         return self
 
+    def ownership_layers(self) -> Generator[Union["HTTPRouteHandler", Controller, "Router"], None, None]:
+        """
+        Returns all the handler and then all owners up to the app level
+
+        handler -> ... -> App
+        """
+        return cast(Generator[Union["HTTPRouteHandler", Controller, "Router"], None, None], super().ownership_layers())
+
     def resolve_response_class(self) -> Type[Response]:
         """Return the closest custom Response class in the owner graph or the default Response class"""
         if self.resolved_response_class is _empty:
             self.resolved_response_class = Response
-            cur: Any = self
-            while cur is not None:
-                if cur.response_class is not None:
-                    self.resolved_response_class = cast(Type[Response], cur.response_class)
+            for layer in self.ownership_layers():
+                if layer.response_class is not None:
+                    self.resolved_response_class = layer.response_class
                     break
-                cur = cur.owner
         return cast(Type[Response], self.resolved_response_class)
 
     def resolve_response_headers(self) -> Dict[str, ResponseHeader]:
@@ -220,20 +256,52 @@ class HTTPRouteHandler(BaseRouteHandler):
         """
         if self.resolved_headers is _empty:
             headers: Dict[str, ResponseHeader] = {}
-            cur: Any = self
-            while cur is not None:
-                for key, value in (cur.response_headers or {}).items():
+            for layer in self.ownership_layers():
+                for key, value in (layer.response_headers or {}).items():
                     if key not in headers:
                         headers[key] = value
-                cur = cur.owner
             self.resolved_headers = headers
         return cast(Dict[str, ResponseHeader], self.resolved_headers)
+
+    def resolve_before_request(self) -> Optional[BEFORE_REQUEST_HANDLER]:
+        """
+        Resolves the before_handler handler by starting from the handler and moving up.
+
+        If a handler is found it is returned, otherwise None is set.
+        This mehtod is memoized so the computation occurs only once
+        """
+        if self.resolved_before_request is _empty:
+            for layer in self.ownership_layers():
+                if layer.before_request:
+                    self.resolved_before_request = layer.before_request
+                    break
+            if self.resolved_before_request is _empty:
+                self.resolved_before_request = None
+        return self.resolved_before_request
+
+    def resolve_after_request(self) -> Optional[AFTER_REQUEST_HANDLER]:
+        """
+        Resolves the after_request handler by starting from the handler and moving up.
+
+        If a handler is found it is returned, otherwise None is set.
+        This mehtod is memoized so the computation occurs only once
+        """
+        if self.resolved_after_request is _empty:
+            for layer in self.ownership_layers():
+                if layer.after_request:
+                    self.resolved_after_request = layer.after_request  # type: ignore
+                    break
+            if self.resolved_after_request is _empty:
+                self.resolved_after_request = None
+        return cast(Optional[AFTER_REQUEST_HANDLER], self.resolved_after_request)
 
     @validator("http_method", always=True, pre=True)
     def validate_http_method(  # pylint: disable=no-self-argument,no-self-use
         cls, value: Union[HttpMethod, List[HttpMethod]]
     ) -> Union[HttpMethod, List[HttpMethod]]:
-        """Validates that a given value is an HttpMethod enum member or list thereof"""
+        """
+        Validates that a given value is an HttpMethod enum member or list thereof
+        """
         if not value:
             raise ValueError("An http_method parameter is required")
         if isinstance(value, list):
@@ -299,44 +367,67 @@ class HTTPRouteHandler(BaseRouteHandler):
         Handles a given Request in relation to self.
         """
         if not self.fn:
-            raise ImproperlyConfiguredException("cannot call a route handler without a decorated function")
-        await self.authorize_connection(connection=request)
-        params = await self.get_parameters_from_connection(connection=request)
+            raise ImproperlyConfiguredException("cannot call 'handle' without a decorated function")
 
-        if isinstance(self.owner, Controller):
-            data = self.fn(self.owner, **params)
-        else:
-            data = self.fn(**params)
+        await self.authorize_connection(connection=request)
+
+        before_request_handler = self.resolve_before_request()
+        data = None
+        # run the before_request hook handler
+        if before_request_handler:
+            data = before_request_handler(request)
+
+        # if data has not been returned by the before request handler, we proceed with the request
+        if data is None:
+            params = await self.get_parameters_from_connection(connection=request)
+            if isinstance(self.owner, Controller):
+                data = self.fn(self.owner, **params)
+            else:
+                data = self.fn(**params)
+
         if isawaitable(data):
             data = await data
-        if isinstance(data, StarletteResponse):
-            return data
 
+        return await self.to_response(request=request, data=data)
+
+    async def to_response(self, request: Request, data: Any) -> StarletteResponse:
+        """
+        Given a data kwarg, determine its type and return the appropriate response
+        """
+        after_request = self.resolve_after_request()
         status_code = cast(int, self.status_code)
-        headers = {k: v.value for k, v in self.resolve_response_headers().items()}
-        if isinstance(data, Redirect):
-            return RedirectResponse(headers=headers, status_code=status_code, url=data.path)
-
         media_type = self.media_type.value if isinstance(self.media_type, Enum) else self.media_type
-        if isinstance(data, File):
-            return FileResponse(media_type=media_type, headers=headers, **data.dict())
-        if isinstance(data, Stream):
-            return StreamingResponse(
+        headers = {k: v.value for k, v in self.resolve_response_headers().items()}
+        if isinstance(data, StarletteResponse):
+            response = data
+        elif isinstance(data, Redirect):
+            response = RedirectResponse(headers=headers, status_code=status_code, url=data.path)
+        elif isinstance(data, File):
+            response = FileResponse(media_type=media_type, headers=headers, **data.dict())
+        elif isinstance(data, Stream):
+            response = StreamingResponse(
                 content=data.iterator, status_code=status_code, media_type=media_type, headers=headers
             )
-        plugin = get_plugin_for_value(data, request.app.plugins)
-        if plugin:
-            if isinstance(data, (list, tuple)):
-                data = [plugin.to_dict(datum) for datum in data]
-            else:
-                data = plugin.to_dict(data)
-        response_class = self.resolve_response_class()
-        return response_class(
-            headers=headers,
-            status_code=status_code,
-            content=data,
-            media_type=media_type,
-        )
+        else:
+            plugin = get_plugin_for_value(data, request.app.plugins)
+            if plugin:
+                if isinstance(data, (list, tuple)):
+                    data = [plugin.to_dict(datum) for datum in data]
+                else:
+                    data = plugin.to_dict(data)
+            response_class = self.resolve_response_class()
+            response = response_class(
+                headers=headers,
+                status_code=status_code,
+                content=data,
+                media_type=media_type,
+            )
+        # run the after_request hook handler
+        if after_request:
+            response = after_request(response)  # type: ignore
+            if isawaitable(response):
+                response = await response
+        return response
 
 
 route = HTTPRouteHandler

--- a/starlite/request.py
+++ b/starlite/request.py
@@ -18,7 +18,7 @@ User = TypeVar("User")
 Auth = TypeVar("Auth")
 
 
-class Request(StarletteRequest, Generic[User, Auth]):
+class Request(StarletteRequest, Generic[User, Auth]):  # pragma: no cover
     @property
     def app(self) -> "Starlite":
         return cast("Starlite", self.scope["app"])
@@ -40,7 +40,7 @@ class Request(StarletteRequest, Generic[User, Auth]):
         return cast(Auth, self.scope["auth"])
 
 
-class WebSocket(StarletteWebSocket, Generic[User, Auth]):
+class WebSocket(StarletteWebSocket, Generic[User, Auth]):  # pragma: no cover
     @property
     def app(self) -> "Starlite":
         return cast("Starlite", self.scope["app"])

--- a/starlite/routing.py
+++ b/starlite/routing.py
@@ -24,7 +24,14 @@ from starlite.handlers import BaseRouteHandler, HTTPRouteHandler, WebsocketRoute
 from starlite.provide import Provide
 from starlite.request import Request, WebSocket
 from starlite.response import Response
-from starlite.types import ControllerRouterHandler, Guard, Method, ResponseHeader
+from starlite.types import (
+    AFTER_REQUEST_HANDLER,
+    BEFORE_REQUEST_HANDLER,
+    ControllerRouterHandler,
+    Guard,
+    Method,
+    ResponseHeader,
+)
 from starlite.utils import find_index, join_paths, normalize_path, unique
 
 param_match_regex = re.compile(r"{(.*?)}")
@@ -197,6 +204,18 @@ class WebSocketRoute(BaseRoute):
 
 
 class Router:
+    __slots__ = (
+        "after_request",
+        "before_request",
+        "dependencies",
+        "guards",
+        "owner",
+        "path",
+        "response_class",
+        "response_headers",
+        "routes",
+    )
+
     @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
@@ -207,6 +226,9 @@ class Router:
         guards: Optional[List[Guard]] = None,
         response_class: Optional[Type[Response]] = None,
         response_headers: Optional[Dict[str, ResponseHeader]] = None,
+        # connection-lifecycle hook handlers
+        before_request: Optional[BEFORE_REQUEST_HANDLER] = None,
+        after_request: Optional[AFTER_REQUEST_HANDLER] = None,
     ):
         self.owner: Optional["Router"] = None
         self.routes: List[BaseRoute] = []
@@ -215,6 +237,8 @@ class Router:
         self.dependencies = dependencies
         self.response_headers = response_headers
         self.guards = guards
+        self.before_request = before_request
+        self.after_request = after_request
         for route_handler in route_handlers or []:
             self.register(value=route_handler)
 

--- a/starlite/routing.py
+++ b/starlite/routing.py
@@ -111,16 +111,9 @@ class BaseRoute(ABC, StarletteBaseRoute):
 
 class HTTPRoute(BaseRoute):
     __slots__ = (
-        "app",
-        "handler_names",
-        "methods",
-        "param_convertors",
-        "path",
-        "path_format",
-        "path_parameters",
-        "path_regex",
         "route_handler_map",
-        "scope_type",
+        # the rest of __slots__ are defined in BaseRoute and should not be duplicated
+        # see: https://stackoverflow.com/questions/472000/usage-of-slots
     )
 
     @validate_arguments()
@@ -169,16 +162,9 @@ class HTTPRoute(BaseRoute):
 
 class WebSocketRoute(BaseRoute):
     __slots__ = (
-        "app",
-        "handler_names",
-        "methods",
-        "param_convertors",
-        "path",
-        "path_format",
-        "path_parameters",
-        "path_regex",
         "route_handler",
-        "scope_type",
+        # the rest of __slots__ are defined in BaseRoute and should not be duplicated
+        # see: https://stackoverflow.com/questions/472000/usage-of-slots
     )
 
     @validate_arguments()

--- a/starlite/testing.py
+++ b/starlite/testing.py
@@ -18,7 +18,13 @@ from starlite.enums import HttpMethod, RequestEncodingType
 from starlite.handlers import BaseRouteHandler
 from starlite.plugins.base import PluginProtocol
 from starlite.request import Request
-from starlite.types import ExceptionHandler, Guard, MiddlewareProtocol
+from starlite.types import (
+    AFTER_REQUEST_HANDLER,
+    BEFORE_REQUEST_HANDLER,
+    ExceptionHandler,
+    Guard,
+    MiddlewareProtocol,
+)
 
 
 class RequestEncoder(RequestEncodingMixin):
@@ -62,10 +68,12 @@ def create_test_client(
         Union[Type[Controller], BaseRouteHandler, Router, AnyCallable],
         List[Union[Type[Controller], BaseRouteHandler, Router, AnyCallable]],
     ],
+    after_request: Optional[AFTER_REQUEST_HANDLER] = None,
     allowed_hosts: Optional[List[str]] = None,
     backend: str = "asyncio",
     backend_options: Optional[Dict[str, Any]] = None,
     base_url: str = "http://testserver",
+    before_request: Optional[BEFORE_REQUEST_HANDLER] = None,
     cors_config: Optional[CORSConfig] = None,
     dependencies: Optional[Dict[str, Provide]] = None,
     exception_handlers: Optional[Dict[Union[int, Type[Exception]], ExceptionHandler]] = None,
@@ -74,14 +82,16 @@ def create_test_client(
     on_shutdown: Optional[List[NoArgAnyCallable]] = None,
     on_startup: Optional[List[NoArgAnyCallable]] = None,
     openapi_config: Optional[OpenAPIConfig] = None,
+    plugins: Optional[List[PluginProtocol]] = None,
     raise_server_exceptions: bool = True,
     root_path: str = "",
-    plugins: Optional[List[PluginProtocol]] = None,
 ) -> TestClient:
     """Create a TestClient"""
     return TestClient(
         app=Starlite(
+            after_request=after_request,
             allowed_hosts=allowed_hosts,
+            before_request=before_request,
             cors_config=cors_config,
             dependencies=dependencies,
             exception_handlers=exception_handlers,
@@ -90,30 +100,30 @@ def create_test_client(
             on_shutdown=on_shutdown,
             on_startup=on_startup,
             openapi_config=openapi_config,
-            route_handlers=cast(Any, route_handlers if isinstance(route_handlers, list) else [route_handlers]),
             plugins=plugins,
+            route_handlers=cast(Any, route_handlers if isinstance(route_handlers, list) else [route_handlers]),
         ),
+        backend=backend,
+        backend_options=backend_options,
         base_url=base_url,
         raise_server_exceptions=raise_server_exceptions,
         root_path=root_path,
-        backend=backend,
-        backend_options=backend_options,
     )
 
 
 def create_test_request(
     http_method: HttpMethod = HttpMethod.GET,
+    app: Optional[Starlite] = None,
+    content: Optional[Union[Dict[str, Any], BaseModel]] = None,
+    cookie: Optional[str] = None,
+    headers: Optional[Dict[str, str]] = None,
+    path: str = "",
+    port: int = 3000,
+    query: Optional[Dict[str, Union[str, List[str]]]] = None,
+    request_media_type: RequestEncodingType = RequestEncodingType.JSON,
+    root_path: str = "/",
     scheme: str = "http",
     server: str = "test.org",
-    port: int = 3000,
-    root_path: str = "/",
-    path: str = "",
-    query: Optional[Dict[str, Union[str, List[str]]]] = None,
-    headers: Optional[Dict[str, str]] = None,
-    cookie: Optional[str] = None,
-    content: Optional[Union[Dict[str, Any], BaseModel]] = None,
-    request_media_type: RequestEncodingType = RequestEncodingType.JSON,
-    app: Optional[Starlite] = None,
 ) -> Request:
     """Create a starlette request using passed in parameters"""
 

--- a/starlite/types.py
+++ b/starlite/types.py
@@ -35,10 +35,11 @@ except ImportError:  # pragma: no cover
 if TYPE_CHECKING:  # pragma: no cover
     from starlite.controller import Controller
     from starlite.handlers import BaseRouteHandler
-    from starlite.request import Request
+    from starlite.request import Request, WebSocket
     from starlite.routing import Router
 else:
     Request = Any
+    WebSocket = Any
     BaseRouteHandler = Any
     Controller = Any
     Router = Any
@@ -51,6 +52,13 @@ Guard = Union[
 ]
 Method = Union[Literal["GET"], Literal["POST"], Literal["DELETE"], Literal["PATCH"], Literal["PUT"], Literal["HEAD"]]
 ControllerRouterHandler = Union[Type[Controller], BaseRouteHandler, Router, AnyCallable]
+
+# connection-lifecycle hook handlers
+BEFORE_REQUEST_HANDLER = Union[Callable[[Request], Any], Callable[[Request], Awaitable[Any]]]
+AFTER_REQUEST_HANDLER = Union[
+    Callable[[Union[StarletteResponse, Response]], Union[StarletteResponse, Response]],
+    Callable[[Union[StarletteResponse, Response]], Awaitable[Union[StarletteResponse, Response]]],
+]
 
 
 @runtime_checkable

--- a/tests/test_connection_lifecycle_hooks.py
+++ b/tests/test_connection_lifecycle_hooks.py
@@ -1,0 +1,69 @@
+import pytest
+
+from starlite import Request, Response, create_test_client, get
+
+
+def greet() -> dict:
+    return {"hello": "world"}
+
+
+def sync_before_request_handler_with_return_value(request: Request) -> dict:
+    assert isinstance(request, Request)
+    return {"hello": "moon"}
+
+
+async def async_before_request_handler_with_return_value(request: Request) -> dict:
+    assert isinstance(request, Request)
+    return {"hello": "moon"}
+
+
+def sync_before_request_handler_without_return_value(request: Request) -> None:
+    assert isinstance(request, Request)
+    return None
+
+
+async def async_before_request_handler_without_return_value(request: Request) -> None:
+    assert isinstance(request, Request)
+    return None
+
+
+@pytest.mark.parametrize(
+    "handler, expected",
+    [
+        [get(path="/")(greet), {"hello": "world"}],
+        [get(path="/", before_request=sync_before_request_handler_with_return_value)(greet), {"hello": "moon"}],
+        [get(path="/", before_request=async_before_request_handler_with_return_value)(greet), {"hello": "moon"}],
+        [get(path="/", before_request=sync_before_request_handler_without_return_value)(greet), {"hello": "world"}],
+        [get(path="/", before_request=async_before_request_handler_without_return_value)(greet), {"hello": "world"}],
+    ],
+)
+def test_before_request_handler_called(handler, expected):
+    with create_test_client(route_handlers=handler) as client:
+        response = client.get("/")
+        assert response.json() == expected
+
+
+def sync_after_request_handler(response: Response) -> Response:
+    assert isinstance(response, Response)
+    response.body = response.render({"hello": "moon"})
+    return response
+
+
+async def async_after_request_handler(response: Response) -> Response:
+    assert isinstance(response, Response)
+    response.body = response.render({"hello": "moon"})
+    return response
+
+
+@pytest.mark.parametrize(
+    "handler, expected",
+    [
+        [get(path="/")(greet), {"hello": "world"}],
+        [get(path="/", after_request=sync_after_request_handler)(greet), {"hello": "moon"}],
+        [get(path="/", after_request=async_after_request_handler)(greet), {"hello": "moon"}],
+    ],
+)
+def test_after_request_handler_called(handler, expected):
+    with create_test_client(route_handlers=handler) as client:
+        response = client.get("/")
+        assert response.json() == expected

--- a/tests/test_connection_lifecycle_hooks.py
+++ b/tests/test_connection_lifecycle_hooks.py
@@ -1,6 +1,6 @@
 import pytest
 
-from starlite import Request, Response, create_test_client, get
+from starlite import Controller, Request, Response, Router, create_test_client, get
 
 
 def greet() -> dict:
@@ -27,22 +27,6 @@ async def async_before_request_handler_without_return_value(request: Request) ->
     return None
 
 
-@pytest.mark.parametrize(
-    "handler, expected",
-    [
-        [get(path="/")(greet), {"hello": "world"}],
-        [get(path="/", before_request=sync_before_request_handler_with_return_value)(greet), {"hello": "moon"}],
-        [get(path="/", before_request=async_before_request_handler_with_return_value)(greet), {"hello": "moon"}],
-        [get(path="/", before_request=sync_before_request_handler_without_return_value)(greet), {"hello": "world"}],
-        [get(path="/", before_request=async_before_request_handler_without_return_value)(greet), {"hello": "world"}],
-    ],
-)
-def test_before_request_handler_called(handler, expected):
-    with create_test_client(route_handlers=handler) as client:
-        response = client.get("/")
-        assert response.json() == expected
-
-
 def sync_after_request_handler(response: Response) -> Response:
     assert isinstance(response, Response)
     response.body = response.render({"hello": "moon"})
@@ -59,6 +43,22 @@ async def async_after_request_handler(response: Response) -> Response:
     "handler, expected",
     [
         [get(path="/")(greet), {"hello": "world"}],
+        [get(path="/", before_request=sync_before_request_handler_with_return_value)(greet), {"hello": "moon"}],
+        [get(path="/", before_request=async_before_request_handler_with_return_value)(greet), {"hello": "moon"}],
+        [get(path="/", before_request=sync_before_request_handler_without_return_value)(greet), {"hello": "world"}],
+        [get(path="/", before_request=async_before_request_handler_without_return_value)(greet), {"hello": "world"}],
+    ],
+)
+def test_before_request_handler_called(handler, expected):
+    with create_test_client(route_handlers=handler) as client:
+        response = client.get("/")
+        assert response.json() == expected
+
+
+@pytest.mark.parametrize(
+    "handler, expected",
+    [
+        [get(path="/")(greet), {"hello": "world"}],
         [get(path="/", after_request=sync_after_request_handler)(greet), {"hello": "moon"}],
         [get(path="/", after_request=async_after_request_handler)(greet), {"hello": "moon"}],
     ],
@@ -66,4 +66,102 @@ async def async_after_request_handler(response: Response) -> Response:
 def test_after_request_handler_called(handler, expected):
     with create_test_client(route_handlers=handler) as client:
         response = client.get("/")
+        assert response.json() == expected
+
+
+@pytest.mark.parametrize(
+    "app_before_request_handler, router_before_request_handler, controller_before_request_handler, method_before_request_handler, expected",
+    [
+        [None, None, None, None, {"hello": "world"}],
+        [sync_before_request_handler_with_return_value, None, None, None, {"hello": "moon"}],
+        [None, sync_before_request_handler_with_return_value, None, None, {"hello": "moon"}],
+        [None, None, sync_before_request_handler_with_return_value, None, {"hello": "moon"}],
+        [None, None, None, sync_before_request_handler_with_return_value, {"hello": "moon"}],
+        [
+            sync_before_request_handler_with_return_value,
+            async_before_request_handler_without_return_value,
+            None,
+            None,
+            {"hello": "world"},
+        ],
+        [
+            None,
+            sync_before_request_handler_with_return_value,
+            async_before_request_handler_without_return_value,
+            None,
+            {"hello": "world"},
+        ],
+        [
+            None,
+            None,
+            sync_before_request_handler_with_return_value,
+            async_before_request_handler_without_return_value,
+            {"hello": "world"},
+        ],
+        [None, None, None, async_before_request_handler_without_return_value, {"hello": "world"}],
+    ],
+)
+def test_before_request_handler_resolution(
+    app_before_request_handler,
+    router_before_request_handler,
+    controller_before_request_handler,
+    method_before_request_handler,
+    expected,
+):
+    class MyController(Controller):
+        path = "/hello"
+
+        before_request = controller_before_request_handler
+
+        @get(before_request=method_before_request_handler)
+        def hello(self) -> dict:
+            return {"hello": "world"}
+
+    router = Router(path="/greetings", route_handlers=[MyController], before_request=router_before_request_handler)
+
+    with create_test_client(route_handlers=router, before_request=app_before_request_handler) as client:
+        response = client.get("/greetings/hello")
+        assert response.json() == expected
+
+
+async def async_after_request_handler_with_hello_world(response: Response) -> Response:
+    assert isinstance(response, Response)
+    response.body = response.render({"hello": "world"})
+    return response
+
+
+@pytest.mark.parametrize(
+    "app_after_request_handler, router_after_request_handler, controller_after_request_handler, method_after_request_handler, expected",
+    [
+        [None, None, None, None, {"hello": "world"}],
+        [sync_after_request_handler, None, None, None, {"hello": "moon"}],
+        [None, sync_after_request_handler, None, None, {"hello": "moon"}],
+        [None, None, sync_after_request_handler, None, {"hello": "moon"}],
+        [None, None, None, sync_after_request_handler, {"hello": "moon"}],
+        [sync_after_request_handler, async_after_request_handler_with_hello_world, None, None, {"hello": "world"}],
+        [None, sync_after_request_handler, async_after_request_handler_with_hello_world, None, {"hello": "world"}],
+        [None, None, sync_after_request_handler, async_after_request_handler_with_hello_world, {"hello": "world"}],
+        [None, None, None, async_after_request_handler_with_hello_world, {"hello": "world"}],
+    ],
+)
+def test_after_request_handler_resolution(
+    app_after_request_handler,
+    router_after_request_handler,
+    controller_after_request_handler,
+    method_after_request_handler,
+    expected,
+):
+    class MyController(Controller):
+        path = "/hello"
+
+        after_request = controller_after_request_handler
+
+        @get(after_request=method_after_request_handler)
+        def hello(self) -> dict:
+            return {"hello": "world"}
+
+    router = Router(path="/greetings", route_handlers=[MyController], after_request=router_after_request_handler)
+
+    with create_test_client(route_handlers=router, after_request=app_after_request_handler) as client:
+        response = client.get("/greetings/hello")
         assert response.json() == expected


### PR DESCRIPTION
This PR adds ''before_request" and "after_request" hooks. 

These are directly borrowed from flask, with two differences:

1. Async support
2. You can define these functions on all layers - app, router,  controller, method/function, and the lowest level takes precedence. 