### PR TITLE
Route path edge case handling

### DIFF
--- a/starlite/app.py
+++ b/starlite/app.py
@@ -173,7 +173,7 @@ class Starlite(Router):
 
         return ExceptionHandlerMiddleware(app=app, exception_handlers=exception_handlers, debug=self.debug)
 
-    def construct_route_map(self) -> None:  # noqa: C901
+    def construct_route_map(self) -> None:  # noqa: C901 # pylint: disable=R0912
         """
         Create a map of the app's routes. This map is used in the asgi router to route requests.
 
@@ -195,7 +195,8 @@ class Starlite(Router):
                         cur[component] = {"_components": set()}
                     cur = cast(Dict[str, Any], cur[component])
             else:
-                self.route_map[path] = {"_components": set()}
+                if path not in self.route_map:
+                    self.route_map[path] = {"_components": set()}
                 self.plain_routes.add(path)
                 cur = self.route_map[path]
             if "_path_parameters" not in cur:

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -22,6 +22,7 @@ from starlite.config import (
     TemplateConfig,
 )
 from starlite.datastructures import State
+from starlite.exceptions import ImproperlyConfiguredException
 from starlite.handlers.asgi import ASGIRouteHandler, asgi
 from starlite.handlers.base import BaseRouteHandler
 from starlite.handlers.http import HTTPRouteHandler
@@ -178,6 +179,7 @@ class Starlite(Router):
         Create a map of the app's routes. This map is used in the asgi router to route requests.
 
         """
+        seen_param_paths = set()
         if "_components" not in self.route_map:
             self.route_map["_components"] = set()
         for route in self.routes:
@@ -186,6 +188,9 @@ class Starlite(Router):
                 for param_definition in route.path_parameters:
                     path = path.replace(param_definition["full"], "")
                 path = path.replace("{}", "*")
+                if path in seen_param_paths:
+                    raise ImproperlyConfiguredException("Should not use routes with conflicting path parameters")
+                seen_param_paths.add(path)
                 cur = self.route_map
                 components = ["/", *[component for component in path.split("/") if component]]
                 for component in components:

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -11,7 +11,15 @@ from starlette.status import (
 )
 from typing_extensions import Type
 
-from starlite import Controller, HTTPRouteHandler, MediaType, delete, get, post
+from starlite import (
+    Controller,
+    HTTPRouteHandler,
+    ImproperlyConfiguredException,
+    MediaType,
+    delete,
+    get,
+    post,
+)
 from starlite.testing import create_test_client
 from tests import Person, PersonFactory
 
@@ -170,3 +178,12 @@ def test_path_order() -> None:
         second_response = client.get("/")
         assert second_response.status_code == HTTP_200_OK
         assert second_response.text == "1"
+
+
+def test_conflicting_paths() -> None:
+    @get(path=["/lmno/{a:int}/{b:int}", "/lmno/{c:int}/{d:int}"], media_type=MediaType.TEXT)
+    def handler_fn(a: int = 0, b: int = 0, c: int = 0, d: int = 0) -> None:
+        ...
+
+    with pytest.raises(ImproperlyConfiguredException):
+        create_test_client(handler_fn)

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -156,3 +156,17 @@ async def test_http_route_raises_for_unsupported_method() -> None:
     with create_test_client(route_handlers=[my_get_handler, my_post_handler]) as client:
         response = client.delete("/")
         assert response.status_code == HTTP_405_METHOD_NOT_ALLOWED
+
+
+def test_path_order() -> None:
+    @get(path=["/something/{some_id:int}", "/"], media_type=MediaType.TEXT)
+    def handler_fn(some_id: int = 1) -> str:
+        return str(some_id)
+
+    with create_test_client(handler_fn) as client:
+        first_response = client.get("/something/5")
+        assert first_response.status_code == HTTP_200_OK
+        assert first_response.text == "5"
+        second_response = client.get("/")
+        assert second_response.status_code == HTTP_200_OK
+        assert second_response.text == "1"


### PR DESCRIPTION
This PR addresses two edge cases that were unhandled and not covered by tests.

1. Route resolution within `construct_route_map()` was affected by the order in which paths were given to a route handler. Specifically, if the root path, `/`, was added to `route_map` after parameters paths had already been added (nested under the `/` key in `route_map`), these paths would be lost.
2. Paths with conflicting parameters were allowed, leading to undefined behavior.  This undefined behavior results from paths with conflicting params (see example test) creating a difference between the `expected_path_parameters` for a route and the actual path parameters that exist in a requested path.

```python
# this test passes
def test_conflicting_paths() -> None:
    @get(path=["/foo/{a:int}/{b:int}", "/foo/{c:int}/{d:int}"], media_type=MediaType.TEXT)
    def handler_fn(a: int = 0, b: int = 0, c: int = 0, d: int = 0) -> str:
        return f"{a} {b} {c} {d}"

    with create_test_client(handler_fn) as client:
        resp = client.get("/foo/1/2")
        assert resp.status_code == HTTP_200_OK
        assert resp.text == "0 0 0 0"
```