### PR TITLE
Disable `disallow_untyped_decorators` mypy directive for test suite.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -12,7 +12,7 @@ disallow_any_generics = False
 implicit_reexport = False
 show_error_codes = True
 
-[mypy-tests.test_dependency,tests.openapi.test_tags]
+[mypy-tests.*]
 disallow_untyped_decorators = False
 
 [pydantic-mypy]

--- a/poetry.lock
+++ b/poetry.lock
@@ -108,7 +108,7 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.4"
+version = "0.4.5"
 description = "Cross-platform colored terminal text."
 category = "dev"
 optional = false
@@ -843,6 +843,33 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.8"
+description = "Typing stubs for PyYAML"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "types-requests"
+version = "2.27.30"
+description = "Typing stubs for requests"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+types-urllib3 = "<1.27"
+
+[[package]]
+name = "types-urllib3"
+version = "1.26.15"
+description = "Typing stubs for urllib3"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "typing-extensions"
 version = "4.2.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -925,7 +952,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "48175b6c6afb5070fa268e05b543845f740d3c23dcc0f4916cef60389ce8b51c"
+content-hash = "e563001d777589bff2e1754930e150499d7ff2795760098a3c65825f06c55a92"
 
 [metadata.files]
 anyio = [
@@ -982,8 +1009,8 @@ click = [
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
-    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
-    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
 ]
 commonmark = [
     {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
@@ -1508,6 +1535,18 @@ typed-ast = [
     {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
     {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
     {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
+]
+types-pyyaml = [
+    {file = "types-PyYAML-6.0.8.tar.gz", hash = "sha256:d9495d377bb4f9c5387ac278776403eb3b4bb376851025d913eea4c22b4c6438"},
+    {file = "types_PyYAML-6.0.8-py3-none-any.whl", hash = "sha256:56a7b0e8109602785f942a11ebfbd16e97d5d0e79f5fbb077ec4e6a0004837ff"},
+]
+types-requests = [
+    {file = "types-requests-2.27.30.tar.gz", hash = "sha256:ca8d7cc549c3d10dbcb3c69c1b53e3ffd1270089c1001a65c1e9e1017eb5e704"},
+    {file = "types_requests-2.27.30-py3-none-any.whl", hash = "sha256:b9b6cd0a6e5d500e56419b79f44ec96f316e9375ff6c8ee566c39d25e9612621"},
+]
+types-urllib3 = [
+    {file = "types-urllib3-1.26.15.tar.gz", hash = "sha256:c89283541ef92e344b7f59f83ea9b5a295b16366ceee3f25ecfc5593c79f794e"},
+    {file = "types_urllib3-1.26.15-py3-none-any.whl", hash = "sha256:6011befa13f901fc934f59bb1fd6973be6f3acf4ebfce427593a27e7f492918f"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},

--- a/tests/app/test_middleware_handling.py
+++ b/tests/app/test_middleware_handling.py
@@ -56,7 +56,7 @@ class CustomHeaderMiddleware(BaseHTTPMiddleware):
         return response
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "middleware",
     [
         MiddlewareProtocolRequestLoggingMiddleware,

--- a/tests/handlers/http/test_defaults.py
+++ b/tests/handlers/http/test_defaults.py
@@ -7,7 +7,7 @@ from starlite import HttpMethod
 from starlite.handlers import HTTPRouteHandler
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "http_method, expected_status_code",
     [
         (HttpMethod.POST, HTTP_201_CREATED),

--- a/tests/handlers/http/test_kwarg_handling.py
+++ b/tests/handlers/http/test_kwarg_handling.py
@@ -26,7 +26,7 @@ def dummy_method() -> None:
     pass
 
 
-@given(  # type: ignore[misc]
+@given(
     http_method=st.one_of(st.sampled_from(HttpMethod), st.lists(st.sampled_from(HttpMethod))),
     media_type=st.sampled_from(MediaType),
     include_in_schema=st.booleans(),
@@ -84,7 +84,7 @@ def test_route_handler_kwarg_handling(
             assert result.status_code == HTTP_200_OK
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "sub, http_method, expected_status_code",
     [
         (post, HttpMethod.POST, HTTP_201_CREATED),

--- a/tests/handlers/http/test_sync.py
+++ b/tests/handlers/http/test_sync.py
@@ -7,7 +7,7 @@ def sync_handler() -> str:
     return "Hello World"
 
 
-@pytest.mark.parametrize(  # type: ignore
+@pytest.mark.parametrize(
     "handler",
     [
         get("/", media_type=MediaType.TEXT, sync_to_thread=True)(sync_handler),

--- a/tests/handlers/http/test_to_response.py
+++ b/tests/handlers/http/test_to_response.py
@@ -33,7 +33,7 @@ from starlite.testing import create_test_client
 from tests import Person, PersonFactory
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_to_response_async_await() -> None:
     @route(http_method=HttpMethod.POST, path="/person")
     async def test_function(data: Person) -> Person:
@@ -48,8 +48,8 @@ async def test_to_response_async_await() -> None:
     assert loads(response.body) == person_instance.dict()
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "expected_response",
     [
         Response(status_code=HTTP_200_OK, content=b"abc", media_type=MediaType.TEXT),
@@ -75,7 +75,7 @@ async def test_to_response_returning_redirect_starlette_response(expected_respon
         assert response is expected_response
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_to_response_returning_redirect_response() -> None:
     @get(path="/test", status_code=301)
     def test_function() -> Redirect:
@@ -89,7 +89,7 @@ async def test_to_response_returning_redirect_response() -> None:
         assert response.headers["location"] == "/somewhere-else"
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_to_response_returning_file_response() -> None:
     current_file_path = Path(__file__).resolve()
     filename = Path(__file__).name
@@ -120,8 +120,8 @@ async def my_async_iterator() -> AsyncGenerator[int, None]:
         yield count
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "iterator, should_raise", [[my_iterator(), False], [my_async_iterator(), False], [{"key": 1}, True]]
 )
 async def test_to_response_streaming_response(iterator: Any, should_raise: bool) -> None:

--- a/tests/handlers/http/test_validations.py
+++ b/tests/handlers/http/test_validations.py
@@ -50,7 +50,7 @@ def test_route_handler_validation_response_class() -> None:
         HTTPRouteHandler(http_method=HttpMethod.GET, response_class=dict())  # type: ignore
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_function_validation() -> None:
     with pytest.raises(ValidationException):
 

--- a/tests/kwargs/test_cookie_params.py
+++ b/tests/kwargs/test_cookie_params.py
@@ -8,7 +8,7 @@ from typing_extensions import Type
 from starlite import Parameter, create_test_client, get
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "t_type,param_dict, param, should_raise",
     [
         (str, {"special-cookie": "123"}, Parameter(cookie="special-cookie", min_length=1, max_length=3), False),

--- a/tests/kwargs/test_header_params.py
+++ b/tests/kwargs/test_header_params.py
@@ -10,7 +10,7 @@ from typing_extensions import Type
 from starlite import Parameter, create_test_client, get
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "t_type,param_dict, param, should_raise",
     [
         (str, {"special-header": "123"}, Parameter(header="special-header", min_length=1, max_length=3), False),

--- a/tests/kwargs/test_multipart_data.py
+++ b/tests/kwargs/test_multipart_data.py
@@ -19,7 +19,7 @@ class FormData(BaseModel):
         arbitrary_types_allowed = True
 
 
-@pytest.mark.parametrize("t_type", [FormData, Dict[str, UploadFile], List[UploadFile], UploadFile])  # type: ignore[misc]
+@pytest.mark.parametrize("t_type", [FormData, Dict[str, UploadFile], List[UploadFile], UploadFile])
 def test_request_body_multi_part(t_type: Type[Any]) -> None:
 
     body = Body(media_type=RequestEncodingType.MULTI_PART)

--- a/tests/kwargs/test_path_params.py
+++ b/tests/kwargs/test_path_params.py
@@ -13,7 +13,7 @@ from starlite import (
 )
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "params_dict,should_raise",
     [
         (

--- a/tests/kwargs/test_query_params.py
+++ b/tests/kwargs/test_query_params.py
@@ -8,7 +8,7 @@ from starlette.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from starlite import Parameter, create_test_client, get
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "params_dict,should_raise",
     [
         (

--- a/tests/kwargs/test_reserved_kwargs_injection.py
+++ b/tests/kwargs/test_reserved_kwargs_injection.py
@@ -51,7 +51,7 @@ class QueryParamsFactory(ModelFactory):
 person_instance = PersonFactory.build()
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (post, HttpMethod.POST, HTTP_201_CREATED),
@@ -66,7 +66,7 @@ def test_data_using_model(decorator: Any, http_method: Any, expected_status_code
     class MyController(Controller):
         path = test_path
 
-        @decorator()  # type: ignore[misc]
+        @decorator()
         def test_method(self, data: Person) -> None:
             assert data == person_instance
 
@@ -75,7 +75,7 @@ def test_data_using_model(decorator: Any, http_method: Any, expected_status_code
         assert response.status_code == expected_status_code
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (post, HttpMethod.POST, HTTP_201_CREATED),
@@ -92,7 +92,7 @@ def test_data_using_list_of_models(decorator: Any, http_method: Any, expected_st
     class MyController(Controller):
         path = test_path
 
-        @decorator()  # type: ignore[misc]
+        @decorator()
         def test_method(self, data: List[Person]) -> None:
             assert data == people
 
@@ -101,7 +101,7 @@ def test_data_using_list_of_models(decorator: Any, http_method: Any, expected_st
         assert response.status_code == expected_status_code
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (get, HttpMethod.GET, HTTP_200_OK),
@@ -117,7 +117,7 @@ def test_path_params(decorator: Any, http_method: Any, expected_status_code: Any
     class MyController(Controller):
         path = test_path
 
-        @decorator(path="/{person_id:str}")  # type: ignore[misc]
+        @decorator(path="/{person_id:str}")
         def test_method(self, person_id: str) -> None:
             assert person_id == person_instance.id
             return None
@@ -127,7 +127,7 @@ def test_path_params(decorator: Any, http_method: Any, expected_status_code: Any
         assert response.status_code == expected_status_code
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (get, HttpMethod.GET, HTTP_200_OK),
@@ -145,7 +145,7 @@ def test_query_params(decorator: Any, http_method: Any, expected_status_code: An
     class MyController(Controller):
         path = test_path
 
-        @decorator()  # type: ignore[misc]
+        @decorator()
         def test_method(self, first: str, second: List[str], third: Optional[int] = None) -> None:
             assert first == query_params_instance.first
             assert second == query_params_instance.second
@@ -157,7 +157,7 @@ def test_query_params(decorator: Any, http_method: Any, expected_status_code: An
         assert response.status_code == expected_status_code
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (get, HttpMethod.GET, HTTP_200_OK),
@@ -180,7 +180,7 @@ def test_header_params(decorator: Any, http_method: Any, expected_status_code: A
     class MyController(Controller):
         path = test_path
 
-        @decorator()  # type: ignore[misc]
+        @decorator()
         def test_method(self, headers: dict) -> None:
             for key, value in request_headers.items():
                 assert headers[key] == value
@@ -190,7 +190,7 @@ def test_header_params(decorator: Any, http_method: Any, expected_status_code: A
         assert response.status_code == expected_status_code
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (get, HttpMethod.GET, HTTP_200_OK),
@@ -206,7 +206,7 @@ def test_request(decorator: Any, http_method: Any, expected_status_code: Any) ->
     class MyController(Controller):
         path = test_path
 
-        @decorator()  # type: ignore[misc]
+        @decorator()
         def test_method(self, request: Request) -> None:
             assert isinstance(request, Request)
 

--- a/tests/kwargs/test_validations.py
+++ b/tests/kwargs/test_validations.py
@@ -57,7 +57,7 @@ def handler_with_dependency_and_aliased_cookie_parameter_collision(my_key: str =
     ...
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "handler",
     [
         handler_with_path_param_and_aliased_query_parameter_collision,
@@ -74,7 +74,7 @@ def test_raises_exception_when_keys_are_ambiguous(handler: HTTPRouteHandler) -> 
         Starlite(route_handlers=[handler])
 
 
-@pytest.mark.parametrize("reserved_kwarg", RESERVED_KWARGS)  # type: ignore[misc]
+@pytest.mark.parametrize("reserved_kwarg", RESERVED_KWARGS)
 def test_raises_when_reserved_kwargs_are_misused(reserved_kwarg: str) -> None:
     decorator = post if reserved_kwarg != "socket" else websocket
 
@@ -136,12 +136,12 @@ def accepted_multi_part_handler(
     assert first
 
 
-@pytest.mark.parametrize("handler", [accepted_json_handler, accepted_url_encoded_handler, accepted_multi_part_handler])  # type: ignore[misc]
+@pytest.mark.parametrize("handler", [accepted_json_handler, accepted_url_encoded_handler, accepted_multi_part_handler])
 def test_dependency_data_kwarg_validation_success_scenarios(handler: HTTPRouteHandler) -> None:
     Starlite(route_handlers=[handler])
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "body, dependency",
     [
         [Body(media_type=RequestEncodingType.JSON), url_encoded_dependency],

--- a/tests/openapi/test_constrained_fields.py
+++ b/tests/openapi/test_constrained_fields.py
@@ -19,7 +19,7 @@ from tests.openapi.utils import (
 )
 
 
-@given(  # type: ignore[misc]
+@given(
     field_type=st.sampled_from(constrained_collection),
 )
 def test_create_collection_constrained_field_schema(field_type: Any) -> None:
@@ -51,7 +51,7 @@ def test_create_collection_constrained_field_schema_sub_fields() -> None:
         assert schema.dict(exclude_none=True) == expected
 
 
-@given(field_type=st.sampled_from(constrained_string))  # type: ignore[misc]
+@given(field_type=st.sampled_from(constrained_string))
 def test_create_string_constrained_field_schema(field_type: Any) -> None:
     schema = create_string_constrained_field_schema(field_type=field_type)
     assert schema.type == OpenAPIType.STRING
@@ -63,7 +63,7 @@ def test_create_string_constrained_field_schema(field_type: Any) -> None:
         assert schema.description
 
 
-@given(field_type=st.sampled_from(constrained_numbers))  # type: ignore[misc]
+@given(field_type=st.sampled_from(constrained_numbers))
 def test_create_numerical_constrained_field_schema(field_type: Any) -> None:
     schema = create_numerical_constrained_field_schema(field_type=field_type)
     assert schema.type == OpenAPIType.INTEGER if issubclass(field_type, int) else OpenAPIType.NUMBER
@@ -75,7 +75,7 @@ def test_create_numerical_constrained_field_schema(field_type: Any) -> None:
     assert schema.multipleOf == field_type.multiple_of
 
 
-@given(field_type=st.sampled_from([*constrained_numbers, *constrained_collection, *constrained_string]))  # type: ignore[misc]
+@given(field_type=st.sampled_from([*constrained_numbers, *constrained_collection, *constrained_string]))
 def test_create_constrained_field_schema(field_type: Any) -> None:
     schema = create_constrained_field_schema(field_type=field_type, sub_fields=None)
     assert schema

--- a/tests/plugins/sql_alchemy_plugin/__init__.py
+++ b/tests/plugins/sql_alchemy_plugin/__init__.py
@@ -9,20 +9,20 @@ class SQLAlchemyBase:
     id: Column
 
     # Generate the table name from the class name
-    @declared_attr  # type: ignore[misc]
+    @declared_attr
     def __tablename__(cls) -> str:
-        return cls.__name__.lower()  # type: ignore
+        return cls.__name__.lower()  # type:ignore[no-any-return,attr-defined]
 
 
 association_table = Table(
     "association",
-    SQLAlchemyBase.metadata,  # type: ignore
+    SQLAlchemyBase.metadata,  # type:ignore[attr-defined]
     Column("pet_id", ForeignKey("pet.id")),
     Column("user_id", ForeignKey("user.id")),
 )
 friendship_table = Table(
     "friendships",
-    SQLAlchemyBase.metadata,  # type: ignore
+    SQLAlchemyBase.metadata,  # type:ignore[attr-defined]
     Column("friend_a_id", Integer, ForeignKey("user.id"), primary_key=True),
     Column("friend_b_id", Integer, ForeignKey("user.id"), primary_key=True),
 )
@@ -34,7 +34,7 @@ class Pet(SQLAlchemyBase):
     name = Column(String)
     age = Column(Float)
     owner_id = Column(Integer, ForeignKey("user.id"))
-    owner = relationship("User", back_populates="pets")
+    owner = relationship("User", back_populates="pets", uselist=False)
 
 
 class Company(SQLAlchemyBase):
@@ -46,15 +46,13 @@ class Company(SQLAlchemyBase):
 class User(SQLAlchemyBase):
     id = Column(Integer, primary_key=True)
     name = Column(String, default="moishe")
-    pets = relationship(
-        "Pet",
-        back_populates="owner",
-    )
+    pets = relationship("Pet", back_populates="owner", uselist=True)
     friends = relationship(
         "User",
         secondary=friendship_table,
         primaryjoin=id == friendship_table.c.friend_a_id,
         secondaryjoin=id == friendship_table.c.friend_b_id,
+        uselist=True,
     )
     company_id = Column(Integer, ForeignKey("company.id"))
     company = relationship("Company")

--- a/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_plugin_integration.py
+++ b/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_plugin_integration.py
@@ -11,7 +11,7 @@ from starlite.plugins.sql_alchemy import SQLAlchemyPlugin
 from tests.plugins.sql_alchemy_plugin import Company
 
 companies = [
-    Company(id=i, name=create_random_string(min_length=5, max_length=20), worth=create_random_float(minimum=1))  # type: ignore
+    Company(id=i, name=create_random_string(min_length=5, max_length=20), worth=create_random_float(minimum=1))  # type: ignore[call-arg]
     for i in range(3)
 ]
 

--- a/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_table_types.py
+++ b/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_table_types.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 import sqlalchemy
 from pydantic import BaseModel
@@ -42,7 +44,6 @@ from sqlalchemy import (
     Table,
     Text,
     Time,
-    TupleType,
     Unicode,
     UnicodeText,
 )
@@ -57,6 +58,9 @@ from sqlalchemy.dialects import (
 )
 from sqlalchemy.orm import registry
 from sqlalchemy.sql.functions import now
+
+# TupleType not a sqlalchemy2-stubs top-level import
+from sqlalchemy.sql.sqltypes import TupleType
 
 from starlite import ImproperlyConfiguredException
 from starlite.plugins.sql_alchemy import SQLAlchemyPlugin
@@ -106,7 +110,8 @@ class DeclarativeModel(SQLAlchemyBase):
     TIMESTAMP_column = Column(TIMESTAMP)
     Text_column = Column(Text)
     Time_column = Column(Time)
-    TupleType_column = Column(TupleType(str, int, bool))
+    # `TupleType[Any]` for 'Value of type variable "_TE" of "TupleType" cannot be "type"  [type-var]'
+    TupleType_column = Column(TupleType[Any](str, int, bool))
     Unicode_column = Column(Unicode)
     UnicodeText_column = Column(UnicodeText)
     VARBINARY_column = Column(VARBINARY)
@@ -175,27 +180,27 @@ class DeclarativeModel(SQLAlchemyBase):
     oracle_VARCHAR_column = Column(oracle.VARCHAR)
     # postgresql
     postgresql_ARRAY_column = Column(postgresql.ARRAY(String, dimensions=2))
-    postgresql_BIT_column = Column(postgresql.BIT)
+    postgresql_BIT_column: bytes = Column(postgresql.BIT)
     postgresql_BYTEA_column = Column(postgresql.BYTEA)
-    postgresql_CIDR_column = Column(postgresql.CIDR)
+    postgresql_CIDR_column: str = Column(postgresql.CIDR)
     postgresql_DATERANGE_column = Column(postgresql.DATERANGE)
     postgresql_DOUBLE_PRECISION_column = Column(postgresql.DOUBLE_PRECISION)
     postgresql_ENUM_column = Column(postgresql.ENUM(Species))
     postgresql_HSTORE_column = Column(postgresql.HSTORE)
-    postgresql_INET_column = Column(postgresql.INET)
+    postgresql_INET_column: str = Column(postgresql.INET)
     postgresql_INT4RANGE_column = Column(postgresql.INT4RANGE)
     postgresql_INT8RANGE_column = Column(postgresql.INT8RANGE)
     postgresql_INTERVAL_column = Column(postgresql.INTERVAL)
     postgresql_JSON_column = Column(postgresql.JSON)
     postgresql_JSONB_column = Column(postgresql.JSONB)
-    postgresql_MACADDR_column = Column(postgresql.MACADDR)
-    postgresql_MONEY_column = Column(postgresql.MONEY)
+    postgresql_MACADDR_column: str = Column(postgresql.MACADDR)
+    postgresql_MONEY_column: str = Column(postgresql.MONEY)
     postgresql_NUMRANGE_column = Column(postgresql.NUMRANGE)
     postgresql_TIME_column = Column(postgresql.TIME)
     postgresql_TIMESTAMP_column = Column(postgresql.TIMESTAMP)
     postgresql_TSRANGE_column = Column(postgresql.TSRANGE)
     postgresql_TSTZRANGE_column = Column(postgresql.TSTZRANGE)
-    postgresql_UUID_column = Column(postgresql.UUID)
+    postgresql_UUID_column: postgresql.UUID = Column(postgresql.UUID)
     # sqlite
     sqlite_DATE_column = Column(sqlite.DATE)
     sqlite_DATETIME_column = Column(sqlite.DATETIME)
@@ -236,7 +241,7 @@ def test_sql_alchemy_plugin_validation() -> None:
 
 
 def test_provider_validation() -> None:
-    class MyStrColumn(sqlalchemy.String):  # type: ignore
+    class MyStrColumn(sqlalchemy.String):  # type:ignore[misc]
         pass
 
     class ModelWithCustomColumn(SQLAlchemyBase):

--- a/tests/response/test_serialization.py
+++ b/tests/response/test_serialization.py
@@ -8,7 +8,7 @@ from starlite import MediaType, Response
 from tests import PersonFactory, PydanticDataClassPerson, VanillaDataClassPerson
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "content, media_type",
     [
         [PersonFactory.build(), MediaType.JSON],

--- a/tests/route/test_validations.py
+++ b/tests/route/test_validations.py
@@ -15,7 +15,7 @@ def my_post_handler() -> None:
     pass
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_http_route_raises_for_unsupported_method() -> None:
     route = HTTPRoute(path="/", route_handlers=[my_get_handler, my_post_handler])
 

--- a/tests/test_connection_lifecycle_hooks.py
+++ b/tests/test_connection_lifecycle_hooks.py
@@ -50,7 +50,7 @@ async def async_after_request_handler(response: Response) -> Response:
     return response
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "handler, expected",
     [
         [get(path="/")(greet), {"hello": "world"}],
@@ -66,7 +66,7 @@ def test_before_request_handler_called(handler: HTTPRouteHandler, expected: dict
         assert response.json() == expected
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "handler, expected",
     [
         [get(path="/")(greet), {"hello": "world"}],
@@ -80,7 +80,7 @@ def test_after_request_handler_called(handler: HTTPRouteHandler, expected: dict)
         assert response.json() == expected
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "app_before_request_handler, router_before_request_handler, controller_before_request_handler, method_before_request_handler, expected",
     [
         [None, None, None, None, {"hello": "world"}],
@@ -141,7 +141,7 @@ async def async_after_request_handler_with_hello_world(response: Response) -> Re
     return response
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "app_after_request_handler, router_after_request_handler, controller_after_request_handler, method_after_request_handler, expected",
     [
         [None, None, None, None, {"hello": "world"}],

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -18,7 +18,7 @@ from starlite.connection import WebSocket
 from tests import Person, PersonFactory
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, http_method, expected_status_code",
     [
         (get, HttpMethod.GET, HTTP_200_OK),

--- a/tests/test_dto_factory.py
+++ b/tests/test_dto_factory.py
@@ -21,7 +21,7 @@ from tests import Species, VanillaDataClassPerson
 from tests.plugins.sql_alchemy_plugin import Pet, User
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "model, exclude, field_mapping, field_definitions, plugins",
     [
         [Person, ["id"], {"complex": "ultra"}, {"special": (str, ...)}, []],
@@ -68,7 +68,7 @@ def test_dto_factory_validation() -> None:
         DTOFactory(plugins=[])("MyDTO", MyClass)
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "model, exclude, field_mapping, plugins",
     [
         [Person, ["id"], {"complex": "ultra"}, []],
@@ -124,7 +124,7 @@ def test_dto_openapi_generation() -> None:
     assert app.openapi_schema
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "model, exclude, field_mapping, plugins",
     [
         [Person, [], {"complex": "ultra"}, []],
@@ -150,8 +150,8 @@ def test_conversion_to_model_instance(model: Any, exclude: list, field_mapping: 
             assert model_instance.__getattribute__(original_key) == dto_instance.__getattribute__(key)  # type: ignore
 
 
-@pytest.mark.skipif(sys.version_info < (3, 9), reason="dataclasses behave differently in lower versions")  # type: ignore
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.skipif(sys.version_info < (3, 9), reason="dataclasses behave differently in lower versions")
+@pytest.mark.parametrize(
     "model, exclude, field_mapping, plugins",
     [
         [Person, ["id"], {"complex": "ultra"}, []],
@@ -174,7 +174,7 @@ def test_conversion_from_model_instance(
             pets=None,
         )
     else:
-        model_instance = cast(Type[Pet], model)(  # type: ignore
+        model_instance = cast(Type[Pet], model)(  # type: ignore[call-arg]
             id=1,
             species=Species.MONKEY,
             name="Mike",

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -13,7 +13,7 @@ from starlite.exceptions import (
 )
 
 
-@given(detail=st.one_of(st.none(), st.text()))  # type: ignore[misc]
+@given(detail=st.one_of(st.none(), st.text()))
 def test_starlite_exception(detail: Optional[str]) -> None:
     result = StarLiteException(detail=detail)  # type: ignore
     assert result.detail == detail
@@ -23,7 +23,7 @@ def test_starlite_exception(detail: Optional[str]) -> None:
         assert result.__repr__() == result.__class__.__name__
 
 
-@given(status_code=st.integers(min_value=400, max_value=404), detail=st.one_of(st.none(), st.text()))  # type: ignore[misc]
+@given(status_code=st.integers(min_value=400, max_value=404), detail=st.one_of(st.none(), st.text()))
 def test_http_exception(status_code: int, detail: Optional[str]) -> None:
     assert HTTPException().status_code == HTTP_500_INTERNAL_SERVER_ERROR
     result = HTTPException(status_code=status_code, detail=detail)
@@ -32,7 +32,7 @@ def test_http_exception(status_code: int, detail: Optional[str]) -> None:
     assert result.__repr__() == f"{result.status_code} - {result.__class__.__name__} - {result.detail}"
 
 
-@given(detail=st.one_of(st.none(), st.text()))  # type: ignore[misc]
+@given(detail=st.one_of(st.none(), st.text()))
 def test_improperly_configured_exception(detail: Optional[str]) -> None:
     result = ImproperlyConfiguredException(detail=detail)
     assert result.__repr__() == f"{HTTP_500_INTERNAL_SERVER_ERROR} - {result.__class__.__name__} - {result.detail}"

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -26,7 +26,7 @@ def root_delete_handler() -> None:
     return None
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "request_path, router_path",
     [
         [f"/path/1/2/sub/{str(uuid4())}", "/path/{first:int}/{second:str}/sub/{third:uuid}"],
@@ -67,7 +67,7 @@ def test_path_parsing_with_ambiguous_paths() -> None:
         assert response.status_code == HTTP_200_OK
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "decorator, test_path, decorator_path, delete_handler",
     [
         (get, "", "/something", None),
@@ -126,7 +126,7 @@ def test_handler_multi_paths() -> None:
         assert fourth_response.text == "2"
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "handler_path, request_path, expected_status_code",
     [
         ("/sub-path", "/", HTTP_404_NOT_FOUND),

--- a/tests/test_provide.py
+++ b/tests/test_provide.py
@@ -10,14 +10,14 @@ def test_fn() -> dict:
     return dict()
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_provide_default() -> None:
     provider = Provide(dependency=test_fn)
     value = await provider()
     assert isinstance(value, dict)
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_provide_cached() -> None:
     provider = Provide(dependency=test_fn, use_cache=True)
     assert provider.value is Undefined
@@ -30,7 +30,7 @@ async def test_provide_cached() -> None:
     assert value == third_value
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_run_in_thread() -> None:
     provider = Provide(dependency=test_fn, sync_to_thread=True)
     value = await provider()

--- a/tests/test_response_class.py
+++ b/tests/test_response_class.py
@@ -23,7 +23,7 @@ class MyController(Controller):
         pass
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "layer, expected",
     [[0, local_response], [1, controller_response], [2, router_response], [3, app_response], [None, Response]],
 )

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -15,8 +15,8 @@ from starlite import (
 from tests import Person
 
 
-@settings(suppress_health_check=HealthCheck.all())  # type: ignore[misc]
-@given(  # type: ignore[misc]
+@settings(suppress_health_check=HealthCheck.all())
+@given(
     http_method=st.sampled_from(HttpMethod),
     scheme=st.text(),
     server=st.text(),

--- a/tests/utils/test_url.py
+++ b/tests/utils/test_url.py
@@ -3,7 +3,7 @@ import pytest
 from starlite.utils.url import join_paths, normalize_path
 
 
-@pytest.mark.parametrize(  # type: ignore[misc]
+@pytest.mark.parametrize(
     "base,fragment, expected",
     [
         ("/path/", "sub", "/path/sub"),
@@ -18,6 +18,6 @@ def test_join_url_fragments(base: str, fragment: str, expected: str) -> None:
     assert join_paths([base, fragment]) == expected
 
 
-@pytest.mark.parametrize("base,expected", [("/path", "/path"), ("path/", "/path"), ("path", "/path")])  # type: ignore[misc]
+@pytest.mark.parametrize("base,expected", [("/path", "/path"), ("path/", "/path"), ("path", "/path")])
 def test_normalize_path(base: str, expected: str) -> None:
     assert normalize_path(base) == expected


### PR DESCRIPTION
Allows to remove many `# type:ignore...`s.