### PR TITLE
Improve path param validation during registration

### DIFF
--- a/tests/kwargs/test_path_params.py
+++ b/tests/kwargs/test_path_params.py
@@ -83,8 +83,22 @@ def test_path_params(params_dict: dict, should_raise: bool) -> None:
             assert response.status_code == HTTP_200_OK
 
 
-def test_path_param_validation() -> None:
-    @get(path="/{param}")
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/{param}",
+        "/{param:foo}",
+        "/{param:int:int}",
+        "/{:int}",
+        "/{param:}",
+        "/{  :int}",
+        "/{:}",
+        "/{::}",
+        "/{}",
+    ],
+)
+def test_path_param_validation(path: str) -> None:
+    @get(path=path)
     def test_method() -> None:
         pass
 


### PR DESCRIPTION
- Adds more test cases for path parameter validation.
- Splits out parameter validation logic from `parse_path`, creating new `validate_path_parameters` method, and adds checks for new test cases within this method.