### PR TITLE
Issue #255: allow single element query param in sequence types

### DIFF
--- a/starlite/kwargs.py
+++ b/starlite/kwargs.py
@@ -1,16 +1,14 @@
-from array import array
 from typing import Any, Dict, List, NamedTuple, Optional, Set, Tuple, Type, Union, cast
 
-
 from pydantic.fields import (
-    FieldInfo,
-    SHAPE_LIST,
-    SHAPE_SET,
-    SHAPE_SEQUENCE,
-    SHAPE_TUPLE,
-    SHAPE_TUPLE_ELLIPSIS,
     SHAPE_DEQUE,
     SHAPE_FROZENSET,
+    SHAPE_LIST,
+    SHAPE_SEQUENCE,
+    SHAPE_SET,
+    SHAPE_TUPLE,
+    SHAPE_TUPLE_ELLIPSIS,
+    FieldInfo,
     ModelField,
     Undefined,
 )
@@ -28,6 +26,17 @@ from starlite.provide import Provide
 from starlite.signature import SignatureModel, get_signature_model
 from starlite.types import ReservedKwargs
 
+# Shapes corresponding to sequences
+SEQ_SHAPES = {
+    SHAPE_LIST,
+    SHAPE_SET,
+    SHAPE_SEQUENCE,
+    SHAPE_TUPLE,
+    SHAPE_TUPLE_ELLIPSIS,
+    SHAPE_DEQUE,
+    SHAPE_FROZENSET,
+}
+
 
 class ParameterDefinition(NamedTuple):
     param_type: ParamType
@@ -35,7 +44,7 @@ class ParameterDefinition(NamedTuple):
     field_alias: str
     is_required: bool
     default_value: Any
-    is_array: bool
+    is_sequence: bool
 
 
 class Dependency:
@@ -64,18 +73,6 @@ def merge_parameter_sets(first: Set[ParameterDefinition], second: Set[ParameterD
     return result
 
 
-def is_array(model_field: ModelField):
-    return model_field.shape in [
-        SHAPE_LIST,
-        SHAPE_SET,
-        SHAPE_SEQUENCE,
-        SHAPE_TUPLE,
-        SHAPE_TUPLE_ELLIPSIS,
-        SHAPE_DEQUE,
-        SHAPE_FROZENSET,
-    ]
-
-
 class KwargsModel:
     """
     This class is used to model the required kwargs for a given handler and its dependencies.
@@ -91,7 +88,7 @@ class KwargsModel:
         "expected_path_params",
         "expected_query_params",
         "expected_reserved_kwargs",
-        "array_query_parameter_names",
+        "sequence_query_parameter_names",
     )
 
     def __init__(
@@ -104,7 +101,7 @@ class KwargsModel:
         expected_path_params: Set[ParameterDefinition],
         expected_query_params: Set[ParameterDefinition],
         expected_reserved_kwargs: Set[ReservedKwargs],
-        array_query_parameter_names: Set[str],
+        sequence_query_parameter_names: Set[str],
     ) -> None:
         self.expected_cookie_params = expected_cookie_params
         self.expected_dependencies = expected_dependencies
@@ -113,7 +110,7 @@ class KwargsModel:
         self.expected_path_params = expected_path_params
         self.expected_query_params = expected_query_params
         self.expected_reserved_kwargs = expected_reserved_kwargs
-        self.array_query_parameter_names = array_query_parameter_names
+        self.sequence_query_parameter_names = sequence_query_parameter_names
         self.has_kwargs = (
             expected_cookie_params
             or expected_dependencies
@@ -139,7 +136,7 @@ class KwargsModel:
 
     @staticmethod
     def create_parameter_definition(
-        allow_none: bool, field_info: FieldInfo, field_name: str, path_parameters: Set[str], is_array: bool
+        allow_none: bool, field_info: FieldInfo, field_name: str, path_parameters: Set[str], is_sequence: bool
     ) -> ParameterDefinition:
         """
         Creates a ParameterDefition for the given pydantic FieldInfo instance and inserts it into the correct parameter set
@@ -167,7 +164,7 @@ class KwargsModel:
             field_alias=field_alias,
             default_value=default_value,
             is_required=is_required and (default_value is None and not allow_none),
-            is_array=is_array,
+            is_sequence=is_sequence,
         )
 
     @classmethod
@@ -207,7 +204,7 @@ class KwargsModel:
                     field_name=field_name,
                     field_info=model_field.field_info,
                     path_parameters=path_parameters,
-                    is_array=is_array(model_field),
+                    is_sequence=model_field.shape in SEQ_SHAPES,
                 )
                 for field_name, model_field in layered_parameters.items()
                 if field_name not in ignored_keys and field_name not in signature_model.__fields__
