### PR TITLE
Add templating

### DIFF
--- a/docs/usage/5-responses.md
+++ b/docs/usage/5-responses.md
@@ -62,17 +62,17 @@ used:
 - GET, PATCH, PUT: 200 (Ok)
 
 !!! note
-    When using the `route` decorator with multiple http methods, the default status code is `200`.
+When using the `route` decorator with multiple http methods, the default status code is `200`.
 
 Also note that the default for `delete` is no content because by default it is assumed that delete operations return no
 data. This though might not be the case in your implementation - so take care of setting it as you see fit.
 
 !!! tip
-    While you can specify write integers as the value for `status_code`, e.g. `status_code=200`,
-    its best practice to use constants (also in tests). Starlette includes easy to use statuses that are
-    exported from `starlette.status`, e.g. `HTTP_200_OK` and `HTTP_201_CREATED`. Another option is the `http.HTTPStatus`
-    enum from the standard library, which also offers extra functionality.
-    For this see [the standard library documentation](https://docs.python.org/3/library/http.html#http.HTTPStatus).
+While you can specify write integers as the value for `status_code`, e.g. `status_code=200`,
+its best practice to use constants (also in tests). Starlette includes easy to use statuses that are
+exported from `starlette.status`, e.g. `HTTP_200_OK` and `HTTP_201_CREATED`. Another option is the `http.HTTPStatus`
+enum from the standard library, which also offers extra functionality.
+For this see [the standard library documentation](https://docs.python.org/3/library/http.html#http.HTTPStatus).
 
 ## Media Type
 
@@ -124,12 +124,12 @@ def health_check() -> str:
 ```
 
 !!! tip
-    It's a good idea to use a templating engine for more complex HTML responses and to write the template itself in a
-    separate file rather than a string.
+It's a good idea to use a [templating engine](#template-responses) for more complex HTML responses and to write the
+[template](#template-responses) itself in a separate file rather than a string.
 
 ### JSON Responses
 
-As previously mentioned, the default `media_type` is `MediaType.JSON`.  which supports the following values:
+As previously mentioned, the default `media_type` is `MediaType.JSON`. which supports the following values:
 
 - dictionaries
 - dataclasses from the standard library
@@ -207,10 +207,10 @@ The File class expects two kwargs:
   attachment.
 
 !!! important
-    When a route handler's return value is annotated with `File`, the default `media_type` for the
-    route_handler is switched from `MediaType.JSON` to `MediaType.TEXT` (i.e. "text/plain"). If the file being sent has
-    an [IANA media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), you should set it as
-    the value for `media_type` instead.
+When a route handler's return value is annotated with `File`, the default `media_type` for the
+route_handler is switched from `MediaType.JSON` to `MediaType.TEXT` (i.e. "text/plain"). If the file being sent has
+an [IANA media type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), you should set it as
+the value for `media_type` instead.
 
 For example:
 
@@ -252,6 +252,30 @@ def stream_time() -> Stream:
 ```
 
 The Stream class receives a single required kwarg - `iterator`, which should be either a sync or an async iterator.
+
+### Template Responses
+
+Starlite can automatically load and render a template file once a template engine is configured in the app. Starlite
+provides two engines by default, `jinja2` and `mako`.
+
+```python
+from starlite import Template, TemplateConfig, Starlite, Request, get
+from starlite.template import JinjaTemplateEngine
+
+
+@get(path="/info")
+def info(request: Request) -> Template:
+    return Template(name="info.html", context={"user": request.user})
+
+
+app = Starlite(
+    route_handlers=[info],
+    template_config=TemplateConfig(directory="templates", engine=JinjaTemplateEngine),
+)
+```
+
+No templating engine is tightly integrated to Starlite, if you want support for other templating engines you can use a
+subclass of `starlite.template.AbstractTemplateEngine` and specify it as the engine in the config.
 
 ## Using Custom Responses
 
@@ -302,7 +326,7 @@ def get_document() -> Document:
 ```
 
 You can specify the response class to use at all levels of your application. On specific route handlers, on a
- controller, a router even on the app instance itself:
+controller, a router even on the app instance itself:
 
 ```python
 from starlite import Controller, Starlite, Router
@@ -354,7 +378,7 @@ def my_route_handler() -> Response:
 ```
 
 !!! important
-    If you return a response directly the OpenAPI schema generation will not be able to properly annotate the response.
+If you return a response directly the OpenAPI schema generation will not be able to properly annotate the response.
 
 ## Response Headers
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -279,6 +279,21 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
+name = "mako"
+version = "1.1.6"
+description = "A super-fast templating language that borrows the  best ideas from the existing templating languages."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+MarkupSafe = ">=0.9.2"
+
+[package.extras]
+babel = ["babel"]
+lingua = ["lingua"]
+
+[[package]]
 name = "markdown"
 version = "3.3.6"
 description = "Python implementation of Markdown."
@@ -822,7 +837,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "69062dee59aefc885f6dc422063acac22de54a723df03cd6d7a9bf7459140a38"
+content-hash = "0262b103743055184cb932d238070aa5ff0da11528f55cef861a2cb2310cd9f0"
 
 [metadata.files]
 anyio = [
@@ -1002,6 +1017,10 @@ iniconfig = [
 jinja2 = [
     {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
     {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
+]
+mako = [
+    {file = "Mako-1.1.6-py2.py3-none-any.whl", hash = "sha256:afaf8e515d075b22fad7d7b8b30e4a1c90624ff2f3733a06ec125f5a5f043a57"},
+    {file = "Mako-1.1.6.tar.gz", hash = "sha256:4e9e345a41924a954251b95b4b28e14a301145b544901332e658907a7464b6b2"},
 ]
 markdown = [
     {file = "Markdown-3.3.6-py3-none-any.whl", hash = "sha256:9923332318f843411e9932237530df53162e29dc7a4e2b91e35764583c46c9a3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ pytest-asyncio = "*"
 pytest-cov = "*"
 uvicorn = "*"
 sqlalchemy = {extras = ["mypy"], version = "*"}
+Jinja2 = "*"
+Mako = "*"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/starlite/__init__.py
+++ b/starlite/__init__.py
@@ -1,8 +1,8 @@
 # flake8: noqa
-from starlite.datastructures import File, Redirect, State, Stream
+from starlite.datastructures import File, Redirect, State, Stream, Template
 
 from .app import Starlite
-from .config import CORSConfig, OpenAPIConfig, StaticFilesConfig
+from .config import CORSConfig, OpenAPIConfig, StaticFilesConfig, TemplateConfig
 from .connection import Request, WebSocket
 from .controller import Controller
 from .dto import DTOFactory
@@ -103,6 +103,8 @@ __all__ = [
     "StaticFilesConfig",
     "Stream",
     "TestClient",
+    "Template",
+    "TemplateConfig",
     "WebSocket",
     "websocket",
     "WebSocketRoute",

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -55,7 +55,7 @@ class Starlite(Router):
         "state",
         "route_map",
         "static_paths",
-        "plain_routes"
+        "plain_routes",
         "template_engine"
         # the rest of __slots__ are defined in Router and should not be duplicated
         # see: https://stackoverflow.com/questions/472000/usage-of-slots

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -226,7 +226,7 @@ class Starlite(Router):
         the Starlette ExceptionMiddleware and the starlette ServerErrorMiddleware
         """
         current_app: ASGIApp = ExceptionMiddleware(
-            app=self.asgi_router, handlers=self.exception_handlers, debug=self.debug  # type: ignore[arg-type]
+            app=self.asgi_router, handlers=self.exception_handlers, debug=self.debug
         )
         if allowed_hosts:
             current_app = TrustedHostMiddleware(app=current_app, allowed_hosts=allowed_hosts)

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -17,7 +17,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from typing_extensions import Type
 
 from starlite.asgi import StarliteASGIRouter
-from starlite.config import CORSConfig, OpenAPIConfig, StaticFilesConfig
+from starlite.config import CORSConfig, OpenAPIConfig, StaticFilesConfig, TemplateConfig
 from starlite.connection import Request
 from starlite.datastructures import State
 from starlite.enums import MediaType
@@ -28,6 +28,7 @@ from starlite.plugins.base import PluginProtocol
 from starlite.provide import Provide
 from starlite.response import Response
 from starlite.routing import ASGIRoute, BaseRoute, HTTPRoute, Router, WebSocketRoute
+from starlite.template import AbstractTemplateEngine
 from starlite.types import (
     AfterRequestHandler,
     BeforeRequestHandler,
@@ -55,6 +56,7 @@ class Starlite(Router):
         "route_map",
         "static_paths",
         "plain_routes"
+        "template_engine"
         # the rest of __slots__ are defined in Router and should not be duplicated
         # see: https://stackoverflow.com/questions/472000/usage-of-slots
     )
@@ -82,6 +84,8 @@ class Starlite(Router):
         after_request: Optional[AfterRequestHandler] = None,
         # static files
         static_files_config: Optional[Union[StaticFilesConfig, List[StaticFilesConfig]]] = None,
+        # template
+        template_config: Optional[TemplateConfig] = None
     ):
         self.debug = debug
         self.state = State()
@@ -120,6 +124,11 @@ class Starlite(Router):
                 static_files = StaticFiles(html=config.html_mode, check_dir=False)
                 static_files.all_directories = config.directories  # type: ignore
                 self.register(asgi(path=path)(static_files))
+
+        if template_config:
+            self.template_engine: Optional[AbstractTemplateEngine] = template_config.engine(template_config.directory)
+        else:
+            self.template_engine = None
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         scope["app"] = self

--- a/starlite/config.py
+++ b/starlite/config.py
@@ -16,6 +16,7 @@ from pydantic import AnyUrl, BaseModel, DirectoryPath, constr
 from typing_extensions import Type
 
 from starlite.openapi.controller import OpenAPIController
+from starlite.template import AbstractTemplateEngine
 
 
 class CORSConfig(BaseModel):
@@ -71,3 +72,11 @@ class StaticFilesConfig(BaseModel):
     path: constr(min_length=1)  # type: ignore
     directories: List[DirectoryPath]
     html_mode: bool = False
+
+
+class TemplateConfig(BaseModel):
+    class Config:
+        arbitrary_types_allowed = True
+
+    directory: Union[DirectoryPath, List[DirectoryPath]]
+    engine: Type[AbstractTemplateEngine]

--- a/starlite/datastructures.py
+++ b/starlite/datastructures.py
@@ -50,4 +50,4 @@ class Stream(StarliteType):
 
 class Template(StarliteType):
     name: str
-    context: Dict[str, Any]
+    context: Optional[Dict[str, Any]]

--- a/starlite/datastructures.py
+++ b/starlite/datastructures.py
@@ -46,3 +46,8 @@ class Stream(StarliteType):
         arbitrary_types_allowed = True
 
     iterator: Union[Iterator[Any], AsyncIterator[Any]]
+
+
+class Template(StarliteType):
+    name: str
+    context: Dict[str, Any]

--- a/starlite/exceptions.py
+++ b/starlite/exceptions.py
@@ -74,3 +74,8 @@ class InternalServerException(HTTPException):
 
 class ServiceUnavailableException(HTTPException):
     status_code = HTTP_503_SERVICE_UNAVAILABLE
+
+
+class TemplateNotFound(InternalServerException):
+    def __init__(self, template_name: str):
+        super().__init__(detail=f"Template {template_name} not found.")

--- a/starlite/handlers.py
+++ b/starlite/handlers.py
@@ -384,7 +384,8 @@ class HTTPRouteHandler(BaseRouteHandler):
                     content=data.iterator, status_code=self.status_code, media_type=media_type, headers=headers
                 )
             elif isinstance(data, Template):
-                if template_engine := request.app.template_engine:  # noqa: SIM106
+                template_engine = request.app.template_engine
+                if template_engine:  # noqa: SIM106
                     response = TemplateResponse(
                         context=data.context,
                         template_name=data.name,

--- a/starlite/handlers.py
+++ b/starlite/handlers.py
@@ -384,12 +384,12 @@ class HTTPRouteHandler(BaseRouteHandler):
                     content=data.iterator, status_code=self.status_code, media_type=media_type, headers=headers
                 )
             elif isinstance(data, Template):
-                template_engine = request.app.template_engine
-                if template_engine:  # noqa: SIM106
+                app = list(self.ownership_layers())[-1]
+                if app.template_engine:  # type: ignore # noqa: SIM106
                     response = TemplateResponse(
                         context=data.context,
                         template_name=data.name,
-                        template_engine=template_engine,
+                        template_engine=app.template_engine,  # type: ignore
                         status_code=self.status_code,
                         headers=headers,
                     )

--- a/starlite/handlers.py
+++ b/starlite/handlers.py
@@ -26,16 +26,17 @@ from starlette.status import HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT
 
 from starlite.constants import REDIRECT_STATUS_CODES
 from starlite.controller import Controller
-from starlite.datastructures import File, Redirect, StarliteType, Stream
+from starlite.datastructures import File, Redirect, StarliteType, Stream, Template
 from starlite.enums import HttpMethod, MediaType
 from starlite.exceptions import (
     HTTPException,
     ImproperlyConfiguredException,
+    InternalServerException,
     ValidationException,
 )
 from starlite.plugins.base import PluginProtocol, get_plugin_for_value
 from starlite.provide import Provide
-from starlite.response import Response
+from starlite.response import Response, TemplateResponse
 from starlite.types import (
     AfterRequestHandler,
     AsyncAnyCallable,
@@ -181,6 +182,7 @@ class HTTPRouteHandler(BaseRouteHandler):
         "resolved_response_class",
         "resolved_after_request",
         "resolved_before_request",
+        "template_name",
     )
 
     @validate_arguments(config={"arbitrary_types_allowed": True})
@@ -381,6 +383,17 @@ class HTTPRouteHandler(BaseRouteHandler):
                 response = StreamingResponse(
                     content=data.iterator, status_code=self.status_code, media_type=media_type, headers=headers
                 )
+            elif isinstance(data, Template):
+                if template_engine := request.app.template_engine:  # noqa: SIM106
+                    response = TemplateResponse(
+                        context=data.context,
+                        template_name=data.name,
+                        template_engine=template_engine,
+                        status_code=self.status_code,
+                        headers=headers,
+                    )
+                else:
+                    raise InternalServerException(detail="Template engine was not initialized in app")
             else:
                 response = cast(StarletteResponse, data)
         else:

--- a/starlite/openapi/responses.py
+++ b/starlite/openapi/responses.py
@@ -8,7 +8,7 @@ from openapi_schema_pydantic import Response, Responses, Schema
 from pydantic.typing import AnyCallable
 from starlette.routing import get_name
 
-from starlite.datastructures import File, Redirect, Stream
+from starlite.datastructures import File, Redirect, Stream, Template
 from starlite.enums import MediaType
 from starlite.exceptions import HTTPException, ValidationException
 from starlite.handlers import HTTPRouteHandler
@@ -38,7 +38,13 @@ def create_success_response(
         or HTTPStatus(route_handler.status_code).description
     )
     if signature.return_annotation not in [signature.empty, None, Redirect, File, Stream]:
-        as_parsed_model_field = create_parsed_model_field(signature.return_annotation)
+
+        return_annotation = signature.return_annotation
+        if signature.return_annotation is Template:
+            return_annotation = str  # since templates return str
+            route_handler.media_type = MediaType.HTML
+
+        as_parsed_model_field = create_parsed_model_field(return_annotation)
         schema = create_schema(field=as_parsed_model_field, generate_examples=generate_examples)
         schema.contentEncoding = route_handler.content_encoding
         schema.contentMediaType = route_handler.content_media_type

--- a/starlite/response.py
+++ b/starlite/response.py
@@ -80,9 +80,10 @@ class TemplateResponse(StarletteResponse):
         )
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # code from https://github.com/encode/starlette/blob/master/starlette/templating.py
         request = self.context.get("request", {})
         extensions = request.get("extensions", {})
-        if "http.response.template" in extensions:
+        if "http.response.template" in extensions:  # pragma: no cover
             await send(
                 {
                     "type": "http.response.template",

--- a/starlite/response.py
+++ b/starlite/response.py
@@ -69,7 +69,7 @@ class TemplateResponse(StarletteResponse):
     ):
         self.template = template_engine.get_template(template_name)
         self.context = context
-        content = self.template.render(context)
+        content = self.template.render(**context)
 
         super().__init__(
             content=content,

--- a/starlite/template.py
+++ b/starlite/template.py
@@ -1,0 +1,58 @@
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, List, TypeVar, Union, cast
+
+from pydantic import DirectoryPath
+from typing_extensions import Protocol, runtime_checkable
+
+from starlite.exceptions import MissingDependencyException
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+@runtime_checkable
+class AbstractTemplate(Protocol):
+    def render(self, context: Dict[str, Any]) -> str:
+        """Returns the rendered template as a string"""
+        ...
+
+
+class AbstractTemplateEngine(ABC):
+    @abstractmethod
+    def __init__(self, directory: Union[DirectoryPath, List[DirectoryPath]]) -> None:
+        ...
+
+    @abstractmethod
+    def get_template(self, name: str) -> AbstractTemplate:
+        """Loads the template with name and returns it."""
+        ...
+
+
+class JinjaTemplateEngine(AbstractTemplateEngine):
+    __slots__ = ["_engine"]
+
+    def __init__(self, directory: Union[DirectoryPath, List[DirectoryPath]]) -> None:
+        try:
+            import jinja2  # pylint: disable=C0415
+        except ImportError as e:
+            raise MissingDependencyException("jinja2 is not installed") from e
+
+        loader = jinja2.FileSystemLoader(searchpath=directory)
+        self._engine = jinja2.Environment(loader=loader, autoescape=True)
+
+    def get_template(self, name: str) -> AbstractTemplate:
+        return cast(AbstractTemplate, self._engine.get_template(name=name))
+
+
+class MakoTemplateEngine(AbstractTemplateEngine):
+    __slots__ = ["_engine"]
+
+    def __init__(self, directory: Union[DirectoryPath, List[DirectoryPath]]) -> None:
+        try:
+            from mako.lookup import TemplateLookup  # pylint: disable=C0415
+        except ImportError as e:
+            raise MissingDependencyException("mako is not installed") from e
+
+        self._engine = TemplateLookup([directory])
+
+    def get_template(self, name: str) -> AbstractTemplate:
+        return cast(AbstractTemplate, self._engine.get_template(name))

--- a/starlite/template.py
+++ b/starlite/template.py
@@ -1,6 +1,6 @@
 # pylint: disable=E0401, C0415
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Union, cast
+from typing import Any, Dict, List, Optional, Union, cast
 
 from pydantic import DirectoryPath
 from typing_extensions import Protocol, runtime_checkable
@@ -10,7 +10,7 @@ from starlite.exceptions import MissingDependencyException, TemplateNotFound
 
 @runtime_checkable
 class AbstractTemplate(Protocol):
-    def render(self, context: Dict[str, Any]) -> str:
+    def render(self, **context: Optional[Dict[str, Any]]) -> str:
         """Returns the rendered template as a string"""
 
 

--- a/starlite/template.py
+++ b/starlite/template.py
@@ -12,18 +12,16 @@ from starlite.exceptions import MissingDependencyException, TemplateNotFound
 class AbstractTemplate(Protocol):
     def render(self, context: Dict[str, Any]) -> str:
         """Returns the rendered template as a string"""
-        ...
 
 
 class AbstractTemplateEngine(ABC):
     @abstractmethod
     def __init__(self, directory: Union[DirectoryPath, List[DirectoryPath]]) -> None:
-        ...
+        """Builds a template engine."""
 
     @abstractmethod
     def get_template(self, name: str) -> AbstractTemplate:
         """Loads the template with name and returns it."""
-        ...
 
 
 class JinjaTemplateEngine(AbstractTemplateEngine):
@@ -32,7 +30,7 @@ class JinjaTemplateEngine(AbstractTemplateEngine):
     def __init__(self, directory: Union[DirectoryPath, List[DirectoryPath]]) -> None:
         try:
             import jinja2
-        except ImportError as e:
+        except ImportError as e:  # pragma: no cover
             raise MissingDependencyException("jinja2 is not installed") from e
 
         loader = jinja2.FileSystemLoader(searchpath=directory)
@@ -53,7 +51,7 @@ class MakoTemplateEngine(AbstractTemplateEngine):
     def __init__(self, directory: Union[DirectoryPath, List[DirectoryPath]]) -> None:
         try:
             from mako.lookup import TemplateLookup
-        except ImportError as e:
+        except ImportError as e:  # pragma: no cover
             raise MissingDependencyException("mako is not installed") from e
 
         self._engine = TemplateLookup(directories=[directory])

--- a/starlite/testing.py
+++ b/starlite/testing.py
@@ -12,7 +12,7 @@ from typing_extensions import Type
 
 from starlite import Controller, Provide, Router
 from starlite.app import Starlite
-from starlite.config import CORSConfig, OpenAPIConfig, StaticFilesConfig
+from starlite.config import CORSConfig, OpenAPIConfig, StaticFilesConfig, TemplateConfig
 from starlite.connection import Request
 from starlite.datastructures import State
 from starlite.enums import HttpMethod, RequestEncodingType
@@ -83,6 +83,7 @@ def create_test_client(
     on_shutdown: Optional[List[LifeCycleHandler]] = None,
     on_startup: Optional[List[LifeCycleHandler]] = None,
     openapi_config: Optional[OpenAPIConfig] = None,
+    template_config: Optional[TemplateConfig] = None,
     plugins: Optional[List[PluginProtocol]] = None,
     raise_server_exceptions: bool = True,
     root_path: str = "",
@@ -102,6 +103,7 @@ def create_test_client(
             on_shutdown=on_shutdown,
             on_startup=on_startup,
             openapi_config=openapi_config,
+            template_config=template_config,
             plugins=plugins,
             route_handlers=cast(Any, route_handlers if isinstance(route_handlers, list) else [route_handlers]),
             static_files_config=static_files_config,

--- a/tests/openapi/test_responses.py
+++ b/tests/openapi/test_responses.py
@@ -7,7 +7,7 @@ from starlette.status import (
     HTTP_406_NOT_ACCEPTABLE,
 )
 
-from starlite import File, MediaType, Redirect, Starlite, Stream, get
+from starlite import File, MediaType, Redirect, Starlite, Stream, Template, get
 from starlite.exceptions import (
     HTTPException,
     PermissionDeniedException,
@@ -149,3 +149,13 @@ def test_create_success_response_file_data():
     assert response.headers["last-modified"].description
     assert response.headers["etag"].param_schema.type == OpenAPIType.STRING
     assert response.headers["etag"].description
+
+
+def test_create_success_response_template():
+    @get(path="/template")
+    def template_handler() -> Template:
+        ...
+
+    response = create_success_response(template_handler, True)
+    assert response.description == "Request fulfilled, document follows"
+    assert response.content[MediaType.HTML]

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -108,3 +108,22 @@ def test_handler_raise_for_no_template_engine():
         response = client.request("GET", "/")
         assert response.status_code == 500
         assert response.json() == {"detail": "Template engine was not initialized in app", "extra": None}
+
+
+def test_template_with_no_context(tmpdir):
+    path = os.path.join(tmpdir, "index.html")
+    with open(path, "w") as file:
+        file.write("<html>This works!</html>")
+
+    @get(path="/")
+    def index() -> Template:
+        return Template(name="index.html")
+
+    with create_test_client(
+        route_handlers=[index],
+        template_config=TemplateConfig(engine=JinjaTemplateEngine, directory=tmpdir),
+    ) as client:
+        index_response = client.request("GET", "/")
+        assert index_response.status_code == 200
+        assert index_response.text == "<html>This works!</html>"
+        assert index_response.headers["Content-Type"] == "text/html; charset=utf-8"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,110 @@
+import os
+
+from starlite import Template, TemplateConfig, create_test_client, get
+from starlite.template import JinjaTemplateEngine, MakoTemplateEngine
+
+
+def test_jinja_template(tmpdir):
+    path = os.path.join(tmpdir, "index.html")
+    with open(path, "w") as file:
+        file.write("<html>Injected? {{test}}</html>")
+
+    nested_dir = os.path.join(tmpdir, "users")
+    os.mkdir(nested_dir)
+    nested_path = os.path.join(nested_dir, "nested.html")
+
+    with open(nested_path, "w") as file:
+        file.write("<html>Does nested dirs work? {{test}}</html>")
+
+    @get(path="/")
+    def index() -> Template:
+        return Template(name="index.html", context={"test": "yep"})
+
+    @get(path="/nested")
+    def nested_path() -> Template:
+        return Template(name="users/nested.html", context={"test": "yep"})
+
+    with create_test_client(
+        route_handlers=[index, nested_path],
+        template_config=TemplateConfig(engine=JinjaTemplateEngine, directory=tmpdir),
+    ) as client:
+        index_response = client.request("GET", "/")
+        assert index_response.status_code == 200
+        assert index_response.text == "<html>Injected? yep</html>"
+        assert index_response.headers["Content-Type"] == "text/html; charset=utf-8"
+
+        nested_response = client.request("GET", "/nested")
+        assert nested_response.status_code == 200
+        assert nested_response.text == "<html>Does nested dirs work? yep</html>"
+        assert nested_response.headers["Content-Type"] == "text/html; charset=utf-8"
+
+
+def test_jinja_raise_for_invalid_path(tmpdir):
+    @get(path="/")
+    def invalid_path() -> Template:
+        return Template(name="invalid.html", context={"test": "yep"})
+
+    with create_test_client(
+        route_handlers=[invalid_path], template_config=TemplateConfig(engine=JinjaTemplateEngine, directory=tmpdir)
+    ) as client:
+        response = client.request("GET", "/")
+        assert response.status_code == 500
+        assert response.json() == {"detail": "Template invalid.html not found.", "extra": None}
+
+
+def test_mako_template(tmpdir):
+    path = os.path.join(tmpdir, "index.html")
+    with open(path, "w") as file:
+        file.write("<html>Injected? ${test}</html>")
+
+    nested_dir = os.path.join(tmpdir, "users")
+    os.mkdir(nested_dir)
+    nested_path = os.path.join(nested_dir, "nested.html")
+
+    with open(nested_path, "w") as file:
+        file.write("<html>Does nested dirs work? ${test}</html>")
+
+    @get(path="/")
+    def index() -> Template:
+        return Template(name="index.html", context={"test": "yep"})
+
+    @get(path="/nested")
+    def nested_path() -> Template:
+        return Template(name="users/nested.html", context={"test": "yep"})
+
+    with create_test_client(
+        route_handlers=[index, nested_path], template_config=TemplateConfig(engine=MakoTemplateEngine, directory=tmpdir)
+    ) as client:
+        index_response = client.request("GET", "/")
+        assert index_response.status_code == 200
+        assert index_response.text == "<html>Injected? yep</html>"
+        assert index_response.headers["Content-Type"] == "text/html; charset=utf-8"
+
+        nested_response = client.request("GET", "/nested")
+        assert nested_response.status_code == 200
+        assert nested_response.text == "<html>Does nested dirs work? yep</html>"
+        assert nested_response.headers["Content-Type"] == "text/html; charset=utf-8"
+
+
+def test_mako_raise_for_invalid_path(tmpdir):
+    @get(path="/")
+    def invalid_path() -> Template:
+        return Template(name="invalid.html", context={"test": "yep"})
+
+    with create_test_client(
+        route_handlers=[invalid_path], template_config=TemplateConfig(engine=MakoTemplateEngine, directory=tmpdir)
+    ) as client:
+        response = client.request("GET", "/")
+        assert response.status_code == 500
+        assert response.json() == {"detail": "Template invalid.html not found.", "extra": None}
+
+
+def test_handler_raise_for_no_template_engine():
+    @get(path="/")
+    def invalid_path() -> Template:
+        return Template(name="index.html", context={"ye": "yeeee"})
+
+    with create_test_client(route_handlers=[invalid_path]) as client:
+        response = client.request("GET", "/")
+        assert response.status_code == 500
+        assert response.json() == {"detail": "Template engine was not initialized in app", "extra": None}


### PR DESCRIPTION
This pr aims to bring templating support for Starlite by leveraging already existing template engine. Currently `mako` and `jinja2` are supported. 

### Basic Example
```py 
from starlite import Starlite, TemplateConfig, Template, get
from starlite.template import JinjaTemplateEngine


@get(path="/")
def index() -> Template:
    return Template(name="index.html", context={"test": "test"})


app = Starlite(
    route_handlers=[heath_check], template_config=TemplateConfig(directory=["templates"], engine=JinjaTemplateEngine)
)
```
#### Stuff to do
- write docs
- ~~write tests~~
-  OpenAPI integration