### PR TITLE
Issue 159 exception handlers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
       - id: blacken-docs
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v2.7.0"
+    rev: "v2.7.1"
     hooks:
       - id: prettier
   - repo: https://github.com/pycqa/bandit
@@ -68,7 +68,7 @@ repos:
             mako,
           ]
   - repo: https://github.com/pycqa/pylint
-    rev: "v2.14.1"
+    rev: "v2.14.3"
     hooks:
       - id: pylint
         exclude: "test_*"

--- a/docs/usage/1-routers-and-controllers.md
+++ b/docs/usage/1-routers-and-controllers.md
@@ -62,6 +62,8 @@ Aside from the `path` class variable, you can also set the following optional cl
 - `after_request`: a sync or async function to execute before the `Response` is returned. This function receives the
   `Respose` object and it must return a `Response` object.
 - `tags`: a list of `str`, which correlate to the [tag specification](https://spec.openapis.org/oas/latest.html#tag-object).
+- `exception_handlers`: A dictionary mapping exceptions or exception codes to handler functions.
+  See [exception-handlers](0-the-starlite-app#exception-handling).
 
 ## Routers
 
@@ -93,6 +95,8 @@ Aside from `path` and `route_handlers` which are required kwargs, you can also p
 - `after_request`: a sync or async function to execute before the `Response` is returned. This function receives the
   `Respose` object and it must return a `Response` object.
 - `tags`: a list of `str`, which correlate to the [tag specification](https://spec.openapis.org/oas/latest.html#tag-object).
+- `exception_handlers`: A dictionary mapping exceptions or exception codes to handler functions.
+  See [exception-handlers](0-the-starlite-app#exception-handling).
 
 ## Registering Routes
 

--- a/docs/usage/2-route-handlers/1_http_route_handlers.md
+++ b/docs/usage/2-route-handlers/1_http_route_handlers.md
@@ -53,6 +53,8 @@ Additionally, you can pass the following optional kwargs:
 - `sync_to_thread`: A boolean dictating whether the handler function will be executed in a worker thread or the main
   event loop. This has an effect only for sync handler functions.
   See [using sync handler functions](#using-sync-handler-functions).
+- `exception_handlers`: A dictionary mapping exceptions or exception codes to handler functions.
+  See [exception-handlers](../0-the-starlite-app#exception-handling).
 
 And the following kwargs, which affect [OpenAPI schema generation](../12-openapi.md#route-handler-configuration)
 
@@ -142,7 +144,7 @@ performant solution within the scope of an ASGI application, including Starlite,
 solution for this purpose.
 
 The reason for this is that async code, if written correctly, is **non-blocking**. That is, async code can be paused and
-resumed, and it therefore does not interupt the main event loop from executing (if written correctly). On the other
+resumed, and it therefore does not interrupt the main event loop from executing (if written correctly). On the other
 hand, sync I/O handling is often **blocking**, and if you use such code in your function it can create performance
 issues.
 

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -48,6 +48,7 @@ from starlite.types import (
     ResponseHeader,
 )
 from starlite.utils import normalize_path
+from starlite.utils.exception import get_exception_handler
 
 DEFAULT_OPENAPI_CONFIG = OpenAPIConfig(title="Starlite API", version="1.0.0")
 DEFAULT_CACHE_CONFIG = CacheConfig()
@@ -156,9 +157,7 @@ class Starlite(Router):
         status_code = exc.status_code if isinstance(exc, StarletteHTTPException) else HTTP_500_INTERNAL_SERVER_ERROR
         if scope["type"] == "http":
             exception_handler = (
-                self.exception_handlers.get(status_code)
-                or self.exception_handlers.get(exc.__class__)
-                or self.default_http_exception_handler
+                get_exception_handler(self.exception_handlers, exc) or self.default_http_exception_handler
             )
             response = exception_handler(Request(scope=scope, receive=receive, send=send), exc)
             await response(scope=scope, receive=receive, send=send)

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -57,7 +57,6 @@ class Starlite(Router):
     __slots__ = (
         "asgi_router",
         "debug",
-        "exception_handlers",
         "middleware_stack",
         "openapi_schema",
         "plugins",

--- a/starlite/controller.py
+++ b/starlite/controller.py
@@ -1,5 +1,5 @@
 from copy import copy
-from typing import TYPE_CHECKING, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
 
 from typing_extensions import Type
 
@@ -8,6 +8,7 @@ from starlite.response import Response
 from starlite.types import (
     AfterRequestHandler,
     BeforeRequestHandler,
+    ExceptionHandler,
     Guard,
     ResponseHeader,
 )
@@ -33,6 +34,7 @@ class Controller:
         "guards",
         "before_request",
         "after_request",
+        "exception_handlers",
     )
 
     dependencies: Optional[Dict[str, "Provide"]]
@@ -42,6 +44,7 @@ class Controller:
     response_headers: Optional[Dict[str, ResponseHeader]]
     response_class: Optional[Type[Response]]
     guards: Optional[List[Guard]]
+    exception_handlers: Optional[Dict[Union[int, Type[Exception]], ExceptionHandler]]
     # connection-lifecycle hook handlers
     before_request: Optional[BeforeRequestHandler]
     after_request: Optional[AfterRequestHandler]
@@ -54,6 +57,7 @@ class Controller:
             "guards",
             "before_request",
             "after_request",
+            "exception_handlers",
         ]:
             if not hasattr(self, key):
                 setattr(self, key, None)

--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -100,6 +100,9 @@ class HTTPRouteHandler(BaseRouteHandler):
         status_code: Optional[int] = None,
         cache: Union[bool, int] = False,
         cache_key_builder: Optional[CacheKeyBuilder] = None,
+        exception_handlers: Optional[Dict[Union[int, Type[Exception]], ExceptionHandler]] = None,
+        # sync only
+        sync_to_thread: bool = False,
         # OpenAPI related attributes
         content_encoding: Optional[str] = None,
         content_media_type: Optional[str] = None,
@@ -111,9 +114,6 @@ class HTTPRouteHandler(BaseRouteHandler):
         response_description: Optional[str] = None,
         summary: Optional[str] = None,
         tags: Optional[List[str]] = None,
-        # sync only
-        sync_to_thread: bool = False,
-        exception_handlers: Optional[Dict[Union[int, Type[Exception]], ExceptionHandler]] = None,
     ):
         if not http_method:
             raise ImproperlyConfiguredException("An http_method kwarg is required")
@@ -376,6 +376,9 @@ class get(HTTPRouteHandler):
         status_code: Optional[int] = None,
         cache: Union[bool, int] = False,
         cache_key_builder: Optional[CacheKeyBuilder] = None,
+        exception_handlers: Optional[Dict[Union[int, Type[Exception]], ExceptionHandler]] = None,
+        # sync only
+        sync_to_thread: bool = False,
         # OpenAPI related attributes
         content_encoding: Optional[str] = None,
         content_media_type: Optional[str] = None,
@@ -387,8 +390,6 @@ class get(HTTPRouteHandler):
         response_description: Optional[str] = None,
         summary: Optional[str] = None,
         tags: Optional[List[str]] = None,
-        # sync only
-        sync_to_thread: bool = False,
     ):
         super().__init__(
             http_method=HttpMethod.GET,
@@ -415,6 +416,7 @@ class get(HTTPRouteHandler):
             summary=summary,
             tags=tags,
             sync_to_thread=sync_to_thread,
+            exception_handlers=exception_handlers,
         )
 
 
@@ -434,6 +436,9 @@ class post(HTTPRouteHandler):
         status_code: Optional[int] = None,
         cache: Union[bool, int] = False,
         cache_key_builder: Optional[CacheKeyBuilder] = None,
+        exception_handlers: Optional[Dict[Union[int, Type[Exception]], ExceptionHandler]] = None,
+        # sync only
+        sync_to_thread: bool = False,
         # OpenAPI related attributes
         content_encoding: Optional[str] = None,
         content_media_type: Optional[str] = None,
@@ -445,8 +450,6 @@ class post(HTTPRouteHandler):
         response_description: Optional[str] = None,
         summary: Optional[str] = None,
         tags: Optional[List[str]] = None,
-        # sync only
-        sync_to_thread: bool = False,
     ):
         super().__init__(
             http_method=HttpMethod.POST,
@@ -473,6 +476,7 @@ class post(HTTPRouteHandler):
             summary=summary,
             tags=tags,
             sync_to_thread=sync_to_thread,
+            exception_handlers=exception_handlers,
         )
 
 
@@ -492,6 +496,9 @@ class put(HTTPRouteHandler):
         status_code: Optional[int] = None,
         cache: Union[bool, int] = False,
         cache_key_builder: Optional[CacheKeyBuilder] = None,
+        exception_handlers: Optional[Dict[Union[int, Type[Exception]], ExceptionHandler]] = None,
+        # sync only
+        sync_to_thread: bool = False,
         # OpenAPI related attributes
         content_encoding: Optional[str] = None,
         content_media_type: Optional[str] = None,
@@ -503,8 +510,6 @@ class put(HTTPRouteHandler):
         response_description: Optional[str] = None,
         summary: Optional[str] = None,
         tags: Optional[List[str]] = None,
-        # sync only
-        sync_to_thread: bool = False,
     ):
         super().__init__(
             http_method=HttpMethod.PUT,
@@ -531,6 +536,7 @@ class put(HTTPRouteHandler):
             summary=summary,
             tags=tags,
             sync_to_thread=sync_to_thread,
+            exception_handlers=exception_handlers,
         )
 
 
@@ -550,6 +556,9 @@ class patch(HTTPRouteHandler):
         status_code: Optional[int] = None,
         cache: Union[bool, int] = False,
         cache_key_builder: Optional[CacheKeyBuilder] = None,
+        exception_handlers: Optional[Dict[Union[int, Type[Exception]], ExceptionHandler]] = None,
+        # sync only
+        sync_to_thread: bool = False,
         # OpenAPI related attributes
         content_encoding: Optional[str] = None,
         content_media_type: Optional[str] = None,
@@ -561,8 +570,6 @@ class patch(HTTPRouteHandler):
         response_description: Optional[str] = None,
         summary: Optional[str] = None,
         tags: Optional[List[str]] = None,
-        # sync only
-        sync_to_thread: bool = False,
     ):
         super().__init__(
             http_method=HttpMethod.PATCH,
@@ -589,6 +596,7 @@ class patch(HTTPRouteHandler):
             summary=summary,
             tags=tags,
             sync_to_thread=sync_to_thread,
+            exception_handlers=exception_handlers,
         )
 
 
@@ -608,6 +616,9 @@ class delete(HTTPRouteHandler):
         status_code: Optional[int] = None,
         cache: Union[bool, int] = False,
         cache_key_builder: Optional[CacheKeyBuilder] = None,
+        exception_handlers: Optional[Dict[Union[int, Type[Exception]], ExceptionHandler]] = None,
+        # sync only
+        sync_to_thread: bool = False,
         # OpenAPI related attributes
         content_encoding: Optional[str] = None,
         content_media_type: Optional[str] = None,
@@ -619,8 +630,6 @@ class delete(HTTPRouteHandler):
         response_description: Optional[str] = None,
         summary: Optional[str] = None,
         tags: Optional[List[str]] = None,
-        # sync only
-        sync_to_thread: bool = False,
     ):
         super().__init__(
             http_method=HttpMethod.DELETE,
@@ -647,4 +656,5 @@ class delete(HTTPRouteHandler):
             summary=summary,
             tags=tags,
             sync_to_thread=sync_to_thread,
+            exception_handlers=exception_handlers,
         )

