### PR TITLE
Enhancement: Move optional dependencies to extras 

### DIFF
--- a/starlite/exceptions.py
+++ b/starlite/exceptions.py
@@ -25,7 +25,29 @@ class StarLiteException(Exception):
 
 
 class MissingDependencyException(StarLiteException, ImportError):
-    pass
+    def __init__(self, feature: str, extras: tuple[str, ...]) -> None:
+        self.feature = feature
+        self.extras = extras
+
+        if len(extras) > 1:
+            _extras_repr = ", ".join(map(repr, extras[:-1])) + " or " + repr(extras[-1])
+        elif extras:
+            _extras_repr = repr(extras[0])
+        else:
+            raise RuntimeError(f"`extras` argument of {self.__class__.__name__} cannot be empty.")
+
+        detail = (
+            f"To use {feature}, install starlite with {_extras_repr} extra:\n"
+            f"e.g. `pip install starlite[{extras[0]}]`\n"
+            f"or `poetry add starlite --extras {extras[0]}`"
+        )
+        super().__init__(detail)
+
+        # this and custom Exception.__repr__ below is a workaround
+        # for https://github.com/starlite-api/starlite/issues/188
+        Exception.__init__(self, detail)
+
+    __repr__ = Exception.__repr__
 
 
 class HTTPException(StarLiteException, StarletteHTTPException):

--- a/starlite/exceptions.py
+++ b/starlite/exceptions.py
@@ -1,7 +1,5 @@
-from __future__ import annotations
-
 from http import HTTPStatus
