### PR TITLE
changed middleware call order

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -208,7 +208,7 @@ typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "hypothesis"
-version = "6.43.1"
+version = "6.44.0"
 description = "A library for property-based testing"
 category = "dev"
 optional = false
@@ -590,6 +590,20 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.7.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -829,7 +843,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "5d35a6012219e6f294e3549157035c4d64a96056820916f47cf81dad48318926"
+content-hash = "6fba81a9cd5a22ddc27f651fc0e63a2c05e77c695237cd25bd928411daf191cf"
 
 [metadata.files]
 anyio = [
@@ -1013,8 +1027,8 @@ h11 = [
     {file = "h11-0.13.0.tar.gz", hash = "sha256:70813c1135087a248a4d38cc0e1a0181ffab2188141a93eaf567940c3957ff06"},
 ]
 hypothesis = [
-    {file = "hypothesis-6.43.1-py3-none-any.whl", hash = "sha256:a4e30f0c787e23ac3081eae5ce327b92b5125010f000403d4b26b74061d8029b"},
-    {file = "hypothesis-6.43.1.tar.gz", hash = "sha256:b0ef5f82bb925e540f5d26e7e06280fa88113a763cc3e6832c93301766fa6900"},
+    {file = "hypothesis-6.44.0-py3-none-any.whl", hash = "sha256:8b43dd0154f5918b0faa3f9d59f5552d9c8671073f6b906c797a8505fd5d09c3"},
+    {file = "hypothesis-6.44.0.tar.gz", hash = "sha256:620ffa1782f9cb0b732b66b811d11c3beeb678b96fae947740aaab1dfd74a996"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
@@ -1135,6 +1149,7 @@ orjson = [
     {file = "orjson-3.6.7-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:93188a9d6eb566419ad48befa202dfe7cd7a161756444b99c4ec77faea9352a4"},
     {file = "orjson-3.6.7-cp310-cp310-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:82515226ecb77689a029061552b5df1802b75d861780c401e96ca6bc8495f775"},
     {file = "orjson-3.6.7-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3af57ffab7848aaec6ba6b9e9b41331250b57bf696f9d502bacdc71a0ebab0ba"},
+    {file = "orjson-3.6.7-cp310-cp310-manylinux_2_24_aarch64.whl", hash = "sha256:a7297504d1142e7efa236ffc53f056d73934a993a08646dbcee89fc4308a8fcf"},
     {file = "orjson-3.6.7-cp310-cp310-manylinux_2_24_x86_64.whl", hash = "sha256:5a50cde0dbbde255ce751fd1bca39d00ecd878ba0903c0480961b31984f2fab7"},
     {file = "orjson-3.6.7-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d21f9a2d1c30e58070f93988db4cad154b9009fafbde238b52c1c760e3607fbe"},
     {file = "orjson-3.6.7-cp310-none-win_amd64.whl", hash = "sha256:e152464c4606b49398afd911777decebcf9749cc8810c5b4199039e1afb0991e"},
@@ -1246,6 +1261,10 @@ pytest-asyncio = [
 pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.7.0.tar.gz", hash = "sha256:5112bd92cc9f186ee96e1a92efc84969ea494939c3aead39c50f421c4cc69534"},
+    {file = "pytest_mock-3.7.0-py3-none-any.whl", hash = "sha256:6cff27cec936bf81dc5ee87f07132b807bcda51106b5ec4b90a04331cba76231"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ sqlalchemy = {extras = ["mypy"], version = "*"}
 Jinja2 = "*"
 Mako = "*"
 freezegun = "*"
+pytest-mock = "^3.7.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -257,7 +257,7 @@ class Starlite(Router):
         Builds the middleware stack by passing middlewares in a specific order
         """
         current_app: ASGIApp = self.asgi_router
-        # last added middleware will be on top of stack hense it will be called first
+        # last added middleware will be on the top of stack and it will therefore be called first.
         # we therefore need to reverse the middlewares to keep the call order according to
         # middlewares list provided by a user
         for middleware in reversed(user_middleware):

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -258,7 +258,7 @@ class Starlite(Router):
         """
         current_app: ASGIApp = self.asgi_router
         # last added middleware will be on top of stack hense it will be called first
-        # so need to reverse middlewares to keep call order according to
+        # we therefore need to reverse the middlewares to keep the call order according to
         # middlewares list provided by a user
         for middleware in reversed(user_middleware):
             if isinstance(middleware, Middleware):

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -259,7 +259,7 @@ class Starlite(Router):
         current_app: ASGIApp = self.asgi_router
         # last added middleware will be on the top of stack and it will therefore be called first.
         # we therefore need to reverse the middlewares to keep the call order according to
-        # middlewares list provided by a user
+        # the middlewares' list provided by the user
         for middleware in reversed(user_middleware):
             if isinstance(middleware, Middleware):
                 current_app = middleware.cls(app=current_app, **middleware.options)

--- a/starlite/response.py
+++ b/starlite/response.py
@@ -26,7 +26,7 @@ class Response(StarletteResponse):
             status_code=status_code,
             headers=headers or {},
             media_type=media_type,
-            background=background,  # type: ignore
+            background=background,
         )
 
     @staticmethod

--- a/tests/app/test_middleware_handling.py
+++ b/tests/app/test_middleware_handling.py
@@ -155,4 +155,4 @@ def test_middleware_call_order(mocker: MockerFixture) -> None:
     )
     client.get("/")
 
-    manager.assert_has_calls([mocker.call.m1(*m1.call_args.args), mocker.call.m2(*m2.call_args.args)], any_order=False)
+    manager.assert_has_calls([mocker.call.m1(*m1.call_args[0]), mocker.call.m2(*m2.call_args[0])], any_order=False)


### PR DESCRIPTION
Currently middlewares provided by user are called in reverse order, my changes make them to be called in order provided by user.
Also changed addition of `TrustedHostMiddleware` and `CORSMiddleware` so that they called before custom middlewares. 