### PR TITLE
Change to order of exception handler resolution.

### DIFF
--- a/starlite/utils/exception.py
+++ b/starlite/utils/exception.py
@@ -1,5 +1,5 @@
 from inspect import getmro
-from typing import Dict, Optional, Type, Union, cast
+from typing import Dict, Optional, Type, Union
 
 from starlette.exceptions import HTTPException
 from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
@@ -13,16 +13,33 @@ def get_exception_handler(
     """
     Given a dictionary that maps exceptions and status codes to handler functions,
     and an exception, returns the appropriate handler if existing.
+
+    Status codes are given preference over exception type.
+
+    If no status code match exists, each class in the MRO of the exception type is checked and
+    the first matching handler is returned.
+
+    Finally, if a `500` handler is registered, it will be returned for any exception that isn't a
+    subclass of `HTTPException`.
+
+    Parameters
+    ----------
+    exception_handlers : dict[int | type[Exception], ExceptionHandler]
+        Mapping of status codes and exception types to handlers.
+    exc : Exception
+        Instance to be resolved to a handler.
+
+    Returns
+    -------
+    Exception | None
     """
     if not exception_handlers:
         return None
     if isinstance(exc, HTTPException) and exc.status_code in exception_handlers:
         return exception_handlers[exc.status_code]
-    if type(exc) in exception_handlers:
-        return exception_handlers[type(exc)]
-    if HTTP_500_INTERNAL_SERVER_ERROR in exception_handlers:
-        return exception_handlers[HTTP_500_INTERNAL_SERVER_ERROR]
     for cls in getmro(type(exc)):
         if cls in exception_handlers:
-            return exception_handlers[cast(Type[Exception], cls)]
+            return exception_handlers[cls]
+    if not isinstance(exc, HTTPException) and HTTP_500_INTERNAL_SERVER_ERROR in exception_handlers:
+        return exception_handlers[HTTP_500_INTERNAL_SERVER_ERROR]
     return None

--- a/tests/utils/test_exceptions.py
+++ b/tests/utils/test_exceptions.py
@@ -3,12 +3,16 @@ from typing import Any, Dict, Type, Union
 import pytest
 from starlette.status import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
 
-from starlite import InternalServerException, ValidationException
+from starlite import HTTPException, InternalServerException, ValidationException
 from starlite.types import ExceptionHandler
 from starlite.utils.exception import get_exception_handler
 
 
 def handler(_: Any, __: Any) -> Any:
+    return None
+
+
+def handler_2(_: Any, __: Any) -> Any:
     return None
 
 
@@ -23,6 +27,11 @@ def handler(_: Any, __: Any) -> Any:
         ({Exception: handler}, ValidationException(), handler),
         ({ValueError: handler}, ValidationException(), handler),
         ({ValidationException: handler}, Exception(), None),
+        ({HTTP_500_INTERNAL_SERVER_ERROR: handler}, ValidationException(), None),
+        ({HTTP_500_INTERNAL_SERVER_ERROR: handler, HTTPException: handler_2}, ValidationException(), handler_2),
+        ({HTTPException: handler, ValidationException: handler_2}, ValidationException(), handler_2),
+        ({HTTPException: handler, ValidationException: handler_2}, InternalServerException(), handler),
+        ({HTTP_500_INTERNAL_SERVER_ERROR: handler, HTTPException: handler_2}, InternalServerException(), handler),
     ],
 )
 def test_get_exception_handler(


### PR DESCRIPTION
- check the MRO before checking for a 500 handler
- only use the 500 handler for non-HTTPException exceptions
- description of algo in docstring
- add tests with multiple handlers in `exception_handlers` mapping

Closes #176 