### PR TITLE
Selective deduplication of openapi parameters.

### DIFF
--- a/starlite/openapi/parameters.py
+++ b/starlite/openapi/parameters.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from pydantic.fields import ModelField
 
 from starlite.constants import RESERVED_KWARGS
+from starlite.exceptions import ImproperlyConfiguredException
 from starlite.handlers import BaseRouteHandler
 from starlite.openapi.schema import create_schema
 
@@ -14,6 +15,48 @@ def create_path_parameter_schema(path_parameter: Dict[str, Any], field: ModelFie
     field.sub_fields = None
     field.outer_type_ = path_parameter["type"]
     return create_schema(field=field, generate_examples=generate_examples)
+
+
+class ParameterCollection:
+    """
+    Facilitates conditional deduplication of parameters.
+
+    If multiple parameters with the same name are produced for a handler, the condition is
+    ignored if the two `Parameter` instances are the same (the first is retained and any
+    duplicates are ignored). If the `Parameter` instances are not the same, an exception
+    is raised.
+    """
+
+    def __init__(self, route_handler: BaseRouteHandler) -> None:
+        self.route_handler = route_handler
+        self._parameters: Dict[str, Parameter] = {}
+
+    def add(self, parameter: Parameter) -> None:
+        """
+        Add a `Parameter` to the collection.
+
+        If an existing parameter with the same name and type already exists, the
+        parameter is ignored.
+
+        If an existing parameter with the same name but different type exists, raises
+        `ImproperlyConfiguredException`.
+        """
+        if parameter.name not in self._parameters:
+            self._parameters[parameter.name] = parameter
+            return
+        pre_existing = self._parameters[parameter.name]
+        if parameter == pre_existing:
+            return
+        raise ImproperlyConfiguredException(
+            f"OpenAPI schema generation for handler `{self.route_handler}` detected multiple parameters named "
+            f"'{parameter.name}' with different types."
+        )
+
+    def list(self) -> List[Parameter]:
+        """
+        Return a list of all `Parameter`'s in the collection.
+        """
+        return list(self._parameters.values())
 
 
 def create_parameters(
@@ -26,12 +69,14 @@ def create_parameters(
     Create a list of path/query/header Parameter models for the given PathHandler
     """
     path_parameter_names = [path_param["name"] for path_param in path_parameters]
-    parameters: List[Parameter] = []
+    parameters = ParameterCollection(route_handler=route_handler)
+
     dependencies = route_handler.resolve_dependencies()
     for f_name, field in handler_fields.items():
         if f_name in dependencies:
             dependency_fields = cast(BaseModel, dependencies[f_name].signature_model).__fields__
-            parameters.extend(create_parameters(route_handler, dependency_fields, path_parameters, generate_examples))
+            for parameter in create_parameters(route_handler, dependency_fields, path_parameters, generate_examples):
+                parameters.add(parameter)
             continue
         if f_name not in RESERVED_KWARGS:
             schema = None
@@ -63,7 +108,7 @@ def create_parameters(
                 required = field.required
             if not schema:
                 schema = create_schema(field=field, generate_examples=generate_examples)
-            parameters.append(
+            parameters.add(
                 Parameter(
                     name=f_name,
                     param_in=param_in,
@@ -72,4 +117,4 @@ def create_parameters(
                     description=schema.description,
                 )
             )
-    return parameters
+    return parameters.list()


### PR DESCRIPTION
Ignores duplicate parameters that are equal in name and type.

Raises ImproperlyConfiguredException for duplicate parameters that differ in type.

For #127