-from typing import Any
+from typing import Any, Dict, List, Optional, Union
 
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.status import (
@@ -54,13 +52,13 @@ class MissingDependencyException(StarLiteException, ImportError):
 
 class HTTPException(StarLiteException, StarletteHTTPException):
     status_code = HTTP_500_INTERNAL_SERVER_ERROR
-    extra: dict[str, Any] | list[Any] | None = None
+    extra: Optional[Union[Dict[str, Any], List[Any]]] = None
 
     def __init__(  # pylint: disable=super-init-not-called
         self,
-        detail: str | None = None,
-        status_code: int | None = None,
-        extra: dict[str, Any] | list[Any] | None = None,
+        detail: Optional[str] = None,
+        status_code: Optional[int] = None,
+        extra: Optional[Union[Dict[str, Any], List[Any]]] = None,
     ):
         if status_code:
             self.status_code = status_code

--- a/starlite/exceptions.py
+++ b/starlite/exceptions.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.status import (
@@ -52,13 +54,13 @@ class MissingDependencyException(StarLiteException, ImportError):
 
 class HTTPException(StarLiteException, StarletteHTTPException):
     status_code = HTTP_500_INTERNAL_SERVER_ERROR
-    extra: Optional[Union[Dict[str, Any], List[Any]]] = None
+    extra: dict[str, Any] | list[Any] | None = None
 
     def __init__(  # pylint: disable=super-init-not-called
         self,
-        detail: Optional[str] = None,
-        status_code: Optional[int] = None,
-        extra: Optional[Union[Dict[str, Any], List[Any]]] = None,
+        detail: str | None = None,
+        status_code: int | None = None,
+        extra: dict[str, Any] | list[Any] | None = None,
     ):
         if status_code:
             self.status_code = status_code

--- a/starlite/exceptions.py
+++ b/starlite/exceptions.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.status import (
@@ -25,7 +25,7 @@ class StarLiteException(Exception):
 
 
 class MissingDependencyException(StarLiteException, ImportError):
-    def __init__(self, feature: str, extras: tuple[str, ...]) -> None:
+    def __init__(self, feature: str, extras: Tuple[str, ...]) -> None:
         self.feature = feature
         self.extras = extras
 

--- a/starlite/extras.py
+++ b/starlite/extras.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import dataclasses
+from types import TracebackType
+
+from starlite.exceptions import MissingDependencyException
+
+
+@dataclasses.dataclass
+class Feature:
+    name: str
+    available_in_extras: tuple[str, ...]
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> None:
+        """Handle import errors of optional dependencies."""
+        if isinstance(exc_val, ImportError):
+            raise MissingDependencyException(self.name, self.available_in_extras)
+
+
+SQLALCHEMY = Feature("SQLAlchemyPlugin", ("sqlalchemy", "all"))
+JINJA = Feature("jinja2 templates", ("jinja2",))
+MAKO = Feature("mako templates", ("mako",))
+TESTING = Feature("starlite.testing", ("testing", "all"))
+YAML = Feature("OpenAPI YAML format", ("yaml", "all"))
+PYDANTIC_FACTORIES = Feature("pydantic-factories", ("pydantic-factories",))

--- a/starlite/extras.py
+++ b/starlite/extras.py
@@ -1,7 +1,6 @@
-from __future__ import annotations
-
 import dataclasses
 from types import TracebackType
+from typing import Tuple
 
 from starlite.exceptions import MissingDependencyException
 
@@ -9,7 +8,7 @@ from starlite.exceptions import MissingDependencyException
 @dataclasses.dataclass
 class Feature:
     name: str
-    available_in_extras: tuple[str, ...]
+    available_in_extras: Tuple[str, ...]
 
     def __enter__(self) -> None:
         return None

--- a/starlite/plugins/sql_alchemy.py
+++ b/starlite/plugins/sql_alchemy.py
@@ -6,16 +6,16 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from uuid import UUID
 
 from pydantic import BaseModel, Json, conint, constr, create_model
-from pydantic_factories import ModelFactory
 from typing_extensions import Type
 
-from starlite.exceptions import (
-    ImproperlyConfiguredException,
-    MissingDependencyException,
-)
+from starlite.exceptions import ImproperlyConfiguredException
+from starlite.extras import PYDANTIC_FACTORIES, SQLALCHEMY
 from starlite.plugins.base import PluginProtocol
 
-try:
+with PYDANTIC_FACTORIES:
+    from pydantic_factories import ModelFactory
+
+with SQLALCHEMY:
     from sqlalchemy import inspect
     from sqlalchemy import types as sqlalchemy_type
     from sqlalchemy.dialects import (
@@ -29,8 +29,6 @@ try:
     )
     from sqlalchemy.orm import DeclarativeMeta, Mapper
     from sqlalchemy.sql.type_api import TypeEngine
-except ImportError as exc:  # pragma: no cover
-    raise MissingDependencyException("sqlalchemy is not installed") from exc
 
 
 class SQLAlchemyPlugin(PluginProtocol[DeclarativeMeta]):

--- a/starlite/response.py
+++ b/starlite/response.py
@@ -1,6 +1,5 @@
 from typing import Any, Dict, Optional, Union, cast
 
-import yaml
 from openapi_schema_pydantic.v3.v3_1_0.open_api import OpenAPI
 from orjson import OPT_INDENT_2, OPT_OMIT_MICROSECONDS, OPT_SERIALIZE_NUMPY, dumps
 from pydantic import BaseModel
@@ -10,6 +9,7 @@ from starlette.status import HTTP_204_NO_CONTENT
 
 from starlite.enums import MediaType, OpenAPIMediaType
 from starlite.exceptions import ImproperlyConfiguredException
+from starlite.extras import YAML
 from starlite.template import TemplateEngineProtocol
 
 
@@ -52,6 +52,10 @@ class Response(StarletteResponse):
             if isinstance(content, OpenAPI):
                 content_dict = content.dict(by_alias=True, exclude_none=True)
                 if self.media_type == OpenAPIMediaType.OPENAPI_YAML:
+                    # FIXME: this should be handled better
+                    #  404 or perhaps 503 with nice message should be returned?
+                    with YAML:
+                        import yaml  # pylint: disable=import-outside-toplevel
                     encoded = yaml.dump(content_dict, default_flow_style=False).encode("utf-8")
                     return cast(bytes, encoded)
                 return dumps(content_dict, option=OPT_INDENT_2 | OPT_OMIT_MICROSECONDS)

--- a/starlite/template/jinja.py
+++ b/starlite/template/jinja.py
@@ -2,15 +2,15 @@ from typing import List, Union
 
 from pydantic import DirectoryPath
 
-from starlite.exceptions import MissingDependencyException, TemplateNotFound
+from starlite.exceptions import TemplateNotFound
+from starlite.extras import JINJA
 from starlite.template.base import TemplateEngineProtocol
 
-try:
+with JINJA:
+    # pylint: disable=import-error
     from jinja2 import Environment, FileSystemLoader
     from jinja2 import Template as JinjaTemplate
     from jinja2 import TemplateNotFound as JinjaTemplateNotFound
-except ImportError as exc:  # pragma: no cover
-    raise MissingDependencyException("jinja2 is not installed") from exc
 
 
 class JinjaTemplateEngine(TemplateEngineProtocol[JinjaTemplate]):

--- a/starlite/template/mako.py
+++ b/starlite/template/mako.py
@@ -2,15 +2,15 @@ from typing import List, Union
 
 from pydantic import DirectoryPath
 
-from starlite.exceptions import MissingDependencyException, TemplateNotFound
+from starlite.exceptions import TemplateNotFound
+from starlite.extras import MAKO
 from starlite.template.base import TemplateEngineProtocol
 
-try:
+with MAKO:
+    # pylint: disable=import-error
     from mako.exceptions import TemplateLookupException as MakoTemplateNotFound
     from mako.lookup import TemplateLookup
     from mako.template import Template as MakoTemplate
-except ImportError as exc:  # pragma: no cover
-    raise MissingDependencyException("mako is not installed") from exc
 
 
 class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate]):

--- a/starlite/testing.py
+++ b/starlite/testing.py
@@ -20,6 +20,7 @@ from starlite.connection import Request
 from starlite.controller import Controller
 from starlite.datastructures import State
 from starlite.enums import HttpMethod, RequestEncodingType
+from starlite.extras import TESTING
 from starlite.handlers import BaseRouteHandler
 from starlite.plugins.base import PluginProtocol
 from starlite.provide import Provide
@@ -33,14 +34,9 @@ from starlite.types import (
     Middleware,
 )
 
-try:
+with TESTING:
     from requests.models import RequestEncodingMixin
-except ImportError:  # pragma: no cover
-    from starlite.exceptions import MissingDependencyException
 
-    raise MissingDependencyException(
-        "To use starlite.testing, intall starlite with 'testing' extra, e.g. `pip install starlite[testing]`"
-    )
 __all__ = [
     "TestClient",
     "create_test_client",

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -1,0 +1,36 @@
+import pytest
+
+from starlite import MissingDependencyException
+from starlite.extras import Feature
+
+
+def test_feature() -> None:
+    sample_feature = Feature("Some Feature", ("some-extra",))
+
+    with pytest.raises(MissingDependencyException) as ctx:  # noqa: SIM117
+        with sample_feature:
+            import non_existing  # noqa: F401
+
+    expected_message = (
+        "To use Some Feature, install starlite with 'some-extra' extra:\n"
+        "e.g. `pip install starlite[some-extra]`\n"
+        "or `poetry add starlite --extras some-extra`"
+    )
+    assert str(ctx.value) == expected_message
+    assert repr(ctx.value) == f"MissingDependencyException({expected_message!r})"
+
+
+def test_feature_with_multiple_extras() -> None:
+    sample_feature = Feature("Some Feature", ("some-extra",))
+
+    with pytest.raises(MissingDependencyException) as ctx:  # noqa: SIM117
+        with sample_feature:
+            import non_existing  # noqa: F401
+
+    expected_message = (
+        "To use Some Feature, install starlite with 'some-extra' extra:\n"
+        "e.g. `pip install starlite[some-extra]`\n"
+        "or `poetry add starlite --extras some-extra`"
+    )
+    assert str(ctx.value) == expected_message
+    assert repr(ctx.value) == f"MissingDependencyException({expected_message!r})"


### PR DESCRIPTION
Closes #185

TODO:
- [x] handle missing optional dependencies
- [ ] create extras in pyproject.toml
- [ ] stop importing these libs at package level
- [ ] change docs accordingly

Context manager was chosen over try/except for three reasons:
1. It looks much cleaner and requires less writing
2. All error-handling is happening in once place
3. It's testable and doesn't require `# pragma: no cover`
