### PR TITLE
Conform exceptions to the existing OpenAPI schema

### DIFF
--- a/starlite/app.py
+++ b/starlite/app.py
@@ -283,7 +283,7 @@ class Starlite(Router):
             server_middleware = ServerErrorMiddleware(app=self)
             return server_middleware.debug_response(request=request, exc=exc)
         if isinstance(exc, HTTPException):
-            content = {"detail": exc.detail, "extra": exc.extra}
+            content = {"detail": exc.detail, "extra": exc.extra, "status_code": exc.status_code}
         elif isinstance(exc, StarletteHTTPException):
             content = {"detail": exc.detail}
         else:

--- a/starlite/openapi/responses.py
+++ b/starlite/openapi/responses.py
@@ -125,7 +125,9 @@ def create_error_responses(exceptions: List[Type[HTTPException]]) -> Iterator[Tu
                 properties=dict(
                     status_code=Schema(type=OpenAPIType.INTEGER),
                     detail=Schema(type=OpenAPIType.STRING),
-                    extra=Schema(type=OpenAPIType.OBJECT, additionalProperties=Schema()),
+                    extra=Schema(
+                        type=[OpenAPIType.NULL, OpenAPIType.OBJECT, OpenAPIType.ARRAY], additionalProperties=Schema()
+                    ),
                 ),
                 description=pascal_case_to_text(get_name(exc)),
                 examples=[{"status_code": status_code, "detail": HTTPStatus(status_code).phrase, "extra": {}}],

--- a/tests/app/test_error_handling.py
+++ b/tests/app/test_error_handling.py
@@ -27,6 +27,7 @@ def test_default_handle_http_exception_handling() -> None:
     assert json.loads(response.body) == {
         "detail": "starlite_exception",
         "extra": {"key": "value"},
+        "status_code": 500,
     }
 
     response = Starlite(route_handlers=[]).default_http_exception_handler(

--- a/tests/app/test_error_handling.py
+++ b/tests/app/test_error_handling.py
@@ -32,6 +32,39 @@ def test_default_handle_http_exception_handling() -> None:
 
     response = Starlite(route_handlers=[]).default_http_exception_handler(
         Request(scope={"type": "http", "method": "GET"}),
+        HTTPException(detail="starlite_exception"),
+    )
+    assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
+    assert json.loads(response.body) == {
+        "detail": "starlite_exception",
+        "extra": None,
+        "status_code": 500,
+    }
+
+    response = Starlite(route_handlers=[]).default_http_exception_handler(
+        Request(scope={"type": "http", "method": "GET"}),
+        HTTPException(detail="starlite_exception", extra=None),
+    )
+    assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
+    assert json.loads(response.body) == {
+        "detail": "starlite_exception",
+        "extra": None,
+        "status_code": 500,
+    }
+
+    response = Starlite(route_handlers=[]).default_http_exception_handler(
+        Request(scope={"type": "http", "method": "GET"}),
+        HTTPException(detail="starlite_exception", extra=["extra-1", "extra-2"]),
+    )
+    assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR
+    assert json.loads(response.body) == {
+        "detail": "starlite_exception",
+        "extra": ["extra-1", "extra-2"],
+        "status_code": 500,
+    }
+
+    response = Starlite(route_handlers=[]).default_http_exception_handler(
+        Request(scope={"type": "http", "method": "GET"}),
         StarletteHTTPException(detail="starlite_exception", status_code=HTTP_500_INTERNAL_SERVER_ERROR),
     )
     assert response.status_code == HTTP_500_INTERNAL_SERVER_ERROR

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -52,7 +52,7 @@ def test_jinja_raise_for_invalid_path(tmpdir: Any) -> None:
     ) as client:
         response = client.request("GET", "/")
         assert response.status_code == 500
-        assert response.json() == {"detail": "Template invalid.html not found.", "extra": None}
+        assert response.json() == {"detail": "Template invalid.html not found.", "extra": None, "status_code": 500}
 
 
 def test_mako_template(tmpdir: Any) -> None:
@@ -101,7 +101,7 @@ def test_mako_raise_for_invalid_path(tmpdir: Any) -> None:
     ) as client:
         response = client.request("GET", "/")
         assert response.status_code == 500
-        assert response.json() == {"detail": "Template invalid.html not found.", "extra": None}
+        assert response.json() == {"detail": "Template invalid.html not found.", "extra": None, "status_code": 500}
 
 
 def test_handler_raise_for_no_template_engine() -> None:
@@ -112,7 +112,7 @@ def test_handler_raise_for_no_template_engine() -> None:
     with create_test_client(route_handlers=[invalid_path]) as client:
         response = client.request("GET", "/")
         assert response.status_code == 500
-        assert response.json() == {"detail": "Template engine is not configured", "extra": None}
+        assert response.json() == {"detail": "Template engine is not configured", "extra": None, "status_code": 500}
 
 
 def test_template_with_no_context(tmpdir: Any) -> None:


### PR DESCRIPTION
Fixes #167 by adding `status_code` to the response body when dealing with exceptions in the default exception handler.