### PR TITLE
Removes `uuid4()` from within parametrized test cases.

### DIFF
--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -1,5 +1,4 @@
 from typing import Any, Callable, Optional, Type
-from uuid import uuid4
 
 import pytest
 from starlette.status import (
@@ -31,8 +30,8 @@ def root_delete_handler() -> None:
 @pytest.mark.parametrize(
     "request_path, router_path",
     [
-        [f"/path/1/2/sub/{str(uuid4())}", "/path/{first:int}/{second:str}/sub/{third:uuid}"],
-        [f"/path/1/2/sub/{str(uuid4())}/", "/path/{first:int}/{second:str}/sub/{third:uuid}/"],
+        ["/path/1/2/sub/c892496f-b1fd-4b91-bdb8-b46f92df1716", "/path/{first:int}/{second:str}/sub/{third:uuid}"],
+        ["/path/1/2/sub/2535a9cb-6554-4d85-bb3b-ad38362f63c7/", "/path/{first:int}/{second:str}/sub/{third:uuid}/"],
         ["/", "/"],
         ["", ""],
     ],


### PR DESCRIPTION
Vscode test discovery caches the test case names including parametrized values.

The behavior makes having dynamic `uuid4()` calls in the parametrized test cases an issue as vscode shows test case failures when the test case names that it previously resolved cannot be found.

The change doesn't affect the utility of the test, so better to fix the case for vscode users so we don't get the same issue reported in the future.