@@ -218,7 +215,7 @@ class KwargsModel:
                     field_name=field_name,
                     field_info=model_field.field_info,
                     path_parameters=path_parameters,
-                    is_array=is_array(model_field),
+                    is_sequence=model_field.shape in SEQ_SHAPES,
                 )
                 for field_name, model_field in signature_model.__fields__.items()
                 if field_name not in ignored_keys and field_name not in layered_parameters
@@ -249,7 +246,7 @@ class KwargsModel:
                     field_name=field_name,
                     field_info=field_info,
                     path_parameters=path_parameters,
-                    is_array=is_array(model_field),
+                    is_sequence=model_field.shape in SEQ_SHAPES,
                 )
             )
 
@@ -257,9 +254,9 @@ class KwargsModel:
         expected_header_parameters = {p for p in param_definitions if p.param_type == ParamType.HEADER}
         expected_cookie_parameters = {p for p in param_definitions if p.param_type == ParamType.COOKIE}
         expected_query_parameters = {p for p in param_definitions if p.param_type == ParamType.QUERY}
-        array_query_parameter_names = set(
-            p.field_alias for p in param_definitions if p.param_type == ParamType.QUERY and p.is_array
-        )
+        sequence_query_parameter_names = {
+            p.field_alias for p in param_definitions if p.param_type == ParamType.QUERY and p.is_sequence
+        }
 
         expected_form_data = None
         data_model_field = signature_model.__fields__.get("data")
@@ -304,7 +301,7 @@ class KwargsModel:
             expected_cookie_params=expected_cookie_parameters,
             expected_header_params=expected_header_parameters,
             expected_reserved_kwargs=cast(Set[ReservedKwargs], expected_reserved_kwargs),
-            array_query_parameter_names=array_query_parameter_names,
+            sequence_query_parameter_names=sequence_query_parameter_names,
         )
 
     @classmethod
@@ -372,15 +369,19 @@ class KwargsModel:
                 f"The following kwargs have been used: {', '.join(used_reserved_kwargs)}"
             )
 
+    def _sequence_or_scalar_param(self, key: str, value: List[str]) -> Union[str, List[str]]:
+        """
+        Returns the first element of 'value' if we expect it to be a scalar value (appears in self.sequence_query_parameter_names)
+        and it contains only a single element.
+        """
+        return value[0] if key not in self.sequence_query_parameter_names and len(value) == 1 else value
+
     def to_kwargs(self, connection: Union[WebSocket, Request]) -> Dict[str, Any]:
         """
         Return a dictionary of kwargs. Async values, i.e. CoRoutines, are not resolved to ensure this function is sync.
         """
         reserved_kwargs: Dict[str, Any] = {}
-        connection_query_params = {
-            k: v[0] if k not in self.array_query_parameter_names and len(v) == 1 else v
-            for k, v in connection.query_params.items()
-        }
+        connection_query_params = {k: self._sequence_or_scalar_param(k, v) for k, v in connection.query_params.items()}
         if self.expected_reserved_kwargs:
             if "state" in self.expected_reserved_kwargs:
                 reserved_kwargs["state"] = connection.app.state.copy()

--- a/starlite/parsers.py
+++ b/starlite/parsers.py
@@ -1,17 +1,6 @@
 from contextlib import suppress
 from functools import reduce
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    Optional,
-    Set,
-    Tuple,
-    Type,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type, Union, cast
 from urllib.parse import parse_qsl
 
 from orjson import JSONDecodeError, loads
@@ -43,7 +32,7 @@ def _query_param_reducer(acc: Dict[str, List[str]], cur: Tuple[str, str]) -> Dic
     if param is None:
         acc[key] = [value]
     else:
-        acc[key].append(value)  # type: ignore
+        acc[key].append(value)
     return acc
 
 

--- a/starlite/parsers.py
+++ b/starlite/parsers.py
@@ -1,6 +1,17 @@
 from contextlib import suppress
 from functools import reduce
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Type, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 from urllib.parse import parse_qsl
 
 from orjson import JSONDecodeError, loads
@@ -17,9 +28,7 @@ _true_values = {"True", "true"}
 _false_values = {"False", "false"}
 
 
