### PR TITLE
feat: normalize operation names to human friendly format

### DIFF
--- a/starlite/openapi/path_item.py
+++ b/starlite/openapi/path_item.py
@@ -32,7 +32,7 @@ def create_path_item(route: "HTTPRoute", create_examples: bool) -> PathItem:
                 or None
             )
             raises_validation_error = bool("data" in handler_fields or path_item.parameters or parameters)
-            handler_name = get_name(cast(AnyCallable, route_handler.fn))
+            handler_name = get_name(cast(AnyCallable, route_handler.fn)).replace("_", " ").title()
             request_body = None
             if "data" in handler_fields:
                 request_body = create_request_body(field=handler_fields["data"], generate_examples=create_examples)


### PR DESCRIPTION
Make operation names in redoc more human friendly by converting underscores to spaces and title-casing the words.

![image](https://user-images.githubusercontent.com/11999013/154145737-12e9fd15-d1ac-488e-b891-8c4a7ab00ada.png)