--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -208,10 +208,8 @@ class HTTPRouteHandler(BaseRouteHandler):
         """
         if self.resolved_headers is BaseRouteHandler.empty:
             headers: Dict[str, ResponseHeader] = {}
-            for layer in self.ownership_layers():
-                for key, value in (layer.response_headers or {}).items():
-                    if key not in headers:
-                        headers[key] = value
+            for layer in reversed(list(self.ownership_layers())):
+                headers = {**headers, **(layer.response_headers or {})}
             self.resolved_headers = headers
         return cast(Dict[str, ResponseHeader], self.resolved_headers)
 
@@ -261,11 +259,8 @@ class HTTPRouteHandler(BaseRouteHandler):
         """
         if self.resolved_exception_handlers is BaseRouteHandler.empty:
             exception_handlers: Dict[Union[int, Type[Exception]], ExceptionHandler] = {}
-            for layer in self.ownership_layers():
-                if layer.exception_handlers:
-                    for key, value in (layer.exception_handlers or {}).items():
-                        if key not in exception_handlers:
-                            exception_handlers[key] = value
+            for layer in reversed(list(self.ownership_layers())):
+                exception_handlers = {**exception_handlers, **(layer.exception_handlers or {})}
             self.resolved_exception_handlers = exception_handlers
         return cast(Dict[Union[int, Type[Exception]], ExceptionHandler], self.resolved_exception_handlers)
 

--- a/starlite/openapi/utils.py
+++ b/starlite/openapi/utils.py
@@ -8,7 +8,7 @@ from starlite.handlers.http import HTTPRouteHandler
 from starlite.openapi.constants import PYDANTIC_FIELD_SHAPE_MAP
 from starlite.openapi.enums import OpenAPIType
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Union
 
     from starlite import Controller, Router, Starlite

--- a/starlite/router.py
+++ b/starlite/router.py
@@ -19,6 +19,7 @@ from starlite.types import (
     AfterRequestHandler,
     BeforeRequestHandler,
     ControllerRouterHandler,
+    ExceptionHandler,
     Guard,
     ResponseHeader,
 )
@@ -37,6 +38,7 @@ class Router:
         "response_class",
         "response_headers",
         "routes",
+        "exception_handlers",
     )
 
     @validate_arguments(config={"arbitrary_types_allowed": True})
@@ -50,6 +52,7 @@ class Router:
         guards: Optional[List[Guard]] = None,
         response_class: Optional[Type[Response]] = None,
         response_headers: Optional[Dict[str, ResponseHeader]] = None,
+        exception_handlers: Optional[Dict[Union[int, Type[Exception]], ExceptionHandler]] = None,
         # connection-lifecycle hook handlers
         before_request: Optional[BeforeRequestHandler] = None,
         after_request: Optional[AfterRequestHandler] = None,
