### PR TITLE
Empty response content for 204 status and `None` handler return value

### DIFF
--- a/starlite/response.py
+++ b/starlite/response.py
@@ -6,6 +6,7 @@ from orjson import OPT_INDENT_2, OPT_OMIT_MICROSECONDS, OPT_SERIALIZE_NUMPY, dum
 from pydantic import BaseModel
 from starlette.background import BackgroundTask
 from starlette.responses import Response as StarletteResponse
+from starlette.status import HTTP_204_NO_CONTENT
 
 from starlite.enums import MediaType, OpenAPIMediaType
 from starlite.exceptions import ImproperlyConfiguredException
@@ -42,6 +43,9 @@ class Response(StarletteResponse):
 
     def render(self, content: Any) -> bytes:
         """Renders content into bytes"""
+        if self.status_code == HTTP_204_NO_CONTENT and content is None:
+            return b""
+
         try:
             if self.media_type == MediaType.JSON:
                 return dumps(content, default=self.serializer, option=OPT_SERIALIZE_NUMPY | OPT_OMIT_MICROSECONDS)

--- a/tests/handlers/http/test_delete.py
+++ b/tests/handlers/http/test_delete.py
@@ -1,0 +1,15 @@
+import pytest
+
+from starlite import delete
+from starlite.testing import create_test_client
+
+
+@pytest.mark.xfail
+def test_none_response() -> None:
+    @delete(path="/")
+    async def route() -> None:
+        return None
+
+    with create_test_client(route_handlers=[route]) as client:
+        response = client.delete("/")
+        assert not response.content

--- a/tests/handlers/http/test_delete.py
+++ b/tests/handlers/http/test_delete.py
@@ -1,10 +1,7 @@
-import pytest
-
 from starlite import delete
 from starlite.testing import create_test_client
 
 
-@pytest.mark.xfail
 def test_none_response() -> None:
     @delete(path="/")
     async def route() -> None:

--- a/tests/handlers/http/test_delete.py
+++ b/tests/handlers/http/test_delete.py
@@ -2,7 +2,7 @@ from starlite import delete
 from starlite.testing import create_test_client
 
 
-def test_none_response() -> None:
+def test_handler_return_none_and_204_status_response_empty() -> None:
     @delete(path="/")
     async def route() -> None:
         return None


### PR DESCRIPTION
Where a handler returns `None` and the status is 204 we assume the response content should be empty, `b''` rather than JSON `null`.