### PR TITLE
Remove "]" in README code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class UserController(Controller):
         ...
 
     @put(path="/{user_id:uuid}")
-    async def update_user(self, user_id: UUID4, data: User]) -> User]:
+    async def update_user(self, user_id: UUID4, data: User]) -> User:
         ...
 
     @get(path="/{user_id:uuid}")


### PR DESCRIPTION
Was jumpstarting a project, and noticed a syntax error in the example code block.