### PR TITLE
Discourage testing import from package, fix star import from `starlite`

### DIFF
--- a/starlite/__init__.py
+++ b/starlite/__init__.py
@@ -120,15 +120,23 @@ __all__ = [
     "websocket",
 ]
 
-# these imports are still allowed, but importing from starlite.testing instead is encouraged
-_dynamic_imports = {"TestClient", "create_test_client", "create_test_request"}
+
+_deprecated_imports = {"TestClient", "create_test_client", "create_test_request"}
 
 
 # pylint: disable=import-outside-toplevel
 def __getattr__(name: str) -> Any:
     """Provide lazy importing as per https://peps.python.org/pep-0562/"""
-    if name not in _dynamic_imports:
+    if name not in _deprecated_imports:
         raise AttributeError(f"Module {__package__} has no attribute {name}")
+
+    import warnings
+
+    warnings.warn(
+        f"Importing {name} from {__package__} is deprecated, use `from startlite.testing import {name}` instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
 
     from . import testing
 

--- a/starlite/__init__.py
+++ b/starlite/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from starlite.datastructures import File, Redirect, State, Stream, Template
 
@@ -57,10 +57,6 @@ from .router import Router
 from .routes import BaseRoute, HTTPRoute, WebSocketRoute
 from .types import MiddlewareProtocol, Partial, ResponseHeader
 
-if TYPE_CHECKING:
-    from .testing import TestClient, create_test_client, create_test_request
-
-
 __all__ = [
     "ASGIRouteHandler",
     "AbstractAuthenticationMiddleware",
@@ -110,14 +106,11 @@ __all__ = [
     "Stream",
     "Template",
     "TemplateConfig",
-    "TestClient",
     "ValidationException",
     "WebSocket",
     "WebSocketRoute",
     "WebsocketRouteHandler",
     "asgi",
-    "create_test_client",
-    "create_test_request",
     "delete",
     "get",
     "patch",
@@ -127,6 +120,7 @@ __all__ = [
     "websocket",
 ]
 
+# these imports are still allowed, but importing from starlite.testing instead is encouraged
 _dynamic_imports = {"TestClient", "create_test_client", "create_test_request"}
 
 

--- a/tests/app/test_error_handling.py
+++ b/tests/app/test_error_handling.py
@@ -3,18 +3,9 @@ import json
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.status import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
 
-from starlite import (
-    HTTPException,
-    MediaType,
-    Request,
-    Response,
-    Starlite,
-    TestClient,
-    create_test_client,
-    get,
-    post,
-)
+from starlite import HTTPException, MediaType, Request, Response, Starlite, get, post
 from starlite.exceptions import InternalServerException
+from starlite.testing import TestClient, create_test_client
 from tests import Person
 
 

--- a/tests/app/test_lifecycle.py
+++ b/tests/app/test_lifecycle.py
@@ -1,6 +1,7 @@
 from typing import cast
 
-from starlite import Starlite, State, create_test_client
+from starlite import Starlite, State
+from starlite.testing import create_test_client
 
 
 def test_lifecycle() -> None:

--- a/tests/app/test_middleware_handling.py
+++ b/tests/app/test_middleware_handling.py
@@ -17,10 +17,10 @@ from starlite import (
     Request,
     Response,
     Starlite,
-    create_test_client,
     get,
     post,
 )
+from starlite.testing import create_test_client
 
 logger = logging.getLogger(__name__)
 

--- a/tests/dependency_injection/test_http_handler_dependency_injection.py
+++ b/tests/dependency_injection/test_http_handler_dependency_injection.py
@@ -3,8 +3,9 @@ from typing import Any, Dict
 
 from starlette.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 
-from starlite import Controller, Provide, create_test_client, get
+from starlite import Controller, Provide, get
 from starlite.connection import Request
+from starlite.testing import create_test_client
 
 
 def router_first_dependency() -> bool:

--- a/tests/dependency_injection/test_injection_of_generic_models.py
+++ b/tests/dependency_injection/test_injection_of_generic_models.py
@@ -4,7 +4,8 @@ from pydantic import BaseModel
 from pydantic.generics import GenericModel
 from starlette.status import HTTP_200_OK
 
-from starlite import Provide, create_test_client, get
+from starlite import Provide, get
+from starlite.testing import create_test_client
 
 T = TypeVar("T")
 

--- a/tests/dependency_injection/test_inter_dependencies.py
+++ b/tests/dependency_injection/test_inter_dependencies.py
@@ -1,4 +1,5 @@
-from starlite import Controller, MediaType, Provide, create_test_client, get
+from starlite import Controller, MediaType, Provide, get
+from starlite.testing import create_test_client
 
 
 def test_inter_dependencies() -> None:

--- a/tests/dependency_injection/test_websocket_handler_dependency_injection.py
+++ b/tests/dependency_injection/test_websocket_handler_dependency_injection.py
@@ -4,8 +4,9 @@ from typing import Any, Dict
 import pytest
 from starlette.websockets import WebSocketDisconnect
 
-from starlite import Controller, Provide, create_test_client, websocket
+from starlite import Controller, Provide, websocket
 from starlite.connection import WebSocket
+from starlite.testing import create_test_client
 
 
 def router_first_dependency() -> bool:

--- a/tests/handlers/asgi/test_handle_asgi.py
+++ b/tests/handlers/asgi/test_handle_asgi.py
@@ -1,7 +1,8 @@
 from starlette.status import HTTP_200_OK
 from starlette.types import Receive, Scope, Send
 
-from starlite import Controller, MediaType, Response, asgi, create_test_client
+from starlite import Controller, MediaType, Response, asgi
+from starlite.testing import create_test_client
 
 
 def test_handle_asgi() -> None:

--- a/tests/handlers/asgi/test_validations.py
+++ b/tests/handlers/asgi/test_validations.py
@@ -1,7 +1,8 @@
 import pytest
 from starlette.types import Receive, Scope, Send
 
-from starlite import ImproperlyConfiguredException, asgi, create_test_client
+from starlite import ImproperlyConfiguredException, asgi
+from starlite.testing import create_test_client
 
 
 def test_asgi_handler_validation() -> None:

--- a/tests/handlers/http/test_sync.py
+++ b/tests/handlers/http/test_sync.py
@@ -1,6 +1,7 @@
 import pytest
 
-from starlite import HTTPRouteHandler, MediaType, create_test_client, get
+from starlite import HTTPRouteHandler, MediaType, get
+from starlite.testing import create_test_client
 
 
 def sync_handler() -> str:

--- a/tests/handlers/websocket/test_handle_websocket.py
+++ b/tests/handlers/websocket/test_handle_websocket.py
@@ -1,4 +1,5 @@
-from starlite import WebSocket, create_test_client, websocket
+from starlite import WebSocket, websocket
+from starlite.testing import create_test_client
 
 
 def test_handle_websocket() -> None:

--- a/tests/handlers/websocket/test_kwarg_handling.py
+++ b/tests/handlers/websocket/test_kwarg_handling.py
@@ -1,4 +1,5 @@
-from starlite import Parameter, WebSocket, create_test_client, websocket
+from starlite import Parameter, WebSocket, websocket
+from starlite.testing import create_test_client
 
 
 def test_handle_websocket_params_parsing() -> None:

--- a/tests/handlers/websocket/test_validations.py
+++ b/tests/handlers/websocket/test_validations.py
@@ -2,12 +2,8 @@ from typing import Any
 
 import pytest
 
-from starlite import (
-    ImproperlyConfiguredException,
-    WebSocket,
-    create_test_client,
-    websocket,
-)
+from starlite import ImproperlyConfiguredException, WebSocket, websocket
+from starlite.testing import create_test_client
 
 
 def test_websocket_handler_function_validation() -> None:

--- a/tests/kwargs/test_cookie_params.py
+++ b/tests/kwargs/test_cookie_params.py
@@ -5,7 +5,8 @@ from pydantic.fields import FieldInfo
 from starlette.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from typing_extensions import Type
 
-from starlite import Parameter, create_test_client, get
+from starlite import Parameter, get
+from starlite.testing import create_test_client
 
 
 @pytest.mark.parametrize(

--- a/tests/kwargs/test_defaults.py
+++ b/tests/kwargs/test_defaults.py
@@ -1,6 +1,7 @@
 from starlette.status import HTTP_200_OK
 
-from starlite import Parameter, create_test_client, get
+from starlite import Parameter, get
+from starlite.testing import create_test_client
 
 
 def test_params_default() -> None:

--- a/tests/kwargs/test_header_params.py
+++ b/tests/kwargs/test_header_params.py
@@ -7,7 +7,8 @@ from pydantic.fields import FieldInfo
 from starlette.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 from typing_extensions import Type
 
-from starlite import Parameter, create_test_client, get
+from starlite import Parameter, get
+from starlite.testing import create_test_client
 
 
 @pytest.mark.parametrize(

--- a/tests/kwargs/test_json_data.py
+++ b/tests/kwargs/test_json_data.py
@@ -1,6 +1,7 @@
 from starlette.status import HTTP_201_CREATED
 
-from starlite import Body, RequestEncodingType, create_test_client, post
+from starlite import Body, RequestEncodingType, post
+from starlite.testing import create_test_client
 from tests.kwargs import Form
 
 

--- a/tests/kwargs/test_multipart_data.py
+++ b/tests/kwargs/test_multipart_data.py
@@ -5,7 +5,8 @@ from pydantic import BaseConfig, BaseModel
 from starlette.datastructures import UploadFile
 from starlette.status import HTTP_201_CREATED
 
-from starlite import Body, RequestEncodingType, create_test_client, post
+from starlite import Body, RequestEncodingType, post
+from starlite.testing import create_test_client
 from tests import Person, PersonFactory
 from tests.kwargs import Form
 

--- a/tests/kwargs/test_path_params.py
+++ b/tests/kwargs/test_path_params.py
@@ -4,13 +4,8 @@ import pytest
 from pydantic import UUID4
 from starlette.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 
-from starlite import (
-    ImproperlyConfiguredException,
-    Parameter,
-    Starlite,
-    create_test_client,
-    get,
-)
+from starlite import ImproperlyConfiguredException, Parameter, Starlite, get
+from starlite.testing import create_test_client
 
 
 @pytest.mark.parametrize(

--- a/tests/kwargs/test_query_params.py
+++ b/tests/kwargs/test_query_params.py
@@ -5,7 +5,8 @@ from urllib.parse import urlencode
 import pytest
 from starlette.status import HTTP_200_OK, HTTP_400_BAD_REQUEST
 
-from starlite import Parameter, create_test_client, get
+from starlite import Parameter, get
+from starlite.testing import create_test_client
 
 
 @pytest.mark.parametrize(

--- a/tests/kwargs/test_reserved_kwargs_injection.py
+++ b/tests/kwargs/test_reserved_kwargs_injection.py
@@ -12,13 +12,13 @@ from starlite import (
     Request,
     Starlite,
     State,
-    create_test_client,
     delete,
     get,
     patch,
     post,
     put,
 )
+from starlite.testing import create_test_client
 from tests import Person, PersonFactory
 
 

--- a/tests/kwargs/test_url_encoded_data.py
+++ b/tests/kwargs/test_url_encoded_data.py
@@ -1,6 +1,7 @@
 from starlette.status import HTTP_201_CREATED
 
-from starlite import Body, RequestEncodingType, create_test_client, post
+from starlite import Body, RequestEncodingType, post
+from starlite.testing import create_test_client
 from tests.kwargs import Form
 
 

--- a/tests/middleware/test_authentication.py
+++ b/tests/middleware/test_authentication.py
@@ -10,10 +10,11 @@ from starlette.status import (
 )
 from starlette.websockets import WebSocketDisconnect
 
-from starlite import Starlite, create_test_client, get, websocket
+from starlite import Starlite, get, websocket
 from starlite.connection import Request, WebSocket
 from starlite.exceptions import PermissionDeniedException
 from starlite.middleware import AbstractAuthenticationMiddleware, AuthenticationResult
+from starlite.testing import create_test_client
 
 
 class User(BaseModel):

--- a/tests/openapi/test_integration.py
+++ b/tests/openapi/test_integration.py
@@ -5,9 +5,10 @@ from openapi_schema_pydantic.util import construct_open_api_with_schema_class
 from orjson import loads
 from starlette.status import HTTP_200_OK
 
-from starlite import Starlite, create_test_client
+from starlite import Starlite
 from starlite.app import DEFAULT_OPENAPI_CONFIG
 from starlite.enums import OpenAPIMediaType
+from starlite.testing import create_test_client
 from tests.openapi.utils import PersonController, PetController
 
 

--- a/tests/openapi/test_schema.py
+++ b/tests/openapi/test_schema.py
@@ -5,15 +5,7 @@ from openapi_schema_pydantic import Example
 from openapi_schema_pydantic.v3.v3_1_0.schema import Schema
 from pydantic.fields import FieldInfo
 
-from starlite import (
-    Controller,
-    MediaType,
-    Parameter,
-    Provide,
-    Starlite,
-    create_test_client,
-    get,
-)
+from starlite import Controller, MediaType, Parameter, Provide, Starlite, get
 from starlite.app import DEFAULT_OPENAPI_CONFIG
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.openapi.constants import (
@@ -21,6 +13,7 @@ from starlite.openapi.constants import (
     PYDANTIC_TO_OPENAPI_PROPERTY_MAP,
 )
 from starlite.openapi.schema import update_schema_with_field_info
+from starlite.testing import create_test_client
 
 
 def test_update_schema_with_field_info() -> None:

--- a/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_plugin_integration.py
+++ b/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_plugin_integration.py
@@ -6,8 +6,9 @@ from pydantic_factories.value_generators.primitives import (
 )
 from starlette.status import HTTP_200_OK, HTTP_201_CREATED
 
-from starlite import create_test_client, get, post
+from starlite import get, post
 from starlite.plugins.sql_alchemy import SQLAlchemyPlugin
+from starlite.testing import create_test_client
 from tests.plugins.sql_alchemy_plugin import Company
 
 companies = [

--- a/tests/request/test_state.py
+++ b/tests/request/test_state.py
@@ -2,7 +2,8 @@ from typing import Dict
 
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from starlite import MiddlewareProtocol, Request, create_test_client, get
+from starlite import MiddlewareProtocol, Request, get
+from starlite.testing import create_test_client
 
 
 class BeforeRequestMiddleWare(MiddlewareProtocol):

--- a/tests/static_files/test_static_files.py
+++ b/tests/static_files/test_static_files.py
@@ -3,8 +3,8 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from starlite import create_test_client
 from starlite.config import StaticFilesConfig
+from starlite.testing import create_test_client
 
 
 def test_staticfiles(tmpdir: Any) -> None:

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -8,8 +8,9 @@ import pytest
 from freezegun import freeze_time
 from pydantic import ValidationError
 
-from starlite import CacheConfig, Request, Response, create_test_client, get
+from starlite import CacheConfig, Request, Response, get
 from starlite.cache import SimpleCacheBackend
+from starlite.testing import create_test_client
 
 
 async def slow_handler() -> dict:

--- a/tests/test_connection_lifecycle_hooks.py
+++ b/tests/test_connection_lifecycle_hooks.py
@@ -2,15 +2,8 @@ from typing import Optional
 
 import pytest
 
-from starlite import (
-    Controller,
-    HTTPRouteHandler,
-    Request,
-    Response,
-    Router,
-    create_test_client,
-    get,
-)
+from starlite import Controller, HTTPRouteHandler, Request, Response, Router, get
+from starlite.testing import create_test_client
 from starlite.types import AfterRequestHandler, BeforeRequestHandler
 
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -6,7 +6,6 @@ from starlite import (
     Controller,
     HttpMethod,
     HTTPRouteHandler,
-    create_test_client,
     delete,
     get,
     patch,
@@ -15,6 +14,7 @@ from starlite import (
     websocket,
 )
 from starlite.connection import WebSocket
+from starlite.testing import create_test_client
 from tests import Person, PersonFactory
 
 

--- a/tests/test_dto_factory.py
+++ b/tests/test_dto_factory.py
@@ -6,15 +6,9 @@ from pydantic import BaseModel, create_model
 from pydantic_factories import ModelFactory
 from starlette.status import HTTP_200_OK, HTTP_201_CREATED
 
-from starlite import (
-    DTOFactory,
-    ImproperlyConfiguredException,
-    Starlite,
-    create_test_client,
-    get,
-    post,
-)
+from starlite import DTOFactory, ImproperlyConfiguredException, Starlite, get, post
 from starlite.plugins.sql_alchemy import SQLAlchemyPlugin
+from starlite.testing import create_test_client
 from tests import Person
 from tests import Pet as PydanticPet
 from tests import Species, VanillaDataClassPerson

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -13,9 +13,9 @@ from starlite import (
     Router,
     ServiceUnavailableException,
     ValidationException,
-    create_test_client,
     get,
 )
+from starlite.testing import create_test_client
 from starlite.types import ExceptionHandler
 
 

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -10,12 +10,12 @@ from starlite import (
     Request,
     Response,
     asgi,
-    create_test_client,
     get,
     websocket,
 )
 from starlite.connection import WebSocket
 from starlite.exceptions import PermissionDeniedException
+from starlite.testing import create_test_client
 
 
 async def local_guard(_: HTTPConnection, route_handler: BaseRouteHandler) -> None:

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -3,12 +3,13 @@ import sys
 
 import pytest
 
+dynamic_imports_names = {"TestClient", "create_test_client", "create_test_request"}
+
 
 @pytest.mark.skipif("starlite" in sys.modules, reason="This tests expects starlite to be imported for the first time")
 def test_testing_import_deprecation() -> None:
     import starlite
 
-    dynamic_imports_names = {"TestClient", "create_test_client", "create_test_request"}
     assert dynamic_imports_names & starlite.__dict__.keys() == set()
     assert "starlite.testing" not in sys.modules
     assert "requests" not in sys.modules
@@ -39,3 +40,11 @@ def test_testing_import_deprecation_in_subprocess() -> None:
     subprocess.check_call(
         [sys.executable, "-m", "pytest", f"{__file__}::{test_testing_import_deprecation.__name__}"], timeout=5
     )
+
+
+def test_star_import_doesnt_import_testing() -> None:
+    from starlite import *  # noqa
+
+    assert locals().keys() & dynamic_imports_names == set()
+    assert Starlite  # noqa
+    assert "Starlite" in locals()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -43,8 +43,6 @@ def test_testing_import_deprecation_in_subprocess() -> None:
 
 
 def test_star_import_doesnt_import_testing() -> None:
-    from starlite import *  # noqa
+    import starlite
 
-    assert locals().keys() & dynamic_imports_names == set()
-    assert Starlite  # noqa
-    assert "Starlite" in locals()
+    assert set(starlite.__all__) & dynamic_imports_names == set()

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -3,8 +3,9 @@ from unittest.mock import Mock, patch
 
 from _pytest.logging import LogCaptureFixture
 
-from starlite import Starlite, TestClient, create_test_client
+from starlite import Starlite
 from starlite.logging import LoggingConfig
+from starlite.testing import TestClient, create_test_client
 
 
 @patch("logging.config.dictConfig")

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,5 +1,5 @@
-from starlite import create_test_request
 from starlite.parsers import parse_query_params
+from starlite.testing import create_test_request
 
 
 def test_parse_query_params() -> None:

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -10,14 +10,8 @@ from starlette.status import (
 )
 from typing_extensions import Type
 
-from starlite import (
-    Controller,
-    HTTPRouteHandler,
-    MediaType,
-    create_test_client,
-    delete,
-    get,
-)
+from starlite import Controller, HTTPRouteHandler, MediaType, delete, get
+from starlite.testing import create_test_client
 from tests import Person, PersonFactory
 
 

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,9 +1,10 @@
 import os
 from typing import Any
 
-from starlite import Template, TemplateConfig, create_test_client, get
+from starlite import Template, TemplateConfig, get
 from starlite.template.jinja import JinjaTemplateEngine
 from starlite.template.mako import MakoTemplateEngine
+from starlite.testing import create_test_client
 
 
 def test_jinja_template(tmpdir: Any) -> None:

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -3,15 +3,8 @@ from typing import Any
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from starlite import (
-    HttpMethod,
-    RequestEncodingType,
-    Starlite,
-    State,
-    TestClient,
-    create_test_request,
-    get,
-)
+from starlite import HttpMethod, RequestEncodingType, Starlite, State, get
+from starlite.testing import TestClient, create_test_request
 from tests import Person
 
 


### PR DESCRIPTION
Fixes #181

I'm hesitant on adding `DeprecationWarning` just yet. 

As I see it, we can deal with deprecation in tho fases:
1. Static: encourage importing from `starlite.testing` by removing testing names it from `__all__`, IDEs will pick this up
2. Runtime: emit warning on import

This PR is executing the 1st phase. This should give people some time to get used to importing it from `starlite.testing`, and then we can explicitly deprecate importing it in runtime as well.