### PR TITLE
Override `TestClient.__enter__()` to support downstream typing.

### DIFF
--- a/starlite/testing.py
+++ b/starlite/testing.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Tuple, TypeVar, Union, cast
 from urllib.parse import urlencode
 
 from orjson import dumps
@@ -64,6 +64,9 @@ class RequestEncoder(RequestEncodingMixin):
         return self._encode_params(data).encode("utf-8")  # type: ignore
 
 
+T_client = TypeVar("T_client", bound="TestClient")
+
+
 class TestClient(StarletteTestClient):
     app: Starlite
 
@@ -84,6 +87,25 @@ class TestClient(StarletteTestClient):
             backend=backend,
             backend_options=backend_options,
         )
+
+    def __enter__(self: T_client, *args: Any, **kwargs: Any) -> T_client:
+        """
+        Starlette's `TestClient.__enter__()` return value is strongly typed to return their own
+        `TestClient`, i.e., not-generic to support subclassing.
+
+        Override here to provide a nicer typing experience downstream from us.
+
+        Parameters
+        ----------
+        args : Any
+        kwargs : Any
+            `*args, **kwargs` passed straight through to `Starlette.testing.TestClient.__enter__()`
+
+        Returns
+        -------
+        TestClient
+        """
+        return super().__enter__(*args, **kwargs)  # type:ignore[return-value]
 
 
 def create_test_client(

--- a/starlite/testing.py
+++ b/starlite/testing.py
@@ -93,7 +93,7 @@ class TestClient(StarletteTestClient):
         Starlette's `TestClient.__enter__()` return value is strongly typed to return their own
         `TestClient`, i.e., not-generic to support subclassing.
 
-        Override here to provide a nicer typing experience downstream from us.
+        We override here to provide a nicer typing experience for our users.
 
         Parameters
         ----------

--- a/tests/app/test_lifecycle.py
+++ b/tests/app/test_lifecycle.py
@@ -1,8 +1,5 @@
-from typing import cast
-
-from starlite import Starlite, State
+from starlite import State
 from starlite.testing import create_test_client
-
 
 def test_lifecycle() -> None:
     counter = {"value": 0}
@@ -41,9 +38,8 @@ def test_lifecycle() -> None:
         ],
     ) as client:
         assert counter["value"] == 4
-        app = cast(Starlite, client.app)
-        assert app.state.x
-        assert app.state.y
+        assert client.app.state.x
+        assert client.app.state.y
         counter["value"] = 0
         assert counter["value"] == 0
     assert counter["value"] == 4

--- a/tests/app/test_lifecycle.py
+++ b/tests/app/test_lifecycle.py
@@ -1,6 +1,7 @@
 from starlite import State
 from starlite.testing import create_test_client
 
+
 def test_lifecycle() -> None:
     counter = {"value": 0}
 

--- a/tests/kwargs/test_reserved_kwargs_injection.py
+++ b/tests/kwargs/test_reserved_kwargs_injection.py
@@ -10,7 +10,6 @@ from starlite import (
     HttpMethod,
     MediaType,
     Request,
-    Starlite,
     State,
     delete,
     get,
@@ -30,12 +29,11 @@ def test_application_state_injection() -> None:
         return cast(str, state.msg)  # this shows injection worked
 
     with create_test_client(route_handler) as client:
-        state = cast(Starlite, client.app).state
-        state.msg = "hello"
-        state.called = False
+        client.app.state.msg = "hello"
+        client.app.state.called = False
         response = client.get("/")
         assert response.text == "hello"
-        assert not state.called
+        assert not client.app.state.called
 
 
 class QueryParams(BaseModel):

--- a/tests/openapi/test_integration.py
+++ b/tests/openapi/test_integration.py
@@ -1,11 +1,8 @@
-from typing import cast
-
 import yaml
 from openapi_schema_pydantic.util import construct_open_api_with_schema_class
 from orjson import loads
 from starlette.status import HTTP_200_OK
 
-from starlite import Starlite
 from starlite.app import DEFAULT_OPENAPI_CONFIG
 from starlite.enums import OpenAPIMediaType
 from starlite.testing import create_test_client
@@ -14,27 +11,25 @@ from tests.openapi.utils import PersonController, PetController
 
 def test_openapi_yaml() -> None:
     with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
-        app = cast(Starlite, client.app)
-        assert app.openapi_schema
-        openapi_schema = app.openapi_schema
+        assert client.app.openapi_schema
+        openapi_schema = client.app.openapi_schema
         assert openapi_schema.paths
         response = client.get("/schema/openapi.yaml")
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"] == OpenAPIMediaType.OPENAPI_YAML.value
-        assert yaml.safe_load(response.content) == construct_open_api_with_schema_class(app.openapi_schema).dict(
+        assert yaml.safe_load(response.content) == construct_open_api_with_schema_class(client.app.openapi_schema).dict(
             by_alias=True, exclude_none=True
         )
 
 
 def test_openapi_json() -> None:
     with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
-        app = cast(Starlite, client.app)
-        assert app.openapi_schema
-        openapi_schema = app.openapi_schema
+        assert client.app.openapi_schema
+        openapi_schema = client.app.openapi_schema
         assert openapi_schema.paths
         response = client.get("/schema/openapi.json")
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"] == OpenAPIMediaType.OPENAPI_JSON.value
         assert response.json() == loads(
-            construct_open_api_with_schema_class(app.openapi_schema).json(by_alias=True, exclude_none=True)
+            construct_open_api_with_schema_class(client.app.openapi_schema).json(by_alias=True, exclude_none=True)
         )

--- a/tests/openapi/test_schema.py
+++ b/tests/openapi/test_schema.py
@@ -1,4 +1,4 @@
-from typing import Generic, TypeVar, cast
+from typing import Generic, TypeVar
 
 import pytest
 from openapi_schema_pydantic import Example
@@ -78,8 +78,7 @@ def test_dependency_schema_generation() -> None:
         dependencies={"top_level": Provide(top_dependency)},
         openapi_config=DEFAULT_OPENAPI_CONFIG,
     ) as client:
-        app = cast(Starlite, client.app)
-        handler = app.openapi_schema.paths["/test/{path_param}"]
+        handler = client.app.openapi_schema.paths["/test/{path_param}"]
         data = {param.name: {"in": param.param_in, "required": param.required} for param in handler.get.parameters}
         assert data == {
             "path_param": {"in": "path", "required": True},

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -75,7 +75,7 @@ def test_cache_key() -> None:
         route_handlers=[get("/cached", cache=True, cache_key_builder=custom_cache_key_builder)(slow_handler)]
     ) as client:
         client.get("/cached")
-        assert client.app.cache_config.backend.get("/cached:::cached")  # type: ignore
+        assert client.app.cache_config.backend.get("/cached:::cached")
 
 
 def test_async_handling() -> None:


### PR DESCRIPTION
- types our `TestClient` such that it should support subclassing downstream.
- remove redundant casts and ignores from our own source.

Closes #182