### PR TITLE
Add templating

### DIFF
--- a/starlite/config.py
+++ b/starlite/config.py
@@ -16,6 +16,7 @@ from pydantic import AnyUrl, BaseModel, DirectoryPath
 from typing_extensions import Type
 
 from starlite.openapi.controller import OpenAPIController
+from starlite.template import TemplateEngine
 
 
 class CORSConfig(BaseModel):
@@ -71,3 +72,11 @@ class StaticFilesConfig(BaseModel):
     path: str
     directories: List[DirectoryPath]
     html_mode: bool = False
+
+
+class TemplateConfig(BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    directory: Union[DirectoryPath, List[DirectoryPath]]
+    engine: Type[TemplateEngine]

--- a/starlite/response.py
+++ b/starlite/response.py
@@ -9,6 +9,7 @@ from starlette.responses import Response as StarletteResponse
 
 from starlite.enums import MediaType, OpenAPIMediaType
 from starlite.exceptions import ImproperlyConfiguredException
+from starlite.template import TemplateEngine
 
 
 class Response(StarletteResponse):
@@ -53,3 +54,25 @@ class Response(StarletteResponse):
             return super().render(content)
         except (AttributeError, ValueError, TypeError) as e:
             raise ImproperlyConfiguredException("Unable to serialize response content") from e
+
+
+class TemplateResponse(StarletteResponse):
+    def __init__(
+        self,
+        context: Dict[str, Any],
+        template_name: str,
+        template_engine: TemplateEngine,
+        status_code: int,
+        background: Optional[BackgroundTask] = None,
+        headers: Optional[Dict[str, str]] = None,
+    ):
+        template = template_engine.get_template(template_name)
+        content = template.render(context)
+
+        super().__init__(
+            content=content,
+            status_code=status_code,
+            headers=headers or {},
+            media_type=MediaType.HTML,
+            background=background,  # type: ignore
+        )

--- a/starlite/template.py
+++ b/starlite/template.py
@@ -1,0 +1,52 @@
+from typing import Any, Dict, List, Union
+
+from typing_extensions import Protocol, runtime_checkable
+
+from starlite.exceptions import MissingDependencyException
+
+
+@runtime_checkable
+class Template(Protocol):
+    def render(self, context: Dict[str, Any]) -> str:
+        ...
+
+
+@runtime_checkable
+class TemplateEngineProtocol(Protocol):
+    directory: str
+
+    def get_template(self, name: str) -> Template:
+        ...
+
+
+class JinjaTemplateEngine:
+    __slots__ = ("_engine", "directory")
+
+    def __init__(self, directory: Union[str, List[str]]) -> None:
+        try:
+            import jinja2  # pylint: disable=C0415
+        except ImportError as e:
+            raise MissingDependencyException("jinja2 is not installed") from e
+
+        self.directory = directory
+        loader = jinja2.FileSystemLoader(searchpath=directory)
+        self._engine = jinja2.Environment(loader=loader, autoescape=True)
+
+    def get_template(self, name: str) -> Template:
+        return self._engine.get_template(name=name)
+
+
+class MakoTemplateEngine:
+    __slots__ = ("_engine", "directory")
+
+    def __init__(self, directory: Union[str, List[str]]) -> None:
+        try:
+            from mako.lookup import TemplateLookup  # pylint: disable=C0415
+        except ImportError as e:
+            raise MissingDependencyException("mako is not installed") from e
+
+        self.directory = directory
+        self._engine = TemplateLookup([directory])
+
+    def get_template(self, name: str) -> Template:
+        return self._engine.get_template(name)


### PR DESCRIPTION
This PR adds support for returning a `dict` as the context for a template from a handler and automatically rendering it. 
Currently `Mako` and `Jinja2` are supported out of the box.

This PR is not completed and hence is a draft.