### PR TITLE
Fix mypy errors after openapi-schema-pydantic update.

### DIFF
--- a/starlite/openapi/path_item.py
+++ b/starlite/openapi/path_item.py
@@ -50,7 +50,7 @@ def create_path_item(route: "HTTPRoute", create_examples: bool) -> PathItem:
                     generate_examples=create_examples,
                 ),
                 requestBody=request_body,
-                parameters=parameters,  # type: ignore[arg-type]
+                parameters=parameters,
             )
             setattr(path_item, http_method.lower(), operation)
     return path_item

--- a/starlite/openapi/responses.py
+++ b/starlite/openapi/responses.py
@@ -139,7 +139,7 @@ def create_error_responses(exceptions: List[Type[HTTPException]]) -> Iterator[Tu
             for exc in exception_group
         ]
         if len(exceptions_schemas) > 1:
-            schema = Schema(oneOf=exceptions_schemas)  # type:ignore[arg-type]
+            schema = Schema(oneOf=exceptions_schemas)
         else:
             schema = exceptions_schemas[0]
         yield str(status_code), Response(

--- a/starlite/openapi/schema.py
+++ b/starlite/openapi/schema.py
@@ -108,7 +108,7 @@ def create_collection_constrained_field_schema(
     if sub_fields:
         items = [create_schema(field=sub_field, generate_examples=False) for sub_field in sub_fields]
         if len(items) > 1:
-            schema.items = Schema(oneOf=items)  # type: ignore[arg-type]
+            schema.items = Schema(oneOf=items)
         else:
             schema.items = items[0]
     else:
@@ -216,7 +216,7 @@ def create_schema(field: ModelField, generate_examples: bool, ignore_optional: b
         if openapi_type == OpenAPIType.ARRAY:
             items = [create_schema(field=sub_field, generate_examples=False) for sub_field in field.sub_fields]
             if len(items) > 1:
-                schema.items = Schema(oneOf=items)  # type: ignore[arg-type]
+                schema.items = Schema(oneOf=items)
             else:
                 schema.items = items[0]
     else:

--- a/starlite/types.py
+++ b/starlite/types.py
@@ -112,7 +112,7 @@ class Partial(Generic[T]):
         return cast(Type[T], cls._models.get(item))
 
 
-class ResponseHeader(Header):
+class ResponseHeader(Header):  # type:ignore[misc]
     value: Any = ...
 
 

--- a/tests/openapi/test_constrained_fields.py
+++ b/tests/openapi/test_constrained_fields.py
@@ -25,7 +25,7 @@ from tests.openapi.utils import (
 def test_create_collection_constrained_field_schema(field_type: Any) -> None:
     schema = create_collection_constrained_field_schema(field_type=field_type, sub_fields=None)
     assert schema.type == OpenAPIType.ARRAY
-    assert schema.items.type == OpenAPIType.INTEGER  # type: ignore
+    assert schema.items.type == OpenAPIType.INTEGER
     assert schema.minItems == field_type.min_items
     assert schema.maxItems == field_type.max_items
 

--- a/tests/openapi/test_parameters.py
+++ b/tests/openapi/test_parameters.py
@@ -16,7 +16,7 @@ def test_create_parameters() -> None:
     app = Starlite(route_handlers=[PersonController])
     index = find_index(app.routes, lambda x: x.path_format == "/{service_id}/person")
     route = app.routes[index]
-    route_handler = route.route_handler_map["GET"][0]  # type: ignore
+    route_handler = route.route_handler_map["GET"][0]  # type:ignore[attr-defined]
     parameters = create_parameters(
         route_handler=route_handler,
         handler_fields=model_function_signature(
@@ -29,38 +29,38 @@ def test_create_parameters() -> None:
     page, name, page_size, service_id, from_date, to_date, gender, secret_header, cookie_value = tuple(parameters)
     assert service_id.name == "service_id"
     assert service_id.param_in == "path"
-    assert service_id.param_schema.type == OpenAPIType.INTEGER  # type: ignore
+    assert service_id.param_schema.type == OpenAPIType.INTEGER
     assert service_id.required
-    assert service_id.param_schema.examples  # type: ignore
+    assert service_id.param_schema.examples
     assert page.param_in == "query"
     assert page.name == "page"
-    assert page.param_schema.type == OpenAPIType.INTEGER  # type: ignore
+    assert page.param_schema.type == OpenAPIType.INTEGER
     assert page.required
-    assert page.param_schema.examples  # type: ignore
+    assert page.param_schema.examples
     assert page_size.param_in == "query"
     assert page_size.name == "pageSize"
-    assert page_size.param_schema.type == OpenAPIType.INTEGER  # type: ignore
+    assert page_size.param_schema.type == OpenAPIType.INTEGER
     assert page_size.required
     assert page_size.description == "Page Size Description"
-    assert page_size.param_schema.examples[0].value == 1  # type: ignore
+    assert page_size.param_schema.examples[0].value == 1
     assert name.param_in == "query"
     assert name.name == "name"
-    assert len(name.param_schema.oneOf) == 3  # type: ignore
+    assert len(name.param_schema.oneOf) == 3
     assert not name.required
-    assert name.param_schema.examples  # type: ignore
+    assert name.param_schema.examples
     assert from_date.param_in == "query"
     assert from_date.name == "from_date"
-    assert len(from_date.param_schema.oneOf) == 4  # type: ignore
+    assert len(from_date.param_schema.oneOf) == 4
     assert not from_date.required
-    assert from_date.param_schema.examples  # type: ignore
+    assert from_date.param_schema.examples
     assert to_date.param_in == "query"
     assert to_date.name == "to_date"
-    assert len(to_date.param_schema.oneOf) == 4  # type: ignore
+    assert len(to_date.param_schema.oneOf) == 4
     assert not to_date.required
-    assert to_date.param_schema.examples  # type: ignore
+    assert to_date.param_schema.examples
     assert gender.param_in == "query"
     assert gender.name == "gender"
-    assert gender.param_schema.dict(exclude_none=True) == {  # type: ignore
+    assert gender.param_schema.dict(exclude_none=True) == {
         "oneOf": [
             {"type": "null"},
             {"type": "string", "enum": ["M", "F", "O", "A"]},
@@ -70,13 +70,13 @@ def test_create_parameters() -> None:
     }
     assert not gender.required
     assert secret_header.param_in == "header"
-    assert secret_header.param_schema.type == OpenAPIType.STRING  # type: ignore
+    assert secret_header.param_schema.type == OpenAPIType.STRING
     assert secret_header.required
-    assert secret_header.param_schema.examples  # type: ignore
+    assert secret_header.param_schema.examples
     assert cookie_value.param_in == "cookie"
-    assert cookie_value.param_schema.type == OpenAPIType.INTEGER  # type: ignore
+    assert cookie_value.param_schema.type == OpenAPIType.INTEGER
     assert cookie_value.required
-    assert cookie_value.param_schema.examples  # type: ignore
+    assert cookie_value.param_schema.examples
 
 
 def test_deduplication_for_param_where_key_and_type_equal() -> None:
@@ -101,10 +101,10 @@ def test_deduplication_for_param_where_key_and_type_equal() -> None:
         return "OK"
 
     app = Starlite(route_handlers=[handler], openapi_config=DEFAULT_OPENAPI_CONFIG)
-    open_api_path_item = cast(OpenAPI, app.openapi_schema).paths["/test"]  # type: ignore
-    open_api_parameters = open_api_path_item.get.parameters  # type: ignore
-    assert len(open_api_parameters) == 2  # type: ignore
-    assert {p.name for p in open_api_parameters} == {"query_param", "other_param"}  # type: ignore
+    open_api_path_item = cast(OpenAPI, app.openapi_schema).paths["/test"]
+    open_api_parameters = open_api_path_item.get.parameters
+    assert len(open_api_parameters) == 2
+    assert {p.name for p in open_api_parameters} == {"query_param", "other_param"}
 
 
 def test_raise_for_multiple_parameters_of_same_name_and_differing_types() -> None:
@@ -131,7 +131,7 @@ def test_dependency_params_in_docs_if_dependency_provided() -> None:
         ...
 
     app = Starlite(route_handlers=[handler])
-    param_name_set = {p.name for p in cast(OpenAPI, app.openapi_schema).paths["/"].get.parameters}  # type: ignore
+    param_name_set = {p.name for p in cast(OpenAPI, app.openapi_schema).paths["/"].get.parameters}
     assert "dep" not in param_name_set
     assert "param" in param_name_set
 
@@ -142,7 +142,7 @@ def test_dependency_not_in_doc_params_if_not_provided() -> None:
         ...
 
     app = Starlite(route_handlers=[handler])
-    assert cast(OpenAPI, app.openapi_schema).paths["/"].get.parameters is None  # type: ignore
+    assert cast(OpenAPI, app.openapi_schema).paths["/"].get.parameters is None
 
 
 def test_non_dependency_in_doc_params_if_not_provided() -> None:
@@ -151,5 +151,5 @@ def test_non_dependency_in_doc_params_if_not_provided() -> None:
         ...
 
     app = Starlite(route_handlers=[handler])
-    param_name_set = {p.name for p in cast(OpenAPI, app.openapi_schema).paths["/"].get.parameters}  # type: ignore
+    param_name_set = {p.name for p in cast(OpenAPI, app.openapi_schema).paths["/"].get.parameters}
     assert "param" in param_name_set

--- a/tests/openapi/test_responses.py
+++ b/tests/openapi/test_responses.py
@@ -25,7 +25,7 @@ from tests.openapi.utils import PersonController, PetController, PetException
 
 def test_create_responses() -> None:
     for route in Starlite(route_handlers=[PersonController]).routes:
-        for route_handler, _ in route.route_handler_map.values():  # type: ignore
+        for route_handler, _ in route.route_handler_map.values():  # type:ignore[attr-defined]
             if route_handler.include_in_schema:
                 responses = create_responses(
                     route_handler=route_handler,
@@ -63,40 +63,40 @@ def test_create_error_responses() -> None:
     )
     assert pet_exc_response[0] == str(PetException.status_code)
     assert pet_exc_response[1].description == HTTPStatus(PetException.status_code).description
-    assert pet_exc_response[1].content[MediaType.JSON]  # type: ignore
-    pet_exc_response_schema = pet_exc_response[1].content[MediaType.JSON].media_type_schema  # type: ignore
-    assert pet_exc_response_schema.examples  # type: ignore
-    assert pet_exc_response_schema.properties  # type: ignore
-    assert pet_exc_response_schema.description  # type: ignore
-    assert pet_exc_response_schema.required  # type: ignore
-    assert pet_exc_response_schema.type  # type: ignore
-    assert not pet_exc_response_schema.oneOf  # type: ignore
+    assert pet_exc_response[1].content[MediaType.JSON]
+    pet_exc_response_schema = pet_exc_response[1].content[MediaType.JSON].media_type_schema
+    assert pet_exc_response_schema.examples
+    assert pet_exc_response_schema.properties
+    assert pet_exc_response_schema.description
+    assert pet_exc_response_schema.required
+    assert pet_exc_response_schema.type
+    assert not pet_exc_response_schema.oneOf
 
     assert permission_denied_exc_response[0] == str(PermissionDeniedException.status_code)
     assert (
         permission_denied_exc_response[1].description == HTTPStatus(PermissionDeniedException.status_code).description
     )
-    assert permission_denied_exc_response[1].content[MediaType.JSON]  # type: ignore
-    media_type_schema = permission_denied_exc_response[1].content[MediaType.JSON].media_type_schema  # type: ignore
-    assert media_type_schema.examples  # type: ignore
-    assert media_type_schema.properties  # type: ignore
-    assert media_type_schema.description  # type: ignore
-    assert media_type_schema.required  # type: ignore
-    assert media_type_schema.type  # type: ignore
-    assert not media_type_schema.oneOf  # type: ignore
+    assert permission_denied_exc_response[1].content[MediaType.JSON]
+    media_type_schema = permission_denied_exc_response[1].content[MediaType.JSON].media_type_schema
+    assert media_type_schema.examples
+    assert media_type_schema.properties
+    assert media_type_schema.description
+    assert media_type_schema.required
+    assert media_type_schema.type
+    assert not media_type_schema.oneOf
 
     assert validation_exc_response[0] == str(ValidationException.status_code)
     assert validation_exc_response[1].description == HTTPStatus(ValidationException.status_code).description
-    assert validation_exc_response[1].content[MediaType.JSON]  # type: ignore
-    media_type_schema = validation_exc_response[1].content[MediaType.JSON].media_type_schema  # type: ignore
-    assert media_type_schema.oneOf  # type: ignore
-    assert len(media_type_schema.oneOf) == 2  # type: ignore
-    for schema in media_type_schema.oneOf:  # type: ignore
-        assert schema.examples  # type: ignore
+    assert validation_exc_response[1].content[MediaType.JSON]
+    media_type_schema = validation_exc_response[1].content[MediaType.JSON].media_type_schema
+    assert media_type_schema.oneOf
+    assert len(media_type_schema.oneOf) == 2
+    for schema in media_type_schema.oneOf:
+        assert schema.examples
         assert schema.description
-        assert schema.properties  # type: ignore
-        assert schema.required  # type: ignore
-        assert schema.type  # type: ignore
+        assert schema.properties
+        assert schema.required
+        assert schema.type
 
 
 def test_create_success_response_with_headers() -> None:
@@ -112,10 +112,16 @@ def test_create_success_response_with_headers() -> None:
 
     response = create_success_response(handler, True)
     assert response.description == "test"
-    assert response.content[handler.media_type.value].media_type_schema.contentEncoding == "base64"  # type: ignore
-    assert response.content[handler.media_type.value].media_type_schema.contentMediaType == "image/png"  # type: ignore
-    assert response.headers["special-header"].param_schema.type == OpenAPIType.INTEGER  # type: ignore
-    assert response.headers["special-header"].description == "super-duper special"  # type: ignore
+    assert (
+        response.content[handler.media_type.value].media_type_schema.contentEncoding  # type:ignore[union-attr]
+        == "base64"
+    )
+    assert (
+        response.content[handler.media_type.value].media_type_schema.contentMediaType  # type:ignore[union-attr]
+        == "image/png"
+    )
+    assert response.headers["special-header"].param_schema.type == OpenAPIType.INTEGER
+    assert response.headers["special-header"].description == "super-duper special"
 
 
 def test_create_success_response_with_stream() -> None:
@@ -134,8 +140,8 @@ def test_create_success_response_redirect() -> None:
 
     response = create_success_response(redirect_handler, True)
     assert response.description == "Redirect Response"
-    assert response.headers["location"].param_schema.type == OpenAPIType.STRING  # type: ignore
-    assert response.headers["location"].description  # type: ignore
+    assert response.headers["location"].param_schema.type == OpenAPIType.STRING
+    assert response.headers["location"].description
 
 
 def test_create_success_response_file_data() -> None:
@@ -145,12 +151,12 @@ def test_create_success_response_file_data() -> None:
 
     response = create_success_response(file_handler, True)
     assert response.description == "File Download"
-    assert response.headers["content-length"].param_schema.type == OpenAPIType.STRING  # type: ignore
-    assert response.headers["content-length"].description  # type: ignore
-    assert response.headers["last-modified"].param_schema.type == OpenAPIType.STRING  # type: ignore
-    assert response.headers["last-modified"].description  # type: ignore
-    assert response.headers["etag"].param_schema.type == OpenAPIType.STRING  # type: ignore
-    assert response.headers["etag"].description  # type: ignore
+    assert response.headers["content-length"].param_schema.type == OpenAPIType.STRING
+    assert response.headers["content-length"].description
+    assert response.headers["last-modified"].param_schema.type == OpenAPIType.STRING
+    assert response.headers["last-modified"].description
+    assert response.headers["etag"].param_schema.type == OpenAPIType.STRING
+    assert response.headers["etag"].description
 
 
 def test_create_success_response_template() -> None:
@@ -160,4 +166,4 @@ def test_create_success_response_template() -> None:
 
     response = create_success_response(template_handler, True)
     assert response.description == "Request fulfilled, document follows"
-    assert response.content[MediaType.HTML]  # type: ignore
+    assert response.content[MediaType.HTML]

--- a/tests/openapi/test_schema.py
+++ b/tests/openapi/test_schema.py
@@ -79,7 +79,7 @@ def test_dependency_schema_generation() -> None:
         openapi_config=DEFAULT_OPENAPI_CONFIG,
     ) as client:
         handler = client.app.openapi_schema.paths["/test/{path_param}"]  # type: ignore
-        data = {param.name: {"in": param.param_in, "required": param.required} for param in handler.get.parameters}  # type: ignore
+        data = {param.name: {"in": param.param_in, "required": param.required} for param in handler.get.parameters}
         assert data == {
             "path_param": {"in": "path", "required": True},
             "header_param": {"in": "header", "required": False},

--- a/tests/openapi/test_tags.py
+++ b/tests/openapi/test_tags.py
@@ -44,12 +44,12 @@ def openapi_schema(app: Starlite) -> OpenAPI:
 
 
 def test_openapi_schema_handler_tags(openapi_schema: OpenAPI) -> None:
-    assert openapi_schema.paths["/handler"].get.tags == ["handler"]  # type: ignore
+    assert openapi_schema.paths["/handler"].get.tags == ["handler"]
 
 
 def test_openapi_schema_controller_tags(openapi_schema: OpenAPI) -> None:
-    assert set(openapi_schema.paths["/controller"].get.tags) == {"handler", "controller"}  # type: ignore
+    assert set(openapi_schema.paths["/controller"].get.tags) == {"handler", "controller"}
 
 
 def test_openapi_schema_router_tags(openapi_schema: OpenAPI) -> None:
-    assert set(openapi_schema.paths["/router/controller"].get.tags) == {"handler", "controller", "router"}  # type: ignore
+    assert set(openapi_schema.paths["/router/controller"].get.tags) == {"handler", "controller", "router"}


### PR DESCRIPTION
Tidy up unnecessary `# type:ignore`'s and add in a few new ones.