### PR TITLE
Add pydantic-factories testing examples

### DIFF
--- a/docs/usage/14-testing.md
+++ b/docs/usage/14-testing.md
@@ -214,7 +214,6 @@ def test_get_item(item: Item):
         assert response.json() == item.dict()
 ```
 
-That's better! Now we don't have to think about this not important thing.
 
 ## Creating a Test Request
 

--- a/docs/usage/14-testing.md
+++ b/docs/usage/14-testing.md
@@ -141,7 +141,7 @@ def get_item(service: Service) -> Item:
     return service.get()
 ```
 
-Then we can add a test for `/item` route:
+We could test the `/item` route like so:
 
 ```python title="main.py"
 @pytest.fixture

--- a/docs/usage/14-testing.md
+++ b/docs/usage/14-testing.md
@@ -115,7 +115,7 @@ def test_health_check():
 
 Starlite bundles the library [pydantic-factories](https://github.com/Goldziher/pydantic-factories), which offers an easy and powerful way to generate mock data from pydantic models and dataclasses.
 
-Let's say we have an API that talks to external service (that we don't care about in unit tests) and retrieves some item:
+Let's say we have an API that talks to an external service and retrieves some data:
 
 ```python title="main.py"
 from typing import Protocol, runtime_checkable

--- a/docs/usage/14-testing.md
+++ b/docs/usage/14-testing.md
@@ -163,7 +163,7 @@ def test_get_item(item: Item):
         assert response.json() == item.dict()
 ```
 
-As you can see, we came up with a test product by ourselves. It is fine for small applications, but can be quite a pain in larger ones. That's where [pydantic-factories](https://github.com/Goldziher/pydantic-factories) library comes in. It generates mock data for pydantic datastructures based on type annotations. Let's rewrite our example using it:
+While we can define the test data manually, as is done in the above, this can be quite cumbersome. That's where [pydantic-factories](https://github.com/Goldziher/pydantic-factories) library comes in. It generates mock data for pydantic models and dataclasses based on type annotations. With it, we could rewrite the above example like so:
 
 ```python title="main.py"
 from typing import Protocol, runtime_checkable


### PR DESCRIPTION
In this PR I added mini-tutorial for using pydantic-factories in tests.
Also corrected markup and made subtitles on Testing page more consistent.
Fixes #143