### PR TITLE
Add a test for hanging body logging middleware

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
         args: [--config=./pyproject.toml]


### PR DESCRIPTION
A failing test addition for accessing Request body in the middleware.

And a version bump of `black` to pass pre-commit ([related black issue](https://github.com/psf/black/issues/2964)).