@@ -64,6 +67,7 @@ class Router:
         self.guards = guards
         self.before_request = before_request
         self.after_request = after_request
+        self.exception_handlers = exception_handlers
         for route_handler in route_handlers or []:
             self.register(value=route_handler)
 

--- a/starlite/utils/exception.py
+++ b/starlite/utils/exception.py
@@ -1,0 +1,30 @@
+from inspect import isclass
+from typing import Dict, Optional, Type, Union
+
+from starlette.exceptions import HTTPException
+from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
+
+from starlite.types import ExceptionHandler
+
+
+def get_exception_handler(
+    exception_handlers: Dict[Union[int, Type[Exception]], ExceptionHandler], exc: Exception
+) -> Optional[ExceptionHandler]:
+    """
+    Given a dictionary that maps exceptions and status codes to handler functions,
+    and an exception, returns the appropriate handler if existing.
+    """
+    if not exception_handlers:
+        return None
+    if isinstance(exc, HTTPException) and exc.status_code in exception_handlers:
+        return exception_handlers[exc.status_code]
+    if exc.__class__ in exception_handlers:
+        return exception_handlers[exc.__class__]
+    if HTTP_500_INTERNAL_SERVER_ERROR in exception_handlers:
+        return exception_handlers[HTTP_500_INTERNAL_SERVER_ERROR]
+    for key, value in exception_handlers.items():
+        if key is Exception:
+            return value
+        if isclass(key) and issubclass(key, Exception) and issubclass(exc.__class__, key):
+            return value
+    return None

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -1,0 +1,75 @@
+from typing import Type
+
+import pytest
+from starlette.status import HTTP_400_BAD_REQUEST
+
+from starlite import (
+    Controller,
+    InternalServerException,
+    MediaType,
+    NotFoundException,
+    Request,
+    Response,
+    Router,
+    ServiceUnavailableException,
+    ValidationException,
+    create_test_client,
+    get,
+)
+from starlite.types import ExceptionHandler
+
+
+@pytest.mark.parametrize(
+    ["exc_to_raise", "expected_layer"],
+    [
+        (ValidationException, "router"),
+        (InternalServerException, "controller"),
+        (ServiceUnavailableException, "handler"),
+        (NotFoundException, "handler"),
+    ],
+)
+def test_exception_handling(exc_to_raise: Exception, expected_layer: str) -> None:
+    caller = {"name": ""}
+
+    def create_named_handler(caller_name: str, expected_exception: Type[Exception]) -> ExceptionHandler:
+        def handler(req: Request, exc: Exception) -> Response:
+            assert isinstance(exc, expected_exception)
+            assert isinstance(req, Request)
+            caller["name"] = caller_name
+            return Response(
+                media_type=MediaType.JSON,
+                content={},
+                status_code=HTTP_400_BAD_REQUEST,
+            )
+
+        return handler
+
+    class ControllerWithHandler(Controller):
+        path = "/test"
+        exception_handlers = {
+            InternalServerException: create_named_handler("controller", InternalServerException),
+            ServiceUnavailableException: create_named_handler("controller", ServiceUnavailableException),
+        }
+
+        @get(
+            "/",
+            exception_handlers={
+                ServiceUnavailableException: create_named_handler("handler", ServiceUnavailableException),
+                NotFoundException: create_named_handler("handler", NotFoundException),
+            },
+        )
+        def my_handler(self) -> None:
+            raise exc_to_raise
+
+    my_router = Router(
+        path="/base",
+        route_handlers=[ControllerWithHandler],
+        exception_handlers={
+            InternalServerException: create_named_handler("router", InternalServerException),
+            ValidationException: create_named_handler("router", ValidationException),
+        },
+    )
+
+    with create_test_client(route_handlers=[my_router]) as client:
+        client.get("/base/test/")
+        assert caller["name"] == expected_layer