-def _query_param_reducer(
-    acc: Dict[str, Union[str, List[str]]], cur: Tuple[str, str]
-) -> Dict[str, Union[str, List[str]]]:
+def _query_param_reducer(acc: Dict[str, List[str]], cur: Tuple[str, str]) -> Dict[str, List[str]]:
     """
     Reducer function - acc is a dictionary, cur is a tuple of key + value
 
@@ -32,9 +41,7 @@ def _query_param_reducer(
         value = False  # type: ignore
     param = acc.get(key)
     if param is None:
-        acc[key] = value
-    elif isinstance(param, str):
-        acc[key] = [param, value]
+        acc[key] = [value]
     else:
         acc[key].append(value)  # type: ignore
     return acc

--- a/tests/kwargs/test_query_params.py
+++ b/tests/kwargs/test_query_params.py
@@ -1,5 +1,16 @@
 from datetime import datetime
-from typing import Any, Deque, Dict, FrozenSet, List, MutableSequence, Optional, Set, Tuple, Union
+from typing import (
+    Any,
+    Deque,
+    Dict,
+    FrozenSet,
+    List,
+    MutableSequence,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 from urllib.parse import urlencode
 
 import pytest

--- a/tests/kwargs/test_query_params.py
+++ b/tests/kwargs/test_query_params.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Deque, Dict, FrozenSet, List, MutableSequence, Optional, Set, Tuple, Union
 from urllib.parse import urlencode
 
 import pytest
@@ -78,6 +78,16 @@ from starlite.testing import create_test_client
             },
             False,
         ),
+        (
+            {
+                "page": 1,
+                "pageSize": 1,
+                "brands": ["Nike"],
+                "from_date": datetime.now().timestamp(),
+                "to_date": datetime.now().timestamp(),
+            },
+            False,
+        ),
     ],
 )
 def test_query_params(params_dict: dict, should_raise: bool) -> None:
@@ -103,3 +113,65 @@ def test_query_params(params_dict: dict, should_raise: bool) -> None:
             assert response.status_code == HTTP_400_BAD_REQUEST
         else:
             assert response.status_code == HTTP_200_OK
+
+
+@pytest.mark.parametrize(
+    "expected_type,provided_value,default,expected_response_code",
+    [
+        (List[int], [1, 2, 3], ..., HTTP_200_OK),
+        (List[int], [1], ..., HTTP_200_OK),
+        (List[str], ["foo", "bar"], Parameter(min_items=1), HTTP_200_OK),
+        (List[str], ["foo", "bar"], Parameter(min_items=3), HTTP_400_BAD_REQUEST),
+        (List[int], ["foo", "bar"], ..., HTTP_400_BAD_REQUEST),
+        (Tuple[int, str, int], (1, "foo", 2), ..., HTTP_200_OK),
+        (Optional[List[str]], [], None, HTTP_200_OK),
+        (Any, [1, 2, 3], ..., HTTP_200_OK),
+        (Union[int, List[int]], [1, 2, 3], None, HTTP_200_OK),
+        (Union[int, List[int]], [1], None, HTTP_200_OK),
+        (Deque[int], [1, 2, 3], None, HTTP_200_OK),
+        (Set[int], [1, 2, 3], None, HTTP_200_OK),
+        (FrozenSet[int], [1, 2, 3], None, HTTP_200_OK),
+        (Tuple[int, ...], [1, 2, 3], None, HTTP_200_OK),
+        (MutableSequence[int], [1, 2, 3], None, HTTP_200_OK),
+    ],
+)
+def test_query_param_arrays(expected_type: Any, provided_value: Any, default: Any, expected_response_code: int) -> None:
+    test_path = "/test"
+
+    @get(test_path)
+    def test_method_with_default(param: Any = default) -> None:
+        return None
+
+    @get(test_path)
+    def test_method_without_default(param: Any) -> None:
+        return None
+
+    test_method = test_method_without_default if default is ... else test_method_with_default
+    # Set the type annotation of 'param' in a way mypy can deal with
+    test_method.fn.__annotations__["param"] = expected_type
+
+    with create_test_client(test_method) as client:
+        params = urlencode({"param": provided_value}, doseq=True)
+        response = client.get(f"{test_path}?{params}")
+        assert response.status_code == expected_response_code
+
+
+def test_query_kwarg() -> None:
+    test_path = "/test"
+
+    params = urlencode(
+        {
+            "a": ["foo", "bar"],
+            "b": "qux",
+        },
+        doseq=True,
+    )
+
+    @get(test_path)
+    def test_method(a: List[str], b: List[str], query: Dict[str, Union[str, List[str]]]) -> None:
+        assert query == {"a": ["foo", "bar"], "b": ["qux"]}
+        return None
+
+    with create_test_client(test_method) as client:
+        response = client.get(f"{test_path}?{params}")
+        assert response.status_code == HTTP_200_OK

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -12,4 +12,10 @@ def test_parse_query_params() -> None:
     }
     request = create_test_request(query=query)  # type: ignore
     result = parse_query_params(connection=request)
-    assert result == query
+    assert result == {
+        "value": ["10"],
+        "veggies": ["tomato", "potato", "aubergine"],
+        "calories": ["122.53"],
+        "healthy": [True],
+        "polluting": [False],
+    }


### PR DESCRIPTION
Resolves #255 

Query parameters declared as `List[T]` will be parsed in as arrays even if they only have one element.