### PR TITLE
Add a bound type for the guard type to fix invalid type issue

### DIFF
--- a/starlite/types.py
+++ b/starlite/types.py
@@ -53,8 +53,9 @@ LifeCycleHandler = Union[
     Callable[[], Awaitable[Any]],
     Callable[[State], Awaitable[Any]],
 ]
+HTTPConnectionT = TypeVar("HTTPConnectionT", bound=HTTPConnection)
 Guard = Union[
-    Callable[[HTTPConnection, BaseRouteHandler], Awaitable[None]], Callable[[HTTPConnection, BaseRouteHandler], None]
+    Callable[[HTTPConnectionT, BaseRouteHandler], Awaitable[None]], Callable[[HTTPConnectionT, BaseRouteHandler], None]
 ]
 Method = Union[Literal["GET"], Literal["POST"], Literal["DELETE"], Literal["PATCH"], Literal["PUT"], Literal["HEAD"]]
 ReservedKwargs = Union[

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -7,6 +7,7 @@ from starlette.websockets import WebSocketDisconnect
 from starlite import (
     BaseRouteHandler,
     MediaType,
+    Request,
     Response,
     asgi,
     create_test_client,
@@ -22,7 +23,7 @@ async def local_guard(_: HTTPConnection, route_handler: BaseRouteHandler) -> Non
         raise PermissionDeniedException("local")
 
 
-def app_guard(request: HTTPConnection, _: BaseRouteHandler) -> None:
+def app_guard(request: Request, _: BaseRouteHandler) -> None:
     if not request.headers.get("Authorization"):
         raise PermissionDeniedException("app")
 


### PR DESCRIPTION
The issue:

When defining a guard function, its type should be [Guard](https://github.com/starlite-api/starlite/blob/13cdae1324c107f2bdf1683e08b273fe4e8a0927/starlite/types.py#L56-L58). That means that the first argument is of type `starlette.requests.HTTPConnection`. So when a guard function is defined that has the first argument of type `starlite.Request` - a subclass of `HTTPConnection` (similar to what is showcased [in the documentation](https://starlite-api.github.io/starlite/usage/9-guards/)), a typing error is raised by type checkers because that function type is actually a supertype of `Guard` (the arguments that the function accepts are more specific than the ones of `Guard` type).

This behaviour can be replicated by replacing request type `HTTPConnection` with `starlite.Request` in [a test in test_guards.py](https://github.com/starlite-api/starlite/blob/13cdae1324c107f2bdf1683e08b273fe4e8a0927/tests/test_guards.py#L20) and running `mypy`:
```
from starlite import Request
...
async def local_guard(_: Request, route_handler: BaseRouteHandler) -> None:
    if not route_handler.opt or not route_handler.opt.get("allow_all"):
        raise PermissionDeniedException("local")
```

This causes the said `mypy` error:
```
tests/test_guards.py:32: error: List item 0 has incompatible type "Callable[[Request[Any, Any], BaseRouteHandler], Coroutine[Any, Any, None]]"; expected "Union[Callable[[HTTPConnection, BaseRouteHandler], Awaitable[None]], Callable[[HTTPConnection, BaseRouteHandler], None]]"  [list-item]
tests/test_guards.py:49: error: List item 0 has incompatible type "Callable[[Request[Any, Any], BaseRouteHandler], Coroutine[Any, Any, None]]"; expected "Union[Callable[[HTTPConnection, BaseRouteHandler], Awaitable[None]], Callable[[HTTPConnection, BaseRouteHandler], None]]"  [list-item]
tests/test_guards.py:67: error: List item 0 has incompatible type "Callable[[Request[Any, Any], BaseRouteHandler], Coroutine[Any, Any, None]]"; expected "Union[Callable[[HTTPConnection, BaseRouteHandler], Awaitable[None]], Callable[[HTTPConnection, BaseRouteHandler], None]]"  [list-item]
```

The solution is rather straightforward - use a bound type variable which allows the arguments to be any subtype of `HTTPConnection`. This is what this PR suggests.