### PR TITLE
Docs/link_to_redoc_in_docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ class UserController(Controller):
         ...
 ```
 
+### ReDoc Automatic API Documentation
+
+While running Starlite, you can access the [ReDoc API Documentation Page](https://redoc.ly/) by accessing it at the default
+location of /schema or change the location using the [OpenAPIController](https://starlite-api.github.io/starlite/usage/12-openapi/#the-openapi-controller). If your app is running locally on port 8000 you can access the [ReDoc page at http://0.0.0.0:8000/schema](http://0.0.0.0:8000/schema).
+
 ### Data Parsing, Type Hints and Pydantic
 
 One key difference between Starlite and Starlette/FastAPI is in parsing of form data and query parameters- Starlite

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ class UserController(Controller):
 
 ### ReDoc Automatic API Documentation
 
-While running Starlite, you can access the [ReDoc API Documentation Page](https://redoc.ly/) by accessing it at the default
-location of /schema or change the location using the [OpenAPIController](https://starlite-api.github.io/starlite/usage/12-openapi/#the-openapi-controller). If your app is running locally on port 8000 you can access the [ReDoc page at http://0.0.0.0:8000/schema](http://0.0.0.0:8000/schema).
+While running Starlite, you can view the [ReDoc API Documentation Page](https://redoc.ly/) by accessing it at the default
+location of /schema or change the location using the [OpenAPIController](https://starlite-api.github.io/starlite/usage/12-openapi-and-redoc/#the-openapi-controller). If your app is running locally on port 8000 you can access the [ReDoc page at http://0.0.0.0:8000/schema](http://0.0.0.0:8000/schema).
 
 ### Data Parsing, Type Hints and Pydantic
 

--- a/docs/usage/12-openapi.md
+++ b/docs/usage/12-openapi.md
@@ -46,6 +46,13 @@ Aside from `title` and `version`, both of which are **required** kwargs, you can
     All models listed above are exported from [openapi-schema-pydantic](https://github.com/kuimono/openapi-schema-pydantic)
     rather than Starlite.
 
+## Viewing the API Documentation in ReDoc
+
+Starlite comes with integration of [ReDoc API Documentation Page](https://redoc.ly/) to render your OpenAPI schema as an
+interactive web user interace. If your app is running locally on port 8000 you can access the
+[ReDoc page at http://0.0.0.0:8000/schema](http://0.0.0.0:8000/schema). The ReDoc page will show and document all your routes,
+DTOs, and any metadata attached to your controllers mentioned above.
+
 #### Disable Schema Generation
 
 If you wish to disable schema generation and not include the schema endpoints in your API, simply pass `None` as the


### PR DESCRIPTION
Update README.md and Docs to include summary of how to access ReDoc UI from a running server. Great for new users who don't know this feature can do or how to access it.