### PR TITLE
fix: proper Partial typing

### DIFF
--- a/starlite/types.py
+++ b/starlite/types.py
@@ -87,16 +87,17 @@ class MiddlewareProtocol(Protocol):
         ...
 
 
-T = TypeVar("T", bound=Type[BaseModel])
+T = TypeVar("T", bound=BaseModel)
 
 
 class Partial(Generic[T]):
-    _models: Dict[T, Any] = {}
+    _models: Dict[Type[T], Any] = {}
 
-    def __class_getitem__(cls, item: T) -> T:
+    def __class_getitem__(cls, item: Type[T]) -> Type[T]:
         """
         Modifies a given T subclass of BaseModel to be all optional
         """
+        item
         if not cls._models.get(item):
             field_definitions: Dict[str, Tuple[Any, None]] = {}
             for field_name, field_type in item.__annotations__.items():
@@ -106,7 +107,7 @@ class Partial(Generic[T]):
                 else:
                     field_definitions[field_name] = (field_type, None)
                 cls._models[item] = create_model("Partial" + item.__name__, **field_definitions)  # type: ignore
-        return cast(T, cls._models.get(item))
+        return cast(Type[T], cls._models.get(item))
 
 
 class ResponseHeader(Header):  # type: ignore


### PR DESCRIPTION
Using `TypeVar("T", bound=Type[BaseModel])` as the type variable in `Partial` does not type-check. 

For example:

```python
class Person(BaseModel):
    name: str

PartialPerson = Partial[Person]  # does NOT type-check
PartialPerson = Partial[Type[Person]]  # type-checks
```

This PR changes the type variable used in `Partial` from `TypeVar("T", bound=Type[BaseModel])` to `TypeVar("T", bound=BaseModel)` and subsequent types in `Partial` as needed to allow `PartialPerson = Partial[Person]` to type-check 🤡 

For context, I enjoy using Pyright in its strictest configuration. If somehow this was ok by MyPy, then please ignore this PR.
BTW, `Partial` is brilliant! Typescript has a similar idea:

```typescript
type Partial<T> = {
    [P in keyof T]?: T[P];
};
```

It's unfortunate Python can't express it in this way, but we make do!

