### PR TITLE
DTOFactory.__call__(): `...` equivalent to `PydanticUndefined` in checking for default

### DIFF
--- a/starlite/dto.py
+++ b/starlite/dto.py
@@ -137,7 +137,7 @@ class DTOFactory:
                         field_name, field_type = mapping
                     else:
                         field_name = mapping
-                if model_field.field_info.default is not Undefined:
+                if model_field.field_info.default not in (Undefined, ...):
                     field_definitions[field_name] = (field_type, model_field.default)
                 elif not model_field.allow_none:
                     field_definitions[field_name] = (field_type, ...)

--- a/tests/test_dto_factory.py
+++ b/tests/test_dto_factory.py
@@ -1,7 +1,7 @@
 from typing import Any, Type, cast
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, create_model
 from pydantic_factories import ModelFactory
 from starlette.status import HTTP_200_OK, HTTP_201_CREATED
 
@@ -184,3 +184,10 @@ def test_conversion_from_model_instance(model: Any, exclude: list, field_mapping
         else:
             original_key = DTO.dto_field_mapping[key]
             assert model_instance.__getattribute__(original_key) == dto_instance.__getattribute__(key)
+
+
+def test_dto_factory_preserves_field_allow_none_false() -> None:
+    Example = create_model("Example", password=(str, ...))
+    assert Example.__fields__["password"].allow_none is False
+    ExampleDTO = DTOFactory()("ExampleDTO", Example)
+    assert ExampleDTO.__fields__["password"].allow_none is False


### PR DESCRIPTION
- fields in `DTOFactory.__call__()` either come from a pydantic model, a dataclass or a plugin
- where fields come from a plugin, they most likely come from a model built with `create_model()`, and no-default defined with `...`

This patch uses `...` as well as `PydanticUndefined` to check whether a field has a default value.