### PR TITLE
Fix `Provide` for `@classmethod`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -843,33 +843,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "types-pyyaml"
-version = "6.0.8"
-description = "Typing stubs for PyYAML"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-requests"
-version = "2.27.30"
-description = "Typing stubs for requests"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-types-urllib3 = "<1.27"
-
-[[package]]
-name = "types-urllib3"
-version = "1.26.15"
-description = "Typing stubs for urllib3"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "typing-extensions"
 version = "4.2.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -952,7 +925,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "e563001d777589bff2e1754930e150499d7ff2795760098a3c65825f06c55a92"
+content-hash = "66739d9bd99f3f0e7db301e0fc0a025a362018759e10ac417794856e4b749238"
 
 [metadata.files]
 anyio = [
@@ -1535,18 +1508,6 @@ typed-ast = [
     {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
     {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
-]
-types-pyyaml = [
-    {file = "types-PyYAML-6.0.8.tar.gz", hash = "sha256:d9495d377bb4f9c5387ac278776403eb3b4bb376851025d913eea4c22b4c6438"},
-    {file = "types_PyYAML-6.0.8-py3-none-any.whl", hash = "sha256:56a7b0e8109602785f942a11ebfbd16e97d5d0e79f5fbb077ec4e6a0004837ff"},
-]
-types-requests = [
-    {file = "types-requests-2.27.30.tar.gz", hash = "sha256:ca8d7cc549c3d10dbcb3c69c1b53e3ffd1270089c1001a65c1e9e1017eb5e704"},
-    {file = "types_requests-2.27.30-py3-none-any.whl", hash = "sha256:b9b6cd0a6e5d500e56419b79f44ec96f316e9375ff6c8ee566c39d25e9612621"},
-]
-types-urllib3 = [
-    {file = "types-urllib3-1.26.15.tar.gz", hash = "sha256:c89283541ef92e344b7f59f83ea9b5a295b16366ceee3f25ecfc5593c79f794e"},
-    {file = "types_urllib3-1.26.15-py3-none-any.whl", hash = "sha256:6011befa13f901fc934f59bb1fd6973be6f3acf4ebfce427593a27e7f492918f"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},

--- a/starlite/provide.py
+++ b/starlite/provide.py
@@ -1,5 +1,5 @@
 from functools import partial
-from inspect import iscoroutinefunction, ismethod
+from inspect import iscoroutinefunction
 from typing import Any, Optional
 
 from anyio.to_thread import run_sync
@@ -19,9 +19,6 @@ class Provide:
         self.value: Any = Undefined
         self.signature_model: Optional[Type[SignatureModel]] = None
         self.sync_to_thread = sync_to_thread
-        if ismethod(dependency) and hasattr(dependency, "__self__"):
-            # ensure that the method's self argument is preserved
-            self.dependency = partial(dependency, dependency.__self__)
 
     async def __call__(self, **kwargs: Any) -> Any:
         """

--- a/tests/test_provide.py
+++ b/tests/test_provide.py
@@ -1,4 +1,5 @@
 from functools import partial
+from typing import Any
 
 import pytest
 from pydantic.fields import Undefined
@@ -6,23 +7,60 @@ from pydantic.fields import Undefined
 from starlite import Provide
 
 
-def test_fn() -> dict:
-    return dict()
+class C:
+    val = 31
+
+    def __init__(self) -> None:
+        self.val = 13
+
+    @classmethod
+    async def async_class(cls) -> int:
+        return cls.val
+
+    @classmethod
+    def sync_class(cls) -> int:
+        return cls.val
+
+    @staticmethod
+    async def async_static() -> str:
+        return "one-three"
+
+    @staticmethod
+    def sync_static() -> str:
+        return "one-three"
+
+    async def async_instance(self) -> int:
+        return self.val
+
+    def sync_instance(self) -> int:
+        return self.val
+
+
+async def async_fn(val: str = "three-one") -> str:
+    return val
+
+
+def sync_fn(val: str = "three-one") -> str:
+    return val
+
+
+async_partial = partial(async_fn, "why-three-and-one")
+sync_partial = partial(sync_fn, "why-three-and-one")
 
 
 @pytest.mark.asyncio
 async def test_provide_default() -> None:
-    provider = Provide(dependency=test_fn)
+    provider = Provide(dependency=async_fn)
     value = await provider()
-    assert isinstance(value, dict)
+    assert value == "three-one"
 
 
 @pytest.mark.asyncio
 async def test_provide_cached() -> None:
-    provider = Provide(dependency=test_fn, use_cache=True)
+    provider = Provide(dependency=async_fn, use_cache=True)
     assert provider.value is Undefined
     value = await provider()
-    assert isinstance(value, dict)
+    assert value == "three-one"
     assert provider.value == value
     second_value = await provider()
     assert value == second_value
@@ -32,29 +70,36 @@ async def test_provide_cached() -> None:
 
 @pytest.mark.asyncio
 async def test_run_in_thread() -> None:
-    provider = Provide(dependency=test_fn, sync_to_thread=True)
+    provider = Provide(dependency=sync_fn, sync_to_thread=True)
     value = await provider()
-    assert isinstance(value, dict)
-
-
-def test_provide_method() -> None:
-    class MyClass:
-        def my_method(self) -> None:
-            assert self.__class__ is MyClass
-
-    provider = Provide(dependency=MyClass().my_method)
-    assert isinstance(provider.dependency, partial)
-    assert isinstance(provider.dependency.args[0], MyClass)
+    assert value == "three-one"
 
 
 def test_provider_equality_check() -> None:
-    def fn() -> None:
-        pass
-
-    first_provider = Provide(dependency=fn)
-    second_provider = Provide(dependency=fn)
+    first_provider = Provide(dependency=sync_fn)
+    second_provider = Provide(dependency=sync_fn)
     assert first_provider == second_provider
-    third_provider = Provide(dependency=fn, use_cache=True)
+    third_provider = Provide(dependency=sync_fn, use_cache=True)
     assert first_provider != third_provider
     second_provider.value = True
     assert first_provider != second_provider
+
+
+@pytest.mark.parametrize(
+    "fn, exp",
+    [
+        (C.async_class, 31),
+        (C.sync_class, 31),
+        (C.async_static, "one-three"),
+        (C.sync_static, "one-three"),
+        (C().async_instance, 13),
+        (C().sync_instance, 13),
+        (async_fn, "three-one"),
+        (sync_fn, "three-one"),
+        (async_partial, "why-three-and-one"),
+        (sync_partial, "why-three-and-one"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_provide_for_callable(fn: Any, exp: Any) -> None:
+    assert await Provide(fn)() == exp


### PR DESCRIPTION
Fix for #142 where `Provide` wasn't working for `@classmethod`s.

Adds tests for each type of callable that might be given to provide.