### PR TITLE
Tests allow untyped decorators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .idea/
 .mypy_cache/
 .pytest_cache/
+.tox/
 .venv/
 .vscode/
 __pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,45 @@ To contribute code changes or update the documentation, please follow these step
 
 Note: if you add new code or modify existing code - 100% test coverage is mandatory and tests should be well written.
 
+## Tox for testing against different versions
+
+### Config
+
+1. Install and configure [pyenv](https://github.com/pyenv/pyenv)
+2. Install required python versions via pyenv, e.g., `$ pyenv install 3.x.x` for each required version.
+3. In root directory of library, create .python-version file in root, e.g.:
+
+```text
+3.10.5
+3.9.13
+3.8.13
+3.7.13
+```
+
+4. Restart shell or run command like: `$ pyenv shell 3.10.5 3.9.13 3.8.13 3.7.13`
+5. Remove any existing poetry environment: `$ poetry env remove python`
+6. Tell poetry to use system python <sup>1</sup>: `$ poetry env use system`
+7. `$ poetry install`
+
+1: Not sure if this is the "right" way to handle this yet, however this prevents poetry from reusing
+the local environment in each of the tox environments.
+
+### Run
+
+`$ poetry run tox`
+
+#### force recreate tox environments
+
+`$ poetry run tox -r`
+
+#### run specific tox environment
+
+`$ poetry run tox -e py37`
+
+#### run pre-commit only
+
+`$ poetry run -e lint`
+
 ## Release workflow
 
 1. Update changelog.md

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,7 +12,7 @@ disallow_any_generics = False
 implicit_reexport = False
 show_error_codes = True
 
-[mypy-tests.test_dependency,tests.openapi.test_tags]
+[mypy-tests.*]
 disallow_untyped_decorators = False
 
 [pydantic-mypy]

--- a/poetry.lock
+++ b/poetry.lock
@@ -108,7 +108,7 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.4"
+version = "0.4.5"
 description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
@@ -843,6 +843,33 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.8"
+description = "Typing stubs for PyYAML"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "types-requests"
+version = "2.27.30"
+description = "Typing stubs for requests"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+types-urllib3 = "<1.27"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.15"
+description = "Typing stubs for urllib3"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.2.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -925,7 +952,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "48175b6c6afb5070fa268e05b543845f740d3c23dcc0f4916cef60389ce8b51c"
+content-hash = "e563001d777589bff2e1754930e150499d7ff2795760098a3c65825f06c55a92"
 
 [metadata.files]
 anyio = [
@@ -982,8 +1009,8 @@ click = [
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
-    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
 commonmark = [
     {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
@@ -1508,6 +1535,18 @@ typed-ast = [
     {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
     {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
+]
+types-pyyaml = [
+    {file = "types-PyYAML-6.0.8.tar.gz", hash = "sha256:d9495d377bb4f9c5387ac278776403eb3b4bb376851025d913eea4c22b4c6438"},
+    {file = "types_PyYAML-6.0.8-py3-none-any.whl", hash = "sha256:56a7b0e8109602785f942a11ebfbd16e97d5d0e79f5fbb077ec4e6a0004837ff"},
+]
+types-requests = [
+    {file = "types-requests-2.27.30.tar.gz", hash = "sha256:ca8d7cc549c3d10dbcb3c69c1b53e3ffd1270089c1001a65c1e9e1017eb5e704"},
+    {file = "types_requests-2.27.30-py3-none-any.whl", hash = "sha256:b9b6cd0a6e5d500e56419b79f44ec96f316e9375ff6c8ee566c39d25e9612621"},
+]
+types-urllib3 = [
+    {file = "types-urllib3-1.26.15.tar.gz", hash = "sha256:c89283541ef92e344b7f59f83ea9b5a295b16366ceee3f25ecfc5593c79f794e"},
+    {file = "types_urllib3-1.26.15-py3-none-any.whl", hash = "sha256:6011befa13f901fc934f59bb1fd6973be6f3acf4ebfce427593a27e7f492918f"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -140,6 +140,14 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
+name = "distlib"
+version = "0.3.4"
+description = "Distribution utilities"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "exceptiongroup"
 version = "1.0.0rc8"
 description = "Backport of PEP 654 (exception groups)"
@@ -169,6 +177,18 @@ python-versions = ">=3.6"
 [package.dependencies]
 python-dateutil = ">=2.4"
 typing-extensions = {version = ">=3.10.0.2", markers = "python_version < \"3.8\""}
+
+[[package]]
+name = "filelock"
+version = "3.7.1"
+description = "A platform independent file lock."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
+testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
 
 [[package]]
 name = "freezegun"
@@ -776,12 +796,43 @@ typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""
 full = ["itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests"]
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "tox"
+version = "3.25.0"
+description = "tox is a generic virtualenv management and test command line tool"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
+filelock = ">=3.0.0"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+packaging = ">=14"
+pluggy = ">=0.12.0"
+py = ">=1.4.17"
+six = ">=1.14.0"
+toml = ">=0.9.4"
+virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
+
+[package.extras]
+docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
+testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "psutil (>=5.6.1)", "pathlib2 (>=2.3.3)"]
 
 [[package]]
 name = "typed-ast"
@@ -830,6 +881,25 @@ typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 standard = ["websockets (>=10.0)", "httptools (>=0.4.0)", "watchgod (>=0.6)", "python-dotenv (>=0.13)", "PyYAML (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "colorama (>=0.4)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.14.1"
+description = "Virtual Python Environment builder"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+distlib = ">=0.3.1,<1"
+filelock = ">=3.2,<4"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+platformdirs = ">=2,<3"
+six = ">=1.9.0,<2"
+
+[package.extras]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
+testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
+
+[[package]]
 name = "watchdog"
 version = "2.1.9"
 description = "Filesystem events monitoring"
@@ -855,7 +925,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "3fb17f32c4f288aa11e2b028350df24f72afaa5e0457095acb4790d91a812d0d"
+content-hash = "48175b6c6afb5070fa268e05b543845f740d3c23dcc0f4916cef60389ce8b51c"
 
 [metadata.files]
 anyio = [
@@ -962,6 +1032,10 @@ coverage = [
     {file = "coverage-6.4.1-pp36.pp37.pp38-none-any.whl", hash = "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815"},
     {file = "coverage-6.4.1.tar.gz", hash = "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c"},
 ]
+distlib = [
+    {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
+    {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
+]
 exceptiongroup = [
     {file = "exceptiongroup-1.0.0rc8-py3-none-any.whl", hash = "sha256:ab0a968e1ef769e55d9a596f4a89f7be9ffedbc9fdefdb77cc68cf5c33ce1035"},
     {file = "exceptiongroup-1.0.0rc8.tar.gz", hash = "sha256:6990c24f06b8d33c8065cfe43e5e8a4bfa384e0358be036af9cc60b6321bd11a"},
@@ -972,6 +1046,10 @@ exrex = [
 faker = [
     {file = "Faker-13.13.0-py3-none-any.whl", hash = "sha256:638b9c362e77bcd8212f0d1434c1940f1e8d6c336fe949add563ba0a154b6310"},
     {file = "Faker-13.13.0.tar.gz", hash = "sha256:f192d238b3b6acb98ee85bd596258a15a171385613b30a7849e5845f8980d722"},
+]
+filelock = [
+    {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},
+    {file = "filelock-3.7.1.tar.gz", hash = "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"},
 ]
 freezegun = [
     {file = "freezegun-1.2.1-py3-none-any.whl", hash = "sha256:15103a67dfa868ad809a8f508146e396be2995172d25f927e48ce51c0bf5cb09"},
@@ -993,7 +1071,6 @@ greenlet = [
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97e5306482182170ade15c4b0d8386ded995a07d7cc2ca8f27958d34d6736497"},
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6a36bb9474218c7a5b27ae476035497a6990e21d04c279884eb10d9b290f1b1"},
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abb7a75ed8b968f3061327c433a0fbd17b729947b400747c334a9c29a9af6c58"},
-    {file = "greenlet-1.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b336501a05e13b616ef81ce329c0e09ac5ed8c732d9ba7e3e983fcc1a9e86965"},
     {file = "greenlet-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:14d4f3cd4e8b524ae9b8aa567858beed70c392fdec26dbdb0a8a418392e71708"},
     {file = "greenlet-1.1.2-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:17ff94e7a83aa8671a25bf5b59326ec26da379ace2ebc4411d690d80a7fbcf23"},
     {file = "greenlet-1.1.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9f3cba480d3deb69f6ee2c1825060177a22c7826431458c697df88e6aeb3caee"},
@@ -1006,7 +1083,6 @@ greenlet = [
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9d29ca8a77117315101425ec7ec2a47a22ccf59f5593378fc4077ac5b754fce"},
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21915eb821a6b3d9d8eefdaf57d6c345b970ad722f856cd71739493ce003ad08"},
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff9d20417ff9dcb0d25e2defc2574d10b491bf2e693b4e491914738b7908168"},
-    {file = "greenlet-1.1.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b8c008de9d0daba7b6666aa5bbfdc23dcd78cafc33997c9b7741ff6353bafb7f"},
     {file = "greenlet-1.1.2-cp36-cp36m-win32.whl", hash = "sha256:32ca72bbc673adbcfecb935bb3fb1b74e663d10a4b241aaa2f5a75fe1d1f90aa"},
     {file = "greenlet-1.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:f0214eb2a23b85528310dad848ad2ac58e735612929c8072f6093f3585fd342d"},
     {file = "greenlet-1.1.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:b92e29e58bef6d9cfd340c72b04d74c4b4e9f70c9fa7c78b674d1fec18896dc4"},
@@ -1015,7 +1091,6 @@ greenlet = [
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e12bdc622676ce47ae9abbf455c189e442afdde8818d9da983085df6312e7a1"},
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8c790abda465726cfb8bb08bd4ca9a5d0a7bd77c7ac1ca1b839ad823b948ea28"},
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f276df9830dba7a333544bd41070e8175762a7ac20350786b322b714b0e654f5"},
-    {file = "greenlet-1.1.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c5d5b35f789a030ebb95bff352f1d27a93d81069f2adb3182d99882e095cefe"},
     {file = "greenlet-1.1.2-cp37-cp37m-win32.whl", hash = "sha256:64e6175c2e53195278d7388c454e0b30997573f3f4bd63697f88d855f7a6a1fc"},
     {file = "greenlet-1.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b11548073a2213d950c3f671aa88e6f83cda6e2fb97a8b6317b1b5b33d850e06"},
     {file = "greenlet-1.1.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:9633b3034d3d901f0a46b7939f8c4d64427dfba6bbc5a36b1a67364cf148a1b0"},
@@ -1024,7 +1099,6 @@ greenlet = [
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e859fcb4cbe93504ea18008d1df98dee4f7766db66c435e4882ab35cf70cac43"},
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711"},
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec8c433b3ab0419100bd45b47c9c8551248a5aee30ca5e9d399a0b57ac04651b"},
-    {file = "greenlet-1.1.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2bde6792f313f4e918caabc46532aa64aa27a0db05d75b20edfc5c6f46479de2"},
     {file = "greenlet-1.1.2-cp38-cp38-win32.whl", hash = "sha256:288c6a76705dc54fba69fbcb59904ae4ad768b4c768839b8ca5fdadec6dd8cfd"},
     {file = "greenlet-1.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:8d2f1fb53a421b410751887eb4ff21386d119ef9cde3797bf5e7ed49fb51a3b3"},
     {file = "greenlet-1.1.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:166eac03e48784a6a6e0e5f041cfebb1ab400b394db188c48b3a84737f505b67"},
@@ -1033,7 +1107,6 @@ greenlet = [
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1692f7d6bc45e3200844be0dba153612103db241691088626a33ff1f24a0d88"},
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7227b47e73dedaa513cdebb98469705ef0d66eb5a1250144468e9c3097d6b59b"},
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ff61ff178250f9bb3cd89752df0f1dd0e27316a8bd1465351652b1b4a4cdfd3"},
-    {file = "greenlet-1.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3"},
     {file = "greenlet-1.1.2-cp39-cp39-win32.whl", hash = "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf"},
     {file = "greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd"},
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
@@ -1356,6 +1429,7 @@ sqlalchemy = [
     {file = "SQLAlchemy-1.4.37-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:d9050b0c4a7f5538650c74aaba5c80cd64450e41c206f43ea6d194ae6d060ff9"},
     {file = "SQLAlchemy-1.4.37-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b4c92823889cf9846b972ee6db30c0e3a92c0ddfc76c6060a6cda467aa5fb694"},
     {file = "SQLAlchemy-1.4.37-cp27-cp27m-win32.whl", hash = "sha256:b55932fd0e81b43f4aff397c8ad0b3c038f540af37930423ab8f47a20b117e4c"},
+    {file = "SQLAlchemy-1.4.37-cp27-cp27m-win_amd64.whl", hash = "sha256:4a17c1a1152ca4c29d992714aa9df3054da3af1598e02134f2e7314a32ef69d8"},
     {file = "SQLAlchemy-1.4.37-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ffe487570f47536b96eff5ef2b84034a8ba4e19aab5ab7647e677d94a119ea55"},
     {file = "SQLAlchemy-1.4.37-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:78363f400fbda80f866e8e91d37d36fe6313ff847ded08674e272873c1377ea5"},
     {file = "SQLAlchemy-1.4.37-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ee34c85cbda7779d66abac392c306ec78c13f5c73a1f01b8b767916d4895d23"},
@@ -1397,9 +1471,17 @@ starlette = [
     {file = "starlette-0.20.3-py3-none-any.whl", hash = "sha256:4d39be143dffde65782865ce40f86e5a8986400c5be0217b3cda3e732bfd7233"},
     {file = "starlette-0.20.3.tar.gz", hash = "sha256:38ef09c1c9a8ea7b7927d2c42d515efbbdbb6ea60dbe88b29abb320824fe16c1"},
 ]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+tox = [
+    {file = "tox-3.25.0-py2.py3-none-any.whl", hash = "sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a"},
+    {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
 ]
 typed-ast = [
     {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
@@ -1438,6 +1520,10 @@ urllib3 = [
 uvicorn = [
     {file = "uvicorn-0.17.6-py3-none-any.whl", hash = "sha256:19e2a0e96c9ac5581c01eb1a79a7d2f72bb479691acd2b8921fce48ed5b961a6"},
     {file = "uvicorn-0.17.6.tar.gz", hash = "sha256:5180f9d059611747d841a4a4c4ab675edf54c8489e97f96d0583ee90ac3bfc23"},
+]
+virtualenv = [
+    {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},
+    {file = "virtualenv-20.14.1.tar.gz", hash = "sha256:ef589a79795589aada0c1c5b319486797c03b67ac3984c48c669c0e4f50df3a5"},
 ]
 watchdog = [
     {file = "watchdog-2.1.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a735a990a1095f75ca4f36ea2ef2752c99e6ee997c46b0de507ba40a09bf7330"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ Jinja2 = "*"
 Mako = "*"
 freezegun = "*"
 pytest-mock = "*"
+tox = "*"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/app/test_middleware_handling.py
+++ b/tests/app/test_middleware_handling.py
@@ -56,7 +56,7 @@ class CustomHeaderMiddleware(BaseHTTPMiddleware):
         return response
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "middleware",
     [
         MiddlewareProtocolRequestLoggingMiddleware,

--- a/tests/handlers/http/test_defaults.py
+++ b/tests/handlers/http/test_defaults.py
@@ -7,7 +7,7 @@ from starlite import HttpMethod
 from starlite.handlers import HTTPRouteHandler
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "http_method, expected_status_code",
     [
         (HttpMethod.POST, HTTP_201_CREATED),

--- a/tests/handlers/http/test_kwarg_handling.py
+++ b/tests/handlers/http/test_kwarg_handling.py
@@ -26,7 +26,7 @@ def dummy_method() -> None:
     pass
 
 
-@given(  # type: ignore[misc]
+@given(
     http_method=st.one_of(st.sampled_from(HttpMethod), st.lists(st.sampled_from(HttpMethod))),
     media_type=st.sampled_from(MediaType),
     include_in_schema=st.booleans(),
@@ -84,7 +84,7 @@ def test_route_handler_kwarg_handling(
             assert result.status_code == HTTP_200_OK
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "sub, http_method, expected_status_code",
     [
         (post, HttpMethod.POST, HTTP_201_CREATED),

--- a/tests/handlers/http/test_sync.py
+++ b/tests/handlers/http/test_sync.py
@@ -7,7 +7,7 @@ def sync_handler() -> str:
     return "Hello World"
 
 
-@pytest.mark.parametrize(  # type: ignore
+@pytest.mark.parametrize(
     "handler",
     [
         get("/", media_type=MediaType.TEXT, sync_to_thread=True)(sync_handler),

--- a/tests/handlers/http/test_to_response.py
+++ b/tests/handlers/http/test_to_response.py
@@ -33,7 +33,7 @@ from starlite.testing import create_test_client
 from tests import Person, PersonFactory
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_to_response_async_await() -> None:
     @route(http_method=HttpMethod.POST, path="/person")
     async def test_function(data: Person) -> Person:
@@ -48,8 +48,8 @@ async def test_to_response_async_await() -> None:
     assert loads(response.body) == person_instance.dict()
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "expected_response",
     [
         Response(status_code=HTTP_200_OK, content=b"abc", media_type=MediaType.TEXT),
@@ -75,7 +75,7 @@ async def test_to_response_returning_redirect_starlette_response(expected_respon
         assert response is expected_response
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_to_response_returning_redirect_response() -> None:
     @get(path="/test", status_code=301)
     def test_function() -> Redirect:
@@ -89,7 +89,7 @@ async def test_to_response_returning_redirect_response() -> None:
         assert response.headers["location"] == "/somewhere-else"
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_to_response_returning_file_response() -> None:
     current_file_path = Path(__file__).resolve()
     filename = Path(__file__).name
@@ -120,8 +120,8 @@ async def my_async_iterator() -> AsyncGenerator[int, None]:
         yield count
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "iterator, should_raise", [[my_iterator(), False], [my_async_iterator(), False], [{"key": 1}, True]]
 )
 async def test_to_response_streaming_response(iterator: Any, should_raise: bool) -> None:

--- a/tests/handlers/http/test_validations.py
+++ b/tests/handlers/http/test_validations.py
@@ -50,7 +50,7 @@ def test_route_handler_validation_response_class() -> None:
         HTTPRouteHandler(http_method=HttpMethod.GET, response_class=dict())  # type: ignore
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_function_validation() -> None:
     with pytest.raises(ValidationException):
 

--- a/tests/kwargs/test_cookie_params.py
+++ b/tests/kwargs/test_cookie_params.py
@@ -8,7 +8,7 @@ from typing_extensions import Type
 from starlite import Parameter, create_test_client, get
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "t_type,param_dict, param, should_raise",
     [
         (str, {"special-cookie": "123"}, Parameter(cookie="special-cookie", min_length=1, max_length=3), False),

--- a/tests/kwargs/test_header_params.py
+++ b/tests/kwargs/test_header_params.py
@@ -10,7 +10,7 @@ from typing_extensions import Type
 from starlite import Parameter, create_test_client, get
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "t_type,param_dict, param, should_raise",
     [
         (str, {"special-header": "123"}, Parameter(header="special-header", min_length=1, max_length=3), False),

--- a/tests/kwargs/test_multipart_data.py
+++ b/tests/kwargs/test_multipart_data.py
@@ -19,7 +19,7 @@ class FormData(BaseModel):
         arbitrary_types_allowed = True
 
 
-@pytest.mark.parametrize("t_type", [FormData, Dict[str, UploadFile], List[UploadFile], UploadFile])  # type: ignore[misc]
+@pytest.mark.parametrize("t_type", [FormData, Dict[str, UploadFile], List[UploadFile], UploadFile])
 def test_request_body_multi_part(t_type: Type[Any]) -> None:
 
     body = Body(media_type=RequestEncodingType.MULTI_PART)

--- a/tests/kwargs/test_path_params.py
+++ b/tests/kwargs/test_path_params.py
@@ -13,7 +13,7 @@ from starlite import (
 )
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "params_dict,should_raise",
     [
         (

--- a/tests/kwargs/test_query_params.py
+++ b/tests/kwargs/test_query_params.py
@@ -8,7 +8,7 @@ from starlette.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from starlite import Parameter, create_test_client, get
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "params_dict,should_raise",
     [
         (

--- a/tests/kwargs/test_reserved_kwargs_injection.py
+++ b/tests/kwargs/test_reserved_kwargs_injection.py
@@ -51,7 +51,7 @@ class QueryParamsFactory(ModelFactory):
 person_instance = PersonFactory.build()
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (post, HttpMethod.POST, HTTP_201_CREATED),
@@ -66,7 +66,7 @@ def test_data_using_model(decorator: Any, http_method: Any, expected_status_code
     class MyController(Controller):
         path = test_path
 
-        @decorator()  # type: ignore[misc]
+        @decorator()
         def test_method(self, data: Person) -> None:
             assert data == person_instance
 
@@ -75,7 +75,7 @@ def test_data_using_model(decorator: Any, http_method: Any, expected_status_code
         assert response.status_code == expected_status_code
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (post, HttpMethod.POST, HTTP_201_CREATED),
@@ -92,7 +92,7 @@ def test_data_using_list_of_models(decorator: Any, http_method: Any, expected_st
     class MyController(Controller):
         path = test_path
 
-        @decorator()  # type: ignore[misc]
+        @decorator()
         def test_method(self, data: List[Person]) -> None:
             assert data == people
 
@@ -101,7 +101,7 @@ def test_data_using_list_of_models(decorator: Any, http_method: Any, expected_st
         assert response.status_code == expected_status_code
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (get, HttpMethod.GET, HTTP_200_OK),
@@ -117,7 +117,7 @@ def test_path_params(decorator: Any, http_method: Any, expected_status_code: Any
     class MyController(Controller):
         path = test_path
 
-        @decorator(path="/{person_id:str}")  # type: ignore[misc]
+        @decorator(path="/{person_id:str}")
         def test_method(self, person_id: str) -> None:
             assert person_id == person_instance.id
             return None
@@ -127,7 +127,7 @@ def test_path_params(decorator: Any, http_method: Any, expected_status_code: Any
         assert response.status_code == expected_status_code
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (get, HttpMethod.GET, HTTP_200_OK),
@@ -145,7 +145,7 @@ def test_query_params(decorator: Any, http_method: Any, expected_status_code: An
     class MyController(Controller):
         path = test_path
 
-        @decorator()  # type: ignore[misc]
+        @decorator()
         def test_method(self, first: str, second: List[str], third: Optional[int] = None) -> None:
             assert first == query_params_instance.first
             assert second == query_params_instance.second
@@ -157,7 +157,7 @@ def test_query_params(decorator: Any, http_method: Any, expected_status_code: An
         assert response.status_code == expected_status_code
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (get, HttpMethod.GET, HTTP_200_OK),
@@ -180,7 +180,7 @@ def test_header_params(decorator: Any, http_method: Any, expected_status_code: A
     class MyController(Controller):
         path = test_path
 
-        @decorator()  # type: ignore[misc]
+        @decorator()
         def test_method(self, headers: dict) -> None:
             for key, value in request_headers.items():
                 assert headers[key] == value
@@ -190,7 +190,7 @@ def test_header_params(decorator: Any, http_method: Any, expected_status_code: A
         assert response.status_code == expected_status_code
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (get, HttpMethod.GET, HTTP_200_OK),
@@ -206,7 +206,7 @@ def test_request(decorator: Any, http_method: Any, expected_status_code: Any) ->
     class MyController(Controller):
         path = test_path
 
-        @decorator()  # type: ignore[misc]
+        @decorator()
         def test_method(self, request: Request) -> None:
             assert isinstance(request, Request)
 

--- a/tests/kwargs/test_validations.py
+++ b/tests/kwargs/test_validations.py
@@ -57,7 +57,7 @@ def handler_with_dependency_and_aliased_cookie_parameter_collision(my_key: str =
     ...
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "handler",
     [
         handler_with_path_param_and_aliased_query_parameter_collision,
@@ -74,7 +74,7 @@ def test_raises_exception_when_keys_are_ambiguous(handler: HTTPRouteHandler) -> 
         Starlite(route_handlers=[handler])
 
 
-@pytest.mark.parametrize("reserved_kwarg", RESERVED_KWARGS)  # type: ignore[misc]
+@pytest.mark.parametrize("reserved_kwarg", RESERVED_KWARGS)
 def test_raises_when_reserved_kwargs_are_misused(reserved_kwarg: str) -> None:
     decorator = post if reserved_kwarg != "socket" else websocket
 
@@ -136,12 +136,12 @@ def accepted_multi_part_handler(
     assert first
 
 
-@pytest.mark.parametrize("handler", [accepted_json_handler, accepted_url_encoded_handler, accepted_multi_part_handler])  # type: ignore[misc]
+@pytest.mark.parametrize("handler", [accepted_json_handler, accepted_url_encoded_handler, accepted_multi_part_handler])
 def test_dependency_data_kwarg_validation_success_scenarios(handler: HTTPRouteHandler) -> None:
     Starlite(route_handlers=[handler])
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "body, dependency",
     [
         [Body(media_type=RequestEncodingType.JSON), url_encoded_dependency],

--- a/tests/openapi/test_constrained_fields.py
+++ b/tests/openapi/test_constrained_fields.py
@@ -19,7 +19,7 @@ from tests.openapi.utils import (
 )
 
 
-@given(  # type: ignore[misc]
+@given(
     field_type=st.sampled_from(constrained_collection),
 )
 def test_create_collection_constrained_field_schema(field_type: Any) -> None:
@@ -51,7 +51,7 @@ def test_create_collection_constrained_field_schema_sub_fields() -> None:
         assert schema.dict(exclude_none=True) == expected
 
 
-@given(field_type=st.sampled_from(constrained_string))  # type: ignore[misc]
+@given(field_type=st.sampled_from(constrained_string))
 def test_create_string_constrained_field_schema(field_type: Any) -> None:
     schema = create_string_constrained_field_schema(field_type=field_type)
     assert schema.type == OpenAPIType.STRING
@@ -63,7 +63,7 @@ def test_create_string_constrained_field_schema(field_type: Any) -> None:
         assert schema.description
 
 
-@given(field_type=st.sampled_from(constrained_numbers))  # type: ignore[misc]
+@given(field_type=st.sampled_from(constrained_numbers))
 def test_create_numerical_constrained_field_schema(field_type: Any) -> None:
     schema = create_numerical_constrained_field_schema(field_type=field_type)
     assert schema.type == OpenAPIType.INTEGER if issubclass(field_type, int) else OpenAPIType.NUMBER
@@ -75,7 +75,7 @@ def test_create_numerical_constrained_field_schema(field_type: Any) -> None:
     assert schema.multipleOf == field_type.multiple_of
 
 
-@given(field_type=st.sampled_from([*constrained_numbers, *constrained_collection, *constrained_string]))  # type: ignore[misc]
+@given(field_type=st.sampled_from([*constrained_numbers, *constrained_collection, *constrained_string]))
 def test_create_constrained_field_schema(field_type: Any) -> None:
     schema = create_constrained_field_schema(field_type=field_type, sub_fields=None)
     assert schema

--- a/tests/plugins/sql_alchemy_plugin/__init__.py
+++ b/tests/plugins/sql_alchemy_plugin/__init__.py
@@ -9,20 +9,20 @@ class SQLAlchemyBase:
     id: Column
 
     # Generate the table name from the class name
-    @declared_attr  # type: ignore[misc]
+    @declared_attr
     def __tablename__(cls) -> str:
-        return cls.__name__.lower()  # type: ignore
+        return cls.__name__.lower()  # type:ignore[no-any-return,attr-defined]
 
 
 association_table = Table(
     "association",
-    SQLAlchemyBase.metadata,  # type: ignore
+    SQLAlchemyBase.metadata,  # type:ignore[attr-defined]
     Column("pet_id", ForeignKey("pet.id")),
     Column("user_id", ForeignKey("user.id")),
 )
 friendship_table = Table(
     "friendships",
-    SQLAlchemyBase.metadata,  # type: ignore
+    SQLAlchemyBase.metadata,  # type:ignore[attr-defined]
     Column("friend_a_id", Integer, ForeignKey("user.id"), primary_key=True),
     Column("friend_b_id", Integer, ForeignKey("user.id"), primary_key=True),
 )
@@ -34,7 +34,7 @@ class Pet(SQLAlchemyBase):
     name = Column(String)
     age = Column(Float)
     owner_id = Column(Integer, ForeignKey("user.id"))
-    owner = relationship("User", back_populates="pets")
+    owner = relationship("User", back_populates="pets", uselist=False)
 
 
 class Company(SQLAlchemyBase):
@@ -46,15 +46,13 @@ class Company(SQLAlchemyBase):
 class User(SQLAlchemyBase):
     id = Column(Integer, primary_key=True)
     name = Column(String, default="moishe")
-    pets = relationship(
-        "Pet",
-        back_populates="owner",
-    )
+    pets = relationship("Pet", back_populates="owner", uselist=True)
     friends = relationship(
         "User",
         secondary=friendship_table,
         primaryjoin=id == friendship_table.c.friend_a_id,
         secondaryjoin=id == friendship_table.c.friend_b_id,
+        uselist=True,
     )
     company_id = Column(Integer, ForeignKey("company.id"))
     company = relationship("Company")

--- a/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_plugin_integration.py
+++ b/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_plugin_integration.py
@@ -11,7 +11,7 @@ from starlite.plugins.sql_alchemy import SQLAlchemyPlugin
 from tests.plugins.sql_alchemy_plugin import Company
 
 companies = [
-    Company(id=i, name=create_random_string(min_length=5, max_length=20), worth=create_random_float(minimum=1))  # type: ignore
+    Company(id=i, name=create_random_string(min_length=5, max_length=20), worth=create_random_float(minimum=1))  # type: ignore[call-arg]
     for i in range(3)
 ]
 

--- a/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_table_types.py
+++ b/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_table_types.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 import sqlalchemy
 from pydantic import BaseModel
@@ -42,7 +44,6 @@ from sqlalchemy import (
     Table,
     Text,
     Time,
-    TupleType,
     Unicode,
     UnicodeText,
 )
@@ -57,6 +58,9 @@ from sqlalchemy.dialects import (
 )
 from sqlalchemy.orm import registry
 from sqlalchemy.sql.functions import now
+
+# TupleType not a sqlalchemy2-stubs top-level import
+from sqlalchemy.sql.sqltypes import TupleType
 
 from starlite import ImproperlyConfiguredException
 from starlite.plugins.sql_alchemy import SQLAlchemyPlugin
@@ -106,7 +110,8 @@ class DeclarativeModel(SQLAlchemyBase):
     TIMESTAMP_column = Column(TIMESTAMP)
     Text_column = Column(Text)
     Time_column = Column(Time)
-    TupleType_column = Column(TupleType(str, int, bool))
+    # `TupleType[Any]` for 'Value of type variable "_TE" of "TupleType" cannot be "type"  [type-var]'
+    TupleType_column = Column(TupleType[Any](str, int, bool))
     Unicode_column = Column(Unicode)
     UnicodeText_column = Column(UnicodeText)
     VARBINARY_column = Column(VARBINARY)
@@ -175,27 +180,27 @@ class DeclarativeModel(SQLAlchemyBase):
     oracle_VARCHAR_column = Column(oracle.VARCHAR)
     # postgresql
     postgresql_ARRAY_column = Column(postgresql.ARRAY(String, dimensions=2))
-    postgresql_BIT_column = Column(postgresql.BIT)
+    postgresql_BIT_column: bytes = Column(postgresql.BIT)
     postgresql_BYTEA_column = Column(postgresql.BYTEA)
-    postgresql_CIDR_column = Column(postgresql.CIDR)
+    postgresql_CIDR_column: str = Column(postgresql.CIDR)
     postgresql_DATERANGE_column = Column(postgresql.DATERANGE)
     postgresql_DOUBLE_PRECISION_column = Column(postgresql.DOUBLE_PRECISION)
     postgresql_ENUM_column = Column(postgresql.ENUM(Species))
     postgresql_HSTORE_column = Column(postgresql.HSTORE)
-    postgresql_INET_column = Column(postgresql.INET)
+    postgresql_INET_column: str = Column(postgresql.INET)
     postgresql_INT4RANGE_column = Column(postgresql.INT4RANGE)
     postgresql_INT8RANGE_column = Column(postgresql.INT8RANGE)
     postgresql_INTERVAL_column = Column(postgresql.INTERVAL)
     postgresql_JSON_column = Column(postgresql.JSON)
     postgresql_JSONB_column = Column(postgresql.JSONB)
-    postgresql_MACADDR_column = Column(postgresql.MACADDR)
-    postgresql_MONEY_column = Column(postgresql.MONEY)
+    postgresql_MACADDR_column: str = Column(postgresql.MACADDR)
+    postgresql_MONEY_column: str = Column(postgresql.MONEY)
     postgresql_NUMRANGE_column = Column(postgresql.NUMRANGE)
     postgresql_TIME_column = Column(postgresql.TIME)
     postgresql_TIMESTAMP_column = Column(postgresql.TIMESTAMP)
     postgresql_TSRANGE_column = Column(postgresql.TSRANGE)
     postgresql_TSTZRANGE_column = Column(postgresql.TSTZRANGE)
-    postgresql_UUID_column = Column(postgresql.UUID)
+    postgresql_UUID_column: postgresql.UUID = Column(postgresql.UUID)
     # sqlite
     sqlite_DATE_column = Column(sqlite.DATE)
     sqlite_DATETIME_column = Column(sqlite.DATETIME)
@@ -236,7 +241,7 @@ def test_sql_alchemy_plugin_validation() -> None:
 
 
 def test_provider_validation() -> None:
-    class MyStrColumn(sqlalchemy.String):  # type: ignore
+    class MyStrColumn(sqlalchemy.String):  # type:ignore[misc]
         pass
 
     class ModelWithCustomColumn(SQLAlchemyBase):

--- a/tests/response/test_serialization.py
+++ b/tests/response/test_serialization.py
@@ -8,7 +8,7 @@ from starlite import MediaType, Response
 from tests import PersonFactory, PydanticDataClassPerson, VanillaDataClassPerson
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "content, media_type",
     [
         [PersonFactory.build(), MediaType.JSON],

--- a/tests/route/test_validations.py
+++ b/tests/route/test_validations.py
@@ -15,7 +15,7 @@ def my_post_handler() -> None:
     pass
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_http_route_raises_for_unsupported_method() -> None:
     route = HTTPRoute(path="/", route_handlers=[my_get_handler, my_post_handler])
 

--- a/tests/test_connection_lifecycle_hooks.py
+++ b/tests/test_connection_lifecycle_hooks.py
@@ -50,7 +50,7 @@ async def async_after_request_handler(response: Response) -> Response:
     return response
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "handler, expected",
     [
         [get(path="/")(greet), {"hello": "world"}],
@@ -66,7 +66,7 @@ def test_before_request_handler_called(handler: HTTPRouteHandler, expected: dict
         assert response.json() == expected
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "handler, expected",
     [
         [get(path="/")(greet), {"hello": "world"}],
@@ -80,7 +80,7 @@ def test_after_request_handler_called(handler: HTTPRouteHandler, expected: dict)
         assert response.json() == expected
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "app_before_request_handler, router_before_request_handler, controller_before_request_handler, method_before_request_handler, expected",
     [
         [None, None, None, None, {"hello": "world"}],
@@ -141,7 +141,7 @@ async def async_after_request_handler_with_hello_world(response: Response) -> Re
     return response
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "app_after_request_handler, router_after_request_handler, controller_after_request_handler, method_after_request_handler, expected",
     [
         [None, None, None, None, {"hello": "world"}],

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -18,7 +18,7 @@ from starlite.connection import WebSocket
 from tests import Person, PersonFactory
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (get, HttpMethod.GET, HTTP_200_OK),

--- a/tests/test_dto_factory.py
+++ b/tests/test_dto_factory.py
@@ -21,7 +21,7 @@ from tests import Species, VanillaDataClassPerson
 from tests.plugins.sql_alchemy_plugin import Pet, User
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "model, exclude, field_mapping, field_definitions, plugins",
     [
         [Person, ["id"], {"complex": "ultra"}, {"special": (str, ...)}, []],
@@ -68,7 +68,7 @@ def test_dto_factory_validation() -> None:
         DTOFactory(plugins=[])("MyDTO", MyClass)
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "model, exclude, field_mapping, plugins",
     [
         [Person, ["id"], {"complex": "ultra"}, []],
@@ -124,7 +124,7 @@ def test_dto_openapi_generation() -> None:
     assert app.openapi_schema
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "model, exclude, field_mapping, plugins",
     [
         [Person, [], {"complex": "ultra"}, []],
@@ -150,8 +150,8 @@ def test_conversion_to_model_instance(model: Any, exclude: list, field_mapping: 
             assert model_instance.__getattribute__(original_key) == dto_instance.__getattribute__(key)  # type: ignore
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="dataclasses behave differently in lower versions")  # type: ignore
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="dataclasses behave differently in lower versions")
+@pytest.mark.parametrize(
     "model, exclude, field_mapping, plugins",
     [
         [Person, ["id"], {"complex": "ultra"}, []],
@@ -174,7 +174,7 @@ def test_conversion_from_model_instance(
             pets=None,
         )
     else:
-        model_instance = cast(Type[Pet], model)(  # type: ignore
+        model_instance = cast(Type[Pet], model)(  # type: ignore[call-arg]
             id=1,
             species=Species.MONKEY,
             name="Mike",

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -13,7 +13,7 @@ from starlite.exceptions import (
 )
 
 
-@given(detail=st.one_of(st.none(), st.text()))  # type: ignore[misc]
+@given(detail=st.one_of(st.none(), st.text()))
 def test_starlite_exception(detail: Optional[str]) -> None:
     result = StarLiteException(detail=detail)  # type: ignore
     assert result.detail == detail
@@ -23,7 +23,7 @@ def test_starlite_exception(detail: Optional[str]) -> None:
         assert result.__repr__() == result.__class__.__name__
 
 
-@given(status_code=st.integers(min_value=400, max_value=404), detail=st.one_of(st.none(), st.text()))  # type: ignore[misc]
+@given(status_code=st.integers(min_value=400, max_value=404), detail=st.one_of(st.none(), st.text()))
 def test_http_exception(status_code: int, detail: Optional[str]) -> None:
     assert HTTPException().status_code == HTTP_500_INTERNAL_SERVER_ERROR
     result = HTTPException(status_code=status_code, detail=detail)
@@ -32,7 +32,7 @@ def test_http_exception(status_code: int, detail: Optional[str]) -> None:
     assert result.__repr__() == f"{result.status_code} - {result.__class__.__name__} - {result.detail}"
 
 
-@given(detail=st.one_of(st.none(), st.text()))  # type: ignore[misc]
+@given(detail=st.one_of(st.none(), st.text()))
 def test_improperly_configured_exception(detail: Optional[str]) -> None:
     result = ImproperlyConfiguredException(detail=detail)
     assert result.__repr__() == f"{HTTP_500_INTERNAL_SERVER_ERROR} - {result.__class__.__name__} - {result.detail}"

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -26,7 +26,7 @@ def root_delete_handler() -> None:
     return None
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "request_path, router_path",
     [
         [f"/path/1/2/sub/{str(uuid4())}", "/path/{first:int}/{second:str}/sub/{third:uuid}"],
@@ -67,7 +67,7 @@ def test_path_parsing_with_ambiguous_paths() -> None:
         assert response.status_code == HTTP_200_OK
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, test_path, decorator_path, delete_handler",
     [
         (get, "", "/something", None),
@@ -126,7 +126,7 @@ def test_handler_multi_paths() -> None:
         assert fourth_response.text == "2"
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "handler_path, request_path, expected_status_code",
     [
         ("/sub-path", "/", HTTP_404_NOT_FOUND),

--- a/tests/test_provide.py
+++ b/tests/test_provide.py
@@ -10,14 +10,14 @@ def test_fn() -> dict:
     return dict()
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_provide_default() -> None:
     provider = Provide(dependency=test_fn)
     value = await provider()
     assert isinstance(value, dict)
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_provide_cached() -> None:
     provider = Provide(dependency=test_fn, use_cache=True)
     assert provider.value is Undefined
@@ -30,7 +30,7 @@ async def test_provide_cached() -> None:
     assert value == third_value
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_run_in_thread() -> None:
     provider = Provide(dependency=test_fn, sync_to_thread=True)
     value = await provider()

--- a/tests/test_response_class.py
+++ b/tests/test_response_class.py
@@ -23,7 +23,7 @@ class MyController(Controller):
         pass
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "layer, expected",
     [[0, local_response], [1, controller_response], [2, router_response], [3, app_response], [None, Response]],
 )

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -15,8 +15,8 @@ from starlite import (
 from tests import Person
 
 
-@settings(suppress_health_check=HealthCheck.all())  # type: ignore[misc]
-@given(  # type: ignore[misc]
+@settings(suppress_health_check=HealthCheck.all())
+@given(
     http_method=st.sampled_from(HttpMethod),
     scheme=st.text(),
     server=st.text(),

--- a/tests/utils/test_url.py
+++ b/tests/utils/test_url.py
@@ -3,7 +3,7 @@ import pytest
 from starlite.utils.url import join_paths, normalize_path
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "base,fragment, expected",
     [
         ("/path/", "sub", "/path/sub"),
@@ -18,6 +18,6 @@ def test_join_url_fragments(base: str, fragment: str, expected: str) -> None:
     assert join_paths([base, fragment]) == expected
 
 
-@pytest.mark.parametrize("base,expected", [("/path", "/path"), ("path/", "/path"), ("path", "/path")])  # type: ignore[misc]
+@pytest.mark.parametrize("base,expected", [("/path", "/path"), ("path/", "/path"), ("path", "/path")])
 def test_normalize_path(base: str, expected: str) -> None:
     assert normalize_path(base) == expected

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+isolated_build = True
+envlist = py37,py38,py39,py310,lint
+
+[testenv]
+whitelist_externals = poetry
+commands =
+  poetry install -v
+  poetry run pytest .
+
+[testenv:lint]
+deps = pre-commit
+commands = pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
We were individually ignoring lots of decorated functions because of this so better to ignore at the config level.

This is based off #145 so needs to merge after that.