### PR TITLE
Refactor of `model_function_signature()` to address complexity limits.

### DIFF
--- a/starlite/app.py
+++ b/starlite/app.py
@@ -31,7 +31,7 @@ from starlite.provide import Provide
 from starlite.response import Response
 from starlite.router import Router
 from starlite.routes import ASGIRoute, BaseRoute, HTTPRoute, WebSocketRoute
-from starlite.signature import model_function_signature
+from starlite.signature import SignatureModelFactory
 from starlite.types import (
     AfterRequestHandler,
     BeforeRequestHandler,
@@ -267,18 +267,18 @@ class Starlite(Router):
         Creates function signature models for all route handler functions and provider dependencies
         """
         if not route_handler.signature_model:
-            route_handler.signature_model = model_function_signature(
+            route_handler.signature_model = SignatureModelFactory(
                 fn=cast(AnyCallable, route_handler.fn),
                 plugins=self.plugins,
                 provided_dependency_names=route_handler.dependency_name_set,
-            )
+            ).model()
         for provider in list(route_handler.resolve_dependencies().values()):
             if not provider.signature_model:
-                provider.signature_model = model_function_signature(
+                provider.signature_model = SignatureModelFactory(
                     fn=provider.dependency,
                     plugins=self.plugins,
                     provided_dependency_names=route_handler.dependency_name_set,
-                )
+                ).model()
 
     def create_openapi_schema_model(self, openapi_config: OpenAPIConfig) -> OpenAPI:
         """

--- a/starlite/utils/dependency.py
+++ b/starlite/utils/dependency.py
@@ -1,29 +1,18 @@
-from typing import AbstractSet, Any
+from typing import Any
 
-from pydantic.fields import FieldInfo, Undefined
-
-from starlite.exceptions import ImproperlyConfiguredException
+from pydantic.fields import FieldInfo
 
 
-def check_for_unprovided_dependency(
-    key: str, field: Any, is_optional: bool, provided_dependency_names: AbstractSet[str], fn_name: str
-) -> None:
+def is_dependency_field(val: Any) -> bool:
     """
-    Where a dependency has been explicitly marked using the ``Dependency`` function, it is a
-    configuration error if that dependency has been defined without a default value, and it hasn't
-    been provided to the handler.
+    Determine if a value is a `FieldInfo` instance created via the `Dependency()` function.
 
-    Raises ``ImproperlyConfiguredException`` where case is detected.
+    Parameters
+    ----------
+    val : Any
+
+    Returns
+    -------
+    bool
     """
-    if is_optional:
-        return
-    if not isinstance(field, FieldInfo):
-        return
-    if not field.extra.get("is_dependency"):
-        return
-    if field.default is not Undefined:
-        return
-    if key not in provided_dependency_names:
-        raise ImproperlyConfiguredException(
-            f"Explicit dependency '{key}' for '{fn_name}' has no default value, or provided dependency."
-        )
+    return isinstance(val, FieldInfo) and bool(val.extra.get("is_dependency"))

--- a/tests/handlers/http/test_to_response.py
+++ b/tests/handlers/http/test_to_response.py
@@ -27,7 +27,7 @@ from starlite import (
     get,
     route,
 )
-from starlite.signature import model_function_signature
+from starlite.signature import SignatureModelFactory
 from starlite.testing import create_test_client
 from tests import Person, PersonFactory
 
@@ -40,7 +40,7 @@ async def test_to_response_async_await() -> None:
         return data
 
     person_instance = PersonFactory.build()
-    test_function.signature_model = model_function_signature(test_function.fn, [], set())  # type: ignore
+    test_function.signature_model = SignatureModelFactory(test_function.fn, [], set()).model()  # type:ignore[arg-type]
 
     response = await test_function.to_response(data=test_function.fn(data=person_instance), plugins=[], app=None)  # type: ignore
     assert loads(response.body) == person_instance.dict()

--- a/tests/openapi/test_parameters.py
+++ b/tests/openapi/test_parameters.py
@@ -7,7 +7,7 @@ from starlite import Dependency, ImproperlyConfiguredException, Provide, Starlit
 from starlite.app import DEFAULT_OPENAPI_CONFIG
 from starlite.openapi.enums import OpenAPIType
 from starlite.openapi.parameters import create_parameters
-from starlite.signature import model_function_signature
+from starlite.signature import SignatureModelFactory
 from starlite.utils import find_index
 from tests.openapi.utils import PersonController
 
@@ -19,9 +19,11 @@ def test_create_parameters() -> None:
     route_handler = route.route_handler_map["GET"][0]  # type: ignore
     parameters = create_parameters(
         route_handler=route_handler,
-        handler_fields=model_function_signature(
+        handler_fields=SignatureModelFactory(
             fn=cast(Callable, route_handler.fn), plugins=[], provided_dependency_names=set()
-        ).__fields__,
+        )
+        .model()
+        .__fields__,
         path_parameters=route.path_parameters,
         generate_examples=True,
     )

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -5,7 +5,7 @@ import pytest
 from starlette.status import HTTP_204_NO_CONTENT
 
 from starlite import ImproperlyConfiguredException, get
-from starlite.signature import model_function_signature
+from starlite.signature import SignatureModelFactory
 
 
 def test_create_function_signature_model_parameter_parsing() -> None:
@@ -13,7 +13,7 @@ def test_create_function_signature_model_parameter_parsing() -> None:
     def my_fn(a: int, b: str, c: Optional[bytes], d: bytes = b"123", e: Optional[dict] = None) -> None:
         pass
 
-    model = model_function_signature(my_fn.fn, [], set())  # type: ignore
+    model = SignatureModelFactory(my_fn.fn, [], set()).model()  # type: ignore[arg-type]
     fields = model.__fields__
     assert fields["a"].type_ == int
     assert fields["a"].required
@@ -35,7 +35,7 @@ def test_create_signature_validation() -> None:
         pass
 
     with pytest.raises(ImproperlyConfiguredException):
-        model_function_signature(my_fn.fn, [], set())  # type: ignore
+        SignatureModelFactory(my_fn.fn, [], set()).model()  # type: ignore[arg-type]
 
 
 def test_create_function_signature_model_ignore_return_annotation() -> None:
@@ -43,9 +43,10 @@ def test_create_function_signature_model_ignore_return_annotation() -> None:
     async def health_check() -> None:
         return
 
-    assert model_function_signature(health_check.fn, [], set())().dict() == {}  # type: ignore
+    signature_model_type = SignatureModelFactory(health_check.fn, [], set()).model()  # type:ignore[arg-type]
+    assert signature_model_type().dict() == {}
 
 
 def test_create_function_signature_model_validation() -> None:
     with pytest.raises(ImproperlyConfiguredException):
-        model_function_signature(lru_cache(maxsize=0)(lambda x: x), [], set())  # type: ignore
+        SignatureModelFactory(lru_cache(maxsize=0)(lambda x: x), [], set()).model().dict()  # type: ignore


### PR DESCRIPTION
- Should be no logical changes.
- Breaks out detailed logic into methods.
- High-level business logic in `.model()` method.
- Added a type to hold interesting properties of the parameters as we iterate over them.
- Docstrings everywhere.