### PR TITLE
Raise exception on routes with duplicate path parameters (#204)

### DIFF
--- a/starlite/routes.py
+++ b/starlite/routes.py
@@ -93,9 +93,7 @@ class BaseRoute:
         for param in self.path_parameters:
             param_name = param["name"]
             if param_name in path_parameters:
-                raise ImproperlyConfiguredException(
-                    f"Duplicate path parameters should not be used. Duplicate parameter {{{param_name}}} found in path {self.path}"
-                )
+                raise ImproperlyConfiguredException(f"Duplicate parameter '{param_name}' detected in '{self.path}'.")
             path_parameters.add(param_name)
         return KwargsModel.create_for_signature_model(
             signature_model=signature_model, dependencies=dependencies, path_parameters=path_parameters

--- a/starlite/routes.py
+++ b/starlite/routes.py
@@ -89,7 +89,14 @@ class BaseRoute:
         """
         dependencies = route_handler.resolve_dependencies()
         signature_model = get_signature_model(route_handler)
-        path_parameters = {p["name"] for p in self.path_parameters}
+        path_parameters = set()
+        for param in self.path_parameters:
+            param_name = param["name"]
+            if param_name in path_parameters:
+                raise ImproperlyConfiguredException(
+                    f"Duplicate path parameters should not be used. Duplicate parameter {{{param_name}}} found in path {self.path}"
+                )
+            path_parameters.add(param_name)
         return KwargsModel.create_for_signature_model(
             signature_model=signature_model, dependencies=dependencies, path_parameters=path_parameters
         )

--- a/tests/kwargs/test_path_params.py
+++ b/tests/kwargs/test_path_params.py
@@ -90,3 +90,12 @@ def test_path_param_validation() -> None:
 
     with pytest.raises(ImproperlyConfiguredException):
         Starlite(route_handlers=[test_method])
+
+
+def test_duplicate_path_param_validation() -> None:
+    @get(path="/{param:int}/foo/{param:int}")
+    def test_method(param: int) -> None:
+        pass
+
+    with pytest.raises(ImproperlyConfiguredException):
+        Starlite(route_handlers=[test_method])


### PR DESCRIPTION
Fixes #204 

Proposed changes to handling duplicate / repeated path parameters in routes.  Raises `ImproperlyConfiguredException` while building the kwargs model for the route that contains the repeated params.