### PR TITLE
Refactor `Starlite.construct_route_map`

### DIFF
--- a/starlite/app.py
+++ b/starlite/app.py
@@ -171,55 +171,69 @@ class Starlite(Router):
 
         return ExceptionHandlerMiddleware(app=app, exception_handlers=exception_handlers, debug=self.debug)
 
-    def construct_route_map(self) -> None:  # noqa: C901 # pylint: disable=R0912
+    def add_node_to_route_map(self, route: BaseRoute) -> Dict[str, Any]:
+        """
+        Adds a new route path (e.g. '/foo/bar/{param:int}') into the route_map tree.
+
+        Inserts non-parameter paths ('plain routes') off the tree's root node.
+        For paths containing parameters, splits the path on '/' and nests each path
+        segment under the previous segment's node (see prefix tree / trie).
+        """
+        cur_node = self.route_map
+        path = route.path
+        if route.path_parameters or path in self.static_paths:
+            for param_definition in route.path_parameters:
+                path = path.replace(param_definition["full"], "")
+            path = path.replace("{}", "*")
+            components = ["/", *[component for component in path.split("/") if component]]
+            for component in components:
+                components_set = cast(Set[str], cur_node["_components"])
+                components_set.add(component)
+                if component not in cur_node:
+                    cur_node[component] = {"_components": set()}
+                cur_node = cast(Dict[str, Any], cur_node[component])
+        else:
+            if path not in self.route_map:
+                self.route_map[path] = {"_components": set()}
+            self.plain_routes.add(path)
+            cur_node = self.route_map[path]
+        self.configure_route_map_node(route, cur_node)
+        return cur_node
+
+    def configure_route_map_node(self, route: BaseRoute, node: Dict[str, Any]) -> None:
+        """
+        Set required attributes and route handlers on route_map tree node.
+        """
+        if "_path_parameters" not in node:
+            node["_path_parameters"] = route.path_parameters
+        if "_asgi_handlers" not in node:
+            node["_asgi_handlers"] = {}
+        if "_is_asgi" not in node:
+            node["_is_asgi"] = False
+        if route.path in self.static_paths:
+            node["static_path"] = route.path
+            node["_is_asgi"] = True
+        asgi_handlers = cast(Dict[str, ASGIApp], node["_asgi_handlers"])
+        if isinstance(route, HTTPRoute):
+            for method, handler_mapping in route.route_handler_map.items():
+                handler, _ = handler_mapping
+                asgi_handlers[method] = self.build_route_middleware_stack(route, handler)
+        elif isinstance(route, WebSocketRoute):
+            asgi_handlers["websocket"] = self.build_route_middleware_stack(route, route.route_handler)
+        elif isinstance(route, ASGIRoute):
+            asgi_handlers["asgi"] = self.build_route_middleware_stack(route, route.route_handler)
+            node["_is_asgi"] = True
+
+    def construct_route_map(self) -> None:
         """
         Create a map of the app's routes. This map is used in the asgi router to route requests.
-
         """
-        seen_param_paths = set()
         if "_components" not in self.route_map:
             self.route_map["_components"] = set()
         for route in self.routes:
-            path = route.path
-            if route.path_parameters or path in self.static_paths:
-                for param_definition in route.path_parameters:
-                    path = path.replace(param_definition["full"], "")
-                path = path.replace("{}", "*")
-                if path in seen_param_paths:
-                    raise ImproperlyConfiguredException("Should not use routes with conflicting path parameters")
-                seen_param_paths.add(path)
-                cur = self.route_map
-                components = ["/", *[component for component in path.split("/") if component]]
-                for component in components:
-                    components_set = cast(Set[str], cur["_components"])
-                    components_set.add(component)
-                    if component not in cur:
-                        cur[component] = {"_components": set()}
-                    cur = cast(Dict[str, Any], cur[component])
-            else:
-                if path not in self.route_map:
-                    self.route_map[path] = {"_components": set()}
-                self.plain_routes.add(path)
-                cur = self.route_map[path]
-            if "_path_parameters" not in cur:
-                cur["_path_parameters"] = route.path_parameters
-            if "_asgi_handlers" not in cur:
-                cur["_asgi_handlers"] = {}
-            if "_is_asgi" not in cur:
-                cur["_is_asgi"] = False
-            if path in self.static_paths:
-                cur["static_path"] = path
-                cur["_is_asgi"] = True
-            asgi_handlers = cast(Dict[str, ASGIApp], cur["_asgi_handlers"])
-            if isinstance(route, HTTPRoute):
-                for method, handler_mapping in route.route_handler_map.items():
-                    handler, _ = handler_mapping
-                    asgi_handlers[method] = self.build_route_middleware_stack(route, handler)
-            elif isinstance(route, WebSocketRoute):
-                asgi_handlers["websocket"] = self.build_route_middleware_stack(route, route.route_handler)
-            elif isinstance(route, ASGIRoute):
-                asgi_handlers["asgi"] = self.build_route_middleware_stack(route, route.route_handler)
-                cur["_is_asgi"] = True
+            node = self.add_node_to_route_map(route)
+            if node["_path_parameters"] != route.path_parameters:
+                raise ImproperlyConfiguredException("Should not use routes with conflicting path parameters")
 
     def build_route_middleware_stack(
         self,


### PR DESCRIPTION
Addresses #203 

- Quick refactor of `construct_route_map` that extracts the logic into three separate methods.
- Fixes the sonar issue related to code complexity.
- Only real logic change is checking for conflicting path parameters (e.g. /foo/{a:int} vs /foo/{b:int}) by comparing the preexisting `_path_parameters` key on the terminating trie node of a route path to the `route.path_parameters` attribute on the route being added to the trie.  Previously used a set of previously seen paths.

Clearly there's more that can be done here, but still more context to learn before I attempt deeper changes! 

Seems to be an opportunity to take a class-based approach whereby we have a RouteMap and PathSegmentNode's that could simplify some of this logic, but I'm not sure it's worth doing given that the route_map is only used by `StarliteASGIRouter.traverse_route_map`?