### PR TITLE
Fix `Router.tags` ignored.

### DIFF
--- a/docs/usage/1-routers-and-controllers.md
+++ b/docs/usage/1-routers-and-controllers.md
@@ -61,6 +61,7 @@ Aside from the `path` class variable, you can also set the following optional cl
   will be used.
 - `after_request`: a sync or async function to execute before the `Response` is returned. This function receives the
   `Respose` object and it must return a `Response` object.
+- `tags`: a list of `str`, which correlate to the [tag specification](https://spec.openapis.org/oas/latest.html#tag-object).
 
 ## Routers
 
@@ -91,6 +92,7 @@ Aside from `path` and `route_handlers` which are required kwargs, you can also p
   and instead this value will be used.
 - `after_request`: a sync or async function to execute before the `Response` is returned. This function receives the
   `Respose` object and it must return a `Response` object.
+- `tags`: a list of `str`, which correlate to the [tag specification](https://spec.openapis.org/oas/latest.html#tag-object).
 
 ## Registering Routes
 

--- a/docs/usage/12-openapi.md
+++ b/docs/usage/12-openapi.md
@@ -82,8 +82,7 @@ def my_route_handler() -> None:
 
 You can also affect the schema by enriching and/or modifying it using the following kwargs:
 
-- `tags`: a list of openapi-pydantic `Tag` models, which correlate to
-  the [tag specification](https://spec.openapis.org/oas/latest.html#tag-object).
+- `tags`: a list of `str`, which correlate to the [tag specification](https://spec.openapis.org/oas/latest.html#tag-object).
 - `summary`: Text used for the route's schema _summary_ section.
 - `description`: Text used for the route's schema _description_ section.
 - `response_description`: Text used for the route's response schema _description_ section.

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,6 +12,9 @@ disallow_any_generics = False
 implicit_reexport = False
 show_error_codes = True
 
+[mypy-tests.openapi.test_tags]
+disallow_untyped_decorators = False
+
 [pydantic-mypy]
 init_forbid_extra = True
 init_typed = True

--- a/starlite/openapi/utils.py
+++ b/starlite/openapi/utils.py
@@ -1,7 +1,13 @@
 import re
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 from starlite.handlers.http import HTTPRouteHandler
+
+if TYPE_CHECKING:
+    from typing import Union
+
+    from starlite import Controller, Router, Starlite
+
 
 CAPITAL_LETTERS_PATTERN = re.compile(r"(?=[A-Z])")
 
@@ -14,7 +20,12 @@ def pascal_case_to_text(s: str) -> str:
 def extract_tags_from_route_handler(route_handler: HTTPRouteHandler) -> Optional[List[str]]:
     """Extracts and combines tags from route_handler and any owners"""
     child_tags = route_handler.tags or []
-    parent_tags = []
-    if route_handler.owner and hasattr(route_handler.owner, "tags"):
-        parent_tags = route_handler.owner.tags or []
+    parent_tags: List[str] = []
+    obj: "Union[HTTPRouteHandler, Controller, Router, Starlite]"
+    obj = route_handler
+    while hasattr(obj, "owner"):
+        if obj.owner is None:
+            break
+        obj = obj.owner
+        parent_tags += getattr(obj, "tags", None) or []
     return list(set(child_tags) | set(parent_tags)) or None

--- a/tests/openapi/test_tags.py
+++ b/tests/openapi/test_tags.py
@@ -1,0 +1,55 @@
+from typing import Any, Type
+
+import pytest
+from openapi_schema_pydantic import OpenAPI
+
+from starlite import Controller, HTTPRouteHandler, Router, Starlite, get
+
+
+@pytest.fixture
+def handler() -> HTTPRouteHandler:
+    @get("/handler", tags=["handler"])
+    def _handler() -> Any:
+        ...
+
+    return _handler
+
+
+@pytest.fixture
+def controller() -> Type[Controller]:
+    class _Controller(Controller):
+        path = "/controller"
+        tags = ["controller"]
+
+        @get(tags=["handler"])
+        def _handler(self) -> Any:
+            ...
+
+    return _Controller
+
+
+@pytest.fixture
+def router(controller: Type[Controller]) -> Router:
+    return Router(path="/router", route_handlers=[controller], tags=["router"])
+
+
+@pytest.fixture
+def app(handler: HTTPRouteHandler, controller: Type[Controller], router: Router) -> Starlite:
+    return Starlite(route_handlers=[handler, controller, router])
+
+
+@pytest.fixture
+def openapi_schema(app: Starlite) -> OpenAPI:
+    return app.openapi_schema
+
+
+def test_openapi_schema_handler_tags(openapi_schema: OpenAPI) -> None:
+    assert openapi_schema.paths["/handler"].get.tags == ["handler"]
+
+
+def test_openapi_schema_controller_tags(openapi_schema: OpenAPI) -> None:
+    assert set(openapi_schema.paths["/controller"].get.tags) == {"handler", "controller"}
+
+
+def test_openapi_schema_router_tags(openapi_schema: OpenAPI) -> None:
+    assert set(openapi_schema.paths["/router/controller"].get.tags) == {"handler", "controller", "router"}


### PR DESCRIPTION
PR #89 added the `tags` slot to `Router` in ef02e8e015b1f42e3390073f0785305a4a1c5838, but `openapi.utils.extract_tags_from_route_handler()` only checks the handler and it's immediate owner (from 7e5610825377c8299845d4429bf669a9ca667d78).

This implementation returns the union of the route handler's tags, and any ancestor tags.

I also made a few changes to the docs:
- `docs/usage/12-openapi.md` - `tags` documented as accepting `Tag` objects but is typed as `Optional[List[str]]`.
- `docs/usage/1-routers-and-controllers` - add `tags` to controller class variables.
- `docs/usage/1-routers-and-controllers` - add `tags` to router kwargs.