--- a/tests/utils/test_exceptions.py
+++ b/tests/utils/test_exceptions.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict, Type, Union
+
+import pytest
+from starlette.status import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
+
+from starlite import InternalServerException, ValidationException
+from starlite.types import ExceptionHandler
+from starlite.utils.exception import get_exception_handler
+
+
+def handler(_: Any, __: Any) -> Any:
+    return None
+
+
+@pytest.mark.parametrize(
+    ["mapping", "exc", "expected"],
+    [
+        ({}, Exception, None),
+        ({HTTP_400_BAD_REQUEST: handler}, ValidationException(), handler),
+        ({InternalServerException: handler}, InternalServerException(), handler),
+        ({HTTP_500_INTERNAL_SERVER_ERROR: handler}, Exception(), handler),
+        ({TypeError: handler}, TypeError(), handler),
+        ({Exception: handler}, ValidationException(), handler),
+        ({ValueError: handler}, ValidationException(), handler),
+        ({ValidationException: handler}, Exception(), None),
+    ],
+)
+def test_get_exception_handler(
+    mapping: Dict[Union[int, Type[Exception]], ExceptionHandler], exc: Exception, expected: Any
+) -> None:
+    assert get_exception_handler(mapping, exc) == expected


### PR DESCRIPTION
This PR updates exception handling by allowing users to define exception handlers on the `Router`, `Controller` or `HTTPRouteHandler` (e.g. `get`, `delete` etc.). This closes #159.

I decided to restrict this to http route handlers because both `@websocket` and `@asgi` do not fall into the same kind of category.

Please let me know what you think of the implementation.