### PR TITLE
Import testing dynamically, install requests as extra dependency

### DIFF
--- a/docs/usage/14-testing.md
+++ b/docs/usage/14-testing.md
@@ -2,6 +2,9 @@
 
 Testing is a first class citizen in Starlite, which offers several powerful testing utilities out of the box.
 
+To use them, you need to install starlite with `testing` extra:
+`pip install starlite[testing]` or `poetry install starlite --extras testing`
+
 ## Test Client
 
 Starlite extends the Starlette testing client, which in turn is built using
@@ -26,7 +29,7 @@ We would then test it using the test client like so:
 
 ```python title="tests/test_health_check.py"
 from starlette.status import HTTP_200_OK
-from starlite import TestClient
+from starlite.testing import TestClient
 
 from my_app.main import app
 
@@ -42,7 +45,7 @@ Since we would probably need to use the client in multiple places, it's better t
 ```python title="tests/conftest.py"
 import pytest
 
-from starlite import TestClient
+from starlite.testing import TestClient
 
 from my_app.main import app
 
@@ -56,7 +59,7 @@ We would then be able to rewrite our test like so:
 
 ```python title="tests/test_health_check.py"
 from starlette.status import HTTP_200_OK
-from starlite import TestClient
+from starlite.testing import TestClient
 
 
 def test_health_check(test_client: TestClient):
@@ -83,7 +86,7 @@ For example, you can do this:
 
 ```python title="my_app/tests/test_health_check.py"
 from starlette.status import HTTP_200_OK
-from starlite import create_test_client
+from starlite.testing import create_test_client
 
 from my_app.main import health_check
 
@@ -99,7 +102,7 @@ But also this:
 
 ```python title="my_app/tests/test_health_check.py"
 from starlette.status import HTTP_200_OK
-from starlite import create_test_client
+from starlite.testing import create_test_client
 
 from my_app.main import health_check
 
@@ -123,7 +126,8 @@ from typing import Protocol, runtime_checkable
 import pytest
 from pydantic import BaseModel
 from starlette.status import HTTP_200_OK
-from starlite import Provide, create_test_client, get
+from starlite import Provide, get
+from starlite.testing import  create_test_client
 
 
 class Item(BaseModel):
@@ -172,9 +176,8 @@ import pytest
 from pydantic import BaseModel
 from pydantic_factories import ModelFactory
 from starlette.status import HTTP_200_OK
-
-from starlite import Provide, create_test_client, get
-
+from starlite import Provide, get
+from starlite.testing import  create_test_client
 
 class Item(BaseModel):
     name: str
@@ -251,7 +254,8 @@ We could thus test the guard function like so:
 ```python title="tests/guards/test_secret_token_guard.py"
 import pytest
 
-from starlite import NotAuthorizedException, HttpMethod, create_test_request
+from starlite import NotAuthorizedException, HttpMethod
+from starlite.testing import  create_test_request
 
 from my_app.guards import secret_token_guard
 from my_app.secret import secret_endpoint

--- a/docs/usage/14-testing.md
+++ b/docs/usage/14-testing.md
@@ -2,7 +2,7 @@
 
 Testing is a first class citizen in Starlite, which offers several powerful testing utilities out of the box.
 
-To use them, you need to install starlite with `testing` extra:
+!!!important Testing utils rely on extra dependencies. So make sure to install them, e.g.:
 `pip install starlite[testing]` or `poetry install starlite --extras testing`
 
 ## Test Client

--- a/poetry.lock
+++ b/poetry.lock
@@ -609,7 +609,7 @@ testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtuale
 
 [[package]]
 name = "pytest-mock"
-version = "3.7.0"
+version = "3.8.1"
 description = "Thin-wrapper around the mock package for easier use with pytest"
 category = "dev"
 optional = false
@@ -722,7 +722,7 @@ python-versions = "*"
 
 [[package]]
 name = "sqlalchemy"
-version = "1.4.38"
+version = "1.4.39"
 description = "Database Abstraction Library"
 category = "dev"
 optional = false
@@ -907,10 +907,13 @@ python-versions = ">=3.7"
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
+[extras]
+testing = ["requests"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "66739d9bd99f3f0e7db301e0fc0a025a362018759e10ac417794856e4b749238"
+content-hash = "7ab2bf4792ada67f9a242cad5b9613f48d85c82f43e6e5aabcbe27ead32adf97"
 
 [metadata.files]
 anyio = [
@@ -1346,8 +1349,8 @@ pytest-cov = [
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
 pytest-mock = [
-    {file = "pytest-mock-3.7.0.tar.gz", hash = "sha256:5112bd92cc9f186ee96e1a92efc84969ea494939c3aead39c50f421c4cc69534"},
-    {file = "pytest_mock-3.7.0-py3-none-any.whl", hash = "sha256:6cff27cec936bf81dc5ee87f07132b807bcda51106b5ec4b90a04331cba76231"},
+    {file = "pytest-mock-3.8.1.tar.gz", hash = "sha256:2c6d756d5d3bf98e2e80797a959ca7f81f479e7d1f5f571611b0fdd6d1745240"},
+    {file = "pytest_mock-3.8.1-py3-none-any.whl", hash = "sha256:d989f11ca4a84479e288b0cd1e6769d6ad0d3d7743dcc75e460d1416a5f2135a"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -1416,41 +1419,42 @@ sortedcontainers = [
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 sqlalchemy = [
-    {file = "SQLAlchemy-1.4.38-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:cf1afb1deec19de7ba282062de8a8c4f931ef120faa8b3dc6fca826bbc2f6a9d"},
-    {file = "SQLAlchemy-1.4.38-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c715347cac3b1c563941162fbbf751d3a5e0c356a33cb20925699f4910504a8f"},
-    {file = "SQLAlchemy-1.4.38-cp27-cp27m-win_amd64.whl", hash = "sha256:55c09559e45d3f067435620195238f983d4a23f796650f959f19964ba9104c6f"},
-    {file = "SQLAlchemy-1.4.38-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f04789d723fbd6214a63006b4711d7afca37630473edb6ab972c5df2b43b7a56"},
-    {file = "SQLAlchemy-1.4.38-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:6edadd6a0a722c22558e1d1f5360d3e85fa938bc69d9049d29968a643de6dd34"},
-    {file = "SQLAlchemy-1.4.38-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42810e560b57e981ed0a947b65a4936b398b4fca97e5b56e10a9c5a151568de2"},
-    {file = "SQLAlchemy-1.4.38-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b8cd779ef29718f3d2c558042ccc45c03006c599dd722fb760faca641a2f32ac"},
-    {file = "SQLAlchemy-1.4.38-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf05b312bf0165f92fa0eb09e7661c26f2f06c7a89694ecb79fa15a933deb768"},
-    {file = "SQLAlchemy-1.4.38-cp310-cp310-win32.whl", hash = "sha256:82701a4cbb14affc6c1ae62dcebdaff65611b7c7f96f9d0e92a34a8be112a8fa"},
-    {file = "SQLAlchemy-1.4.38-cp310-cp310-win_amd64.whl", hash = "sha256:57ea67a9206eab2abe130e4fdae0662f10cca3dc72ba27553f70a7d613588571"},
-    {file = "SQLAlchemy-1.4.38-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:492f25432f0a998bcaa35e907f9d33f436d208326bb1e6c0f8485e8117502a3d"},
-    {file = "SQLAlchemy-1.4.38-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa64578158cb374e4dd6da2377f1ceabf9973313d171e67fc01a353aa8967858"},
-    {file = "SQLAlchemy-1.4.38-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bdea12b997b174903292cf19f40d36cad46b44b645725b9485164684d1849bfd"},
-    {file = "SQLAlchemy-1.4.38-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63f8e68356b53072a653e8f61c5f1c19721469af4dbfdb3e3356073e9918f1fe"},
-    {file = "SQLAlchemy-1.4.38-cp36-cp36m-win32.whl", hash = "sha256:cfdb1b3763aa4bddccd7b627b9466fce94952dc150a49309eb56e5f50dd00806"},
-    {file = "SQLAlchemy-1.4.38-cp36-cp36m-win_amd64.whl", hash = "sha256:b33388891faf67d0c4a7bb65657dd1a068168eda4b793cb929c4c3894adfdcf2"},
-    {file = "SQLAlchemy-1.4.38-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:a57edcbbb45e8307153c5d4635407df71529ed263666064c0524b0c412778306"},
-    {file = "SQLAlchemy-1.4.38-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:470fd9d820fbd25c2a2a2929327c44aaff9d5871a20e0cadd32d293540817517"},
-    {file = "SQLAlchemy-1.4.38-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d8193b4a340d868f2daeeb856dfae9d9d4b011f249128380a83ee7342a887bdb"},
-    {file = "SQLAlchemy-1.4.38-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ac6b091b322ec54a30c751dfcb736987e317f5c53a5cf3beb62e11a18210319"},
-    {file = "SQLAlchemy-1.4.38-cp37-cp37m-win32.whl", hash = "sha256:42a60988aad143a4b2745711548833f57340d7f35586160140361314a509e6f7"},
-    {file = "SQLAlchemy-1.4.38-cp37-cp37m-win_amd64.whl", hash = "sha256:380e09881cdf3c87e90b8995425f7ea618e6bbd33c6b7c9234af21c4b6b3c143"},
-    {file = "SQLAlchemy-1.4.38-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:e44e5f4d84861f4a2a00da8e55712db0dd2ec3d680544fb5d3ac84d3682d7d4c"},
-    {file = "SQLAlchemy-1.4.38-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77831317da71adec7b785ebf9e6467b59ba1e186de1ba13c94b4e4951387ba64"},
-    {file = "SQLAlchemy-1.4.38-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f036bdc951b0d64c64ae83e7ff83a1848eea74f1c6e42461347caab2ed7282b9"},
-    {file = "SQLAlchemy-1.4.38-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad2447f17425e6889f0fb2b229844799aabafc90ff780123067fc5846a30992c"},
-    {file = "SQLAlchemy-1.4.38-cp38-cp38-win32.whl", hash = "sha256:737f4feee88d78230fa38027ad5645cb327fe9aac0dd0bde3f8fa7026ed81910"},
-    {file = "SQLAlchemy-1.4.38-cp38-cp38-win_amd64.whl", hash = "sha256:eba2c5f717fa6d7be040bbc1e4334f1827d31e672cfd53ddbd995935d43e517e"},
-    {file = "SQLAlchemy-1.4.38-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:cd1aba14bbb1ecfe8b5cc52dc840a7e071cfcce6bff545037cf56714c48dfc92"},
-    {file = "SQLAlchemy-1.4.38-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da424c8b285da91733fed2dd40fed7db076818a62859244d311b80fc8ba4d75e"},
-    {file = "SQLAlchemy-1.4.38-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:07865d93e4ca77b59a5ce0f36fbae8161f7dfe57ba17934a3e442cf95dcb3c49"},
-    {file = "SQLAlchemy-1.4.38-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3abe087b641788abbbe94abbf9f15f50bb985f72c0669ef35d1941d2912a276d"},
-    {file = "SQLAlchemy-1.4.38-cp39-cp39-win32.whl", hash = "sha256:d3c4191e0348428b127c4c2e25ec9c1e8e895e3c6d9a7f083fca28dce23257ee"},
-    {file = "SQLAlchemy-1.4.38-cp39-cp39-win_amd64.whl", hash = "sha256:97ba370e31b70be94f2f1e85494a5c90f8cf50381ddc02ab95a33a4a86371e02"},
-    {file = "SQLAlchemy-1.4.38.tar.gz", hash = "sha256:93ae1d2ef42fbf0f0b3d44b35225bda123310df4b33c9bf662e7b50a68c48a98"},
+    {file = "SQLAlchemy-1.4.39-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:4770eb3ba69ec5fa41c681a75e53e0e342ac24c1f9220d883458b5596888e43a"},
+    {file = "SQLAlchemy-1.4.39-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:752ef2e8dbaa3c5d419f322e3632f00ba6b1c3230f65bc97c2ff5c5c6c08f441"},
+    {file = "SQLAlchemy-1.4.39-cp27-cp27m-win32.whl", hash = "sha256:b30e70f1594ee3c8902978fd71900d7312453922827c4ce0012fa6a8278d6df4"},
+    {file = "SQLAlchemy-1.4.39-cp27-cp27m-win_amd64.whl", hash = "sha256:864d4f89f054819cb95e93100b7d251e4d114d1c60bc7576db07b046432af280"},
+    {file = "SQLAlchemy-1.4.39-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8f901be74f00a13bf375241a778455ee864c2c21c79154aad196b7a994e1144f"},
+    {file = "SQLAlchemy-1.4.39-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:1745987ada1890b0e7978abdb22c133eca2e89ab98dc17939042240063e1ef21"},
+    {file = "SQLAlchemy-1.4.39-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ede13a472caa85a13abe5095e71676af985d7690eaa8461aeac5c74f6600b6c0"},
+    {file = "SQLAlchemy-1.4.39-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7f13644b15665f7322f9e0635129e0ef2098409484df67fcd225d954c5861559"},
+    {file = "SQLAlchemy-1.4.39-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26146c59576dfe9c546c9f45397a7c7c4a90c25679492ff610a7500afc7d03a6"},
+    {file = "SQLAlchemy-1.4.39-cp310-cp310-win32.whl", hash = "sha256:91d2b89bb0c302f89e753bea008936acfa4e18c156fb264fe41eb6bbb2bbcdeb"},
+    {file = "SQLAlchemy-1.4.39-cp310-cp310-win_amd64.whl", hash = "sha256:50e7569637e2e02253295527ff34666706dbb2bc5f6c61a5a7f44b9610c9bb09"},
+    {file = "SQLAlchemy-1.4.39-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:107df519eb33d7f8e0d0d052128af2f25066c1a0f6b648fd1a9612ab66800b86"},
+    {file = "SQLAlchemy-1.4.39-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f24d4d6ec301688c59b0c4bb1c1c94c5d0bff4ecad33bb8f5d9efdfb8d8bc925"},
+    {file = "SQLAlchemy-1.4.39-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7b2785dd2a0c044a36836857ac27310dc7a99166253551ee8f5408930958cc60"},
+    {file = "SQLAlchemy-1.4.39-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6e2c8581c6620136b9530137954a8376efffd57fe19802182c7561b0ab48b48"},
+    {file = "SQLAlchemy-1.4.39-cp36-cp36m-win32.whl", hash = "sha256:fbc076f79d830ae4c9d49926180a1140b49fa675d0f0d555b44c9a15b29f4c80"},
+    {file = "SQLAlchemy-1.4.39-cp36-cp36m-win_amd64.whl", hash = "sha256:0ec54460475f0c42512895c99c63d90dd2d9cbd0c13491a184182e85074b04c5"},
+    {file = "SQLAlchemy-1.4.39-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:6f95706da857e6e79b54c33c1214f5467aab10600aa508ddd1239d5df271986e"},
+    {file = "SQLAlchemy-1.4.39-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:621f050e72cc7dfd9ad4594ff0abeaad954d6e4a2891545e8f1a53dcdfbef445"},
+    {file = "SQLAlchemy-1.4.39-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05a05771617bfa723ba4cef58d5b25ac028b0d68f28f403edebed5b8243b3a87"},
+    {file = "SQLAlchemy-1.4.39-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:20bf65bcce65c538e68d5df27402b39341fabeecf01de7e0e72b9d9836c13c52"},
+    {file = "SQLAlchemy-1.4.39-cp37-cp37m-win32.whl", hash = "sha256:f2a42acc01568b9701665e85562bbff78ec3e21981c7d51d56717c22e5d3d58b"},
+    {file = "SQLAlchemy-1.4.39-cp37-cp37m-win_amd64.whl", hash = "sha256:6d81de54e45f1d756785405c9d06cd17918c2eecc2d4262dc2d276ca612c2f61"},
+    {file = "SQLAlchemy-1.4.39-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:5c2d19bfb33262bf987ef0062345efd0f54c4189c2d95159c72995457bf4a359"},
+    {file = "SQLAlchemy-1.4.39-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14ea8ff2d33c48f8e6c3c472111d893b9e356284d1482102da9678195e5a8eac"},
+    {file = "SQLAlchemy-1.4.39-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ec3985c883d6d217cf2013028afc6e3c82b8907192ba6195d6e49885bfc4b19d"},
+    {file = "SQLAlchemy-1.4.39-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1962dfee37b7fb17d3d4889bf84c4ea08b1c36707194c578f61e6e06d12ab90f"},
+    {file = "SQLAlchemy-1.4.39-cp38-cp38-win32.whl", hash = "sha256:047ef5ccd8860f6147b8ac6c45a4bc573d4e030267b45d9a1c47b55962ff0e6f"},
+    {file = "SQLAlchemy-1.4.39-cp38-cp38-win_amd64.whl", hash = "sha256:b71be98ef6e180217d1797185c75507060a57ab9cd835653e0112db16a710f0d"},
+    {file = "SQLAlchemy-1.4.39-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:365b75938049ae31cf2176efd3d598213ddb9eb883fbc82086efa019a5f649df"},
+    {file = "SQLAlchemy-1.4.39-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e7a7667d928ba6ee361a3176e1bef6847c1062b37726b33505cc84136f657e0d"},
+    {file = "SQLAlchemy-1.4.39-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c6d00cb9da8d0cbfaba18cad046e94b06de6d4d0ffd9d4095a3ad1838af22528"},
+    {file = "SQLAlchemy-1.4.39-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0538b66f959771c56ff996d828081908a6a52a47c5548faed4a3d0a027a5368"},
+    {file = "SQLAlchemy-1.4.39-cp39-cp39-win32.whl", hash = "sha256:d1f665e50592caf4cad3caed3ed86f93227bffe0680218ccbb293bd5a6734ca8"},
+    {file = "SQLAlchemy-1.4.39-cp39-cp39-win_amd64.whl", hash = "sha256:8b773c9974c272aae0fa7e95b576d98d17ee65f69d8644f9b6ffc90ee96b4d19"},
+    {file = "SQLAlchemy-1.4.39.tar.gz", hash = "sha256:8194896038753b46b08a0b0ae89a5d80c897fb601dd51e243ed5720f1f155d27"},
 ]
 sqlalchemy2-stubs = [
     {file = "sqlalchemy2-stubs-0.0.2a24.tar.gz", hash = "sha256:e15c45302eafe196ed516f979ef017135fd619d2c62d02de9a5c5f2e59a600c4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ python-multipart = "*"
 pyyaml = "*"
 starlette = "*"
 typing-extensions = "*"
-
 requests = { version = "*", optional = true }
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,10 @@ pydantic = "*"
 pydantic-factories = "*"
 python-multipart = "*"
 pyyaml = "*"
-requests = "*"
 starlette = "*"
 typing-extensions = "*"
+
+requests = { version = "*", optional = true }
 
 [tool.poetry.dev-dependencies]
 hypothesis = { extras = ["cli"], version = "*" }
@@ -56,6 +57,10 @@ Mako = "*"
 freezegun = "*"
 pytest-mock = "*"
 tox = "*"
+requests = "*"
+
+[tool.poetry.extras]
+testing = ["requests"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/starlite/__init__.py
+++ b/starlite/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from starlite.datastructures import File, Redirect, State, Stream, Template
 
 from .app import Starlite
@@ -53,7 +55,6 @@ from .provide import Provide
 from .response import Response
 from .router import Router
 from .routes import BaseRoute, HTTPRoute, WebSocketRoute
-from .testing import TestClient, create_test_client, create_test_request
 from .types import MiddlewareProtocol, Partial, ResponseHeader
 
 __all__ = [
@@ -105,14 +106,11 @@ __all__ = [
     "Stream",
     "Template",
     "TemplateConfig",
-    "TestClient",
     "ValidationException",
     "WebSocket",
     "WebSocketRoute",
     "WebsocketRouteHandler",
     "asgi",
-    "create_test_client",
-    "create_test_request",
     "delete",
     "get",
     "patch",
@@ -121,3 +119,24 @@ __all__ = [
     "route",
     "websocket",
 ]
+
+_deprecated_imports = {"TestClient", "create_test_client", "create_test_request"}
+
+
+# pylint: disable=import-outside-toplevel
+def __getattr__(name: str) -> Any:
+    """Provide lazy importing as per https://peps.python.org/pep-0562/"""
+    if name not in _deprecated_imports:
+        raise AttributeError(f"Module {__package__} has no attribute {name}")
+
+    import warnings
+
+    warnings.warn(
+        f"Importing {name} from {__package__} is deprecated, use `from startlite.testing import {name}` instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from . import testing
+
+    attr = globals()[name] = getattr(testing, name)
+    return attr

--- a/starlite/__init__.py
+++ b/starlite/__init__.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from starlite.datastructures import File, Redirect, State, Stream, Template
 
@@ -57,6 +57,10 @@ from .router import Router
 from .routes import BaseRoute, HTTPRoute, WebSocketRoute
 from .types import MiddlewareProtocol, Partial, ResponseHeader
 
+if TYPE_CHECKING:
+    from .testing import TestClient, create_test_client, create_test_request
+
+
 __all__ = [
     "ASGIRouteHandler",
     "AbstractAuthenticationMiddleware",
@@ -106,11 +110,14 @@ __all__ = [
     "Stream",
     "Template",
     "TemplateConfig",
+    "TestClient",
     "ValidationException",
     "WebSocket",
     "WebSocketRoute",
     "WebsocketRouteHandler",
     "asgi",
+    "create_test_client",
+    "create_test_request",
     "delete",
     "get",
     "patch",
@@ -120,22 +127,15 @@ __all__ = [
     "websocket",
 ]
 
-_deprecated_imports = {"TestClient", "create_test_client", "create_test_request"}
+_dynamic_imports = {"TestClient", "create_test_client", "create_test_request"}
 
 
 # pylint: disable=import-outside-toplevel
 def __getattr__(name: str) -> Any:
     """Provide lazy importing as per https://peps.python.org/pep-0562/"""
-    if name not in _deprecated_imports:
+    if name not in _dynamic_imports:
         raise AttributeError(f"Module {__package__} has no attribute {name}")
 
-    import warnings
-
-    warnings.warn(
-        f"Importing {name} from {__package__} is deprecated, use `from startlite.testing import {name}` instead",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     from . import testing
 
     attr = globals()[name] = getattr(testing, name)

--- a/starlite/testing.py
+++ b/starlite/testing.py
@@ -4,7 +4,13 @@ from urllib.parse import urlencode
 from orjson import dumps
 from pydantic import BaseModel
 from pydantic.typing import AnyCallable
-from requests.models import RequestEncodingMixin
+
+try:
+    from requests.models import RequestEncodingMixin
+except ImportError:
+    raise RuntimeError(
+        "To use starlite.testing, install starlite with 'testing' extra, e.g. `pip install starlite[testing]`"
+    )
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.testclient import TestClient as StarletteTestClient
@@ -34,6 +40,12 @@ from starlite.types import (
     LifeCycleHandler,
     MiddlewareProtocol,
 )
+
+__all__ = [
+    "TestClient",
+    "create_test_client",
+    "create_test_request",
+]
 
 
 class RequestEncoder(RequestEncodingMixin):

--- a/starlite/testing.py
+++ b/starlite/testing.py
@@ -7,9 +7,11 @@ from pydantic.typing import AnyCallable
 
 try:
     from requests.models import RequestEncodingMixin
-except ImportError:
-    raise RuntimeError(
-        "To use starlite.testing, install starlite with 'testing' extra, e.g. `pip install starlite[testing]`"
+except ImportError:  # pragma: no cover
+    from starlite.exceptions import MissingDependencyException
+
+    raise MissingDependencyException(
+        "To use starlite.testing, intall starlite with 'testing' extra, e.g. `pip install starlite[testing]`"
     )
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -37,5 +37,5 @@ def test_testing_import_deprecation() -> None:
 def test_testing_import_deprecation_in_subprocess() -> None:
     """Run test_testing_import_deprecation in subprocess so it can test importing starlite for the first time"""
     subprocess.check_call(
-        [sys.executable, "-m", "pytest", f"{__file__}::{test_testing_import_deprecation.__name__}"], timeout=1
+        [sys.executable, "-m", "pytest", f"{__file__}::{test_testing_import_deprecation.__name__}"], timeout=5
     )

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,41 @@
+import subprocess
+import sys
+import warnings
+
+import pytest
+
+
+@pytest.mark.skipif("starlite" in sys.modules, reason="This tests expects starlite to be imported for the first time")
+def test_testing_import_deprecation() -> None:
+    import starlite
+
+    deprecated_imports = {"TestClient", "create_test_client", "create_test_request"}
+    assert deprecated_imports & starlite.__dict__.keys() == set()
+    assert "starlite.testing" not in sys.modules
+    assert "requests" not in sys.modules
+    assert "requests.models" not in sys.modules
+
+    for deprecated_name in deprecated_imports:
+        with pytest.warns(DeprecationWarning):
+            getattr(starlite, deprecated_name)
+
+    assert deprecated_imports & starlite.__dict__.keys() == deprecated_imports
+    assert "starlite.testing" in sys.modules
+    assert "requests.models" in sys.modules
+
+    # ensure no warnings emited on the second usage
+    with warnings.catch_warnings(record=True) as record:
+        for deprecated_name in deprecated_imports:
+            getattr(starlite, deprecated_name)
+
+    assert record == []
+
+
+@pytest.mark.skipif(
+    "starlite" not in sys.modules, reason="Was able to run previous test, no need to launch subprocess for that"
+)
+def test_testing_import_deprecation_in_subprocess() -> None:
+    """Run test_testing_import_deprecation in subprocess so it can test importing starlite for the first time"""
+    subprocess.check_call(
+        [sys.executable, "-m", "pytest", f"{__file__}::{test_testing_import_deprecation.__name__}"], timeout=1
+    )


### PR DESCRIPTION
Closes #130

```py
>>> from starlite import Starlite
>>> Starlite
<class 'starlite.app.Starlite'>
>>> from starlite import TestClient
Traceback (most recent call last):
    ...
MissingDependencyException: To use starlite.testing, install starlite with 'testing' extra, e.g. `pip install starlite[testing]`
```