### PR TITLE
Take resolved dependencies into account when generating OpenAPI schema

### DIFF
--- a/starlite/openapi/parameters.py
+++ b/starlite/openapi/parameters.py
@@ -1,6 +1,7 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 
 from openapi_schema_pydantic import Parameter, Schema
+from pydantic import BaseModel
 from pydantic.fields import ModelField
 
 from starlite.constants import RESERVED_KWARGS
@@ -26,11 +27,13 @@ def create_parameters(
     """
     path_parameter_names = [path_param["name"] for path_param in path_parameters]
     parameters: List[Parameter] = []
-    ignored_fields = [
-        *RESERVED_KWARGS,
-        *list(route_handler.resolve_dependencies().keys()),
-    ]
+    ignored_fields = [*RESERVED_KWARGS]
+    dependencies = route_handler.resolve_dependencies()
     for f_name, field in handler_fields.items():
+        if f_name in dependencies:
+            dependency_fields = cast(BaseModel, dependencies[f_name].signature_model).__fields__
+            parameters.extend(create_parameters(route_handler, dependency_fields, path_parameters, generate_examples))
+            continue
         if f_name not in ignored_fields:
             schema = None
             param_in = "query"

--- a/starlite/openapi/parameters.py
+++ b/starlite/openapi/parameters.py
@@ -27,14 +27,13 @@ def create_parameters(
     """
     path_parameter_names = [path_param["name"] for path_param in path_parameters]
     parameters: List[Parameter] = []
-    ignored_fields = [*RESERVED_KWARGS]
     dependencies = route_handler.resolve_dependencies()
     for f_name, field in handler_fields.items():
         if f_name in dependencies:
             dependency_fields = cast(BaseModel, dependencies[f_name].signature_model).__fields__
             parameters.extend(create_parameters(route_handler, dependency_fields, path_parameters, generate_examples))
             continue
-        if f_name not in ignored_fields:
+        if f_name not in RESERVED_KWARGS:
             schema = None
             param_in = "query"
             required = field.required


### PR DESCRIPTION
Instead of simply ignoring dependencies that are mentioned in the method definition, this change resolves them and adds the dependency's parameters to the schema. IMHO this behavior makes more sense, as any time a dependency is active, its own path/header/query parameters are taken into account when invoking the endpoint, so they should also show up in the OpenAPI schema.

Since this is my first PR for this project i'm not a 100% on all the things I need to do to upstream something (nor am I that familiar with the codebase), so this is a tentative start to test the waters and to gauge whether this even makes any sense.