### PR TITLE
Adds a `LifecycleHook` container object.

### DIFF
--- a/starlite/controller.py
+++ b/starlite/controller.py
@@ -3,7 +3,11 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
 
 from starlite.handlers import BaseRouteHandler
 from starlite.utils import ensure_unbound, normalize_path
-from starlite.utils.lifecycle_hooks import LifecycleHook
+from starlite.utils.lifecycle_hooks import (
+    AfterRequestHook,
+    AfterResponseHook,
+    BeforeRequestHook,
+)
 
 if TYPE_CHECKING:
     from typing import Type
@@ -71,9 +75,9 @@ class Controller:
 
         self.path = normalize_path(self.path or "/")
         self.owner = owner
-        self._after_request = LifecycleHook(ensure_unbound(self.after_request)) if self.after_request else None
-        self._after_response = LifecycleHook(ensure_unbound(self.after_response)) if self.after_response else None
-        self._before_request = LifecycleHook(ensure_unbound(self.before_request)) if self.before_request else None
+        self._after_request = AfterRequestHook(ensure_unbound(self.after_request)) if self.after_request else None
+        self._after_response = AfterResponseHook(ensure_unbound(self.after_response)) if self.after_response else None
+        self._before_request = BeforeRequestHook(ensure_unbound(self.before_request)) if self.before_request else None
 
     def get_route_handlers(self) -> List[BaseRouteHandler]:
         """

--- a/starlite/controller.py
+++ b/starlite/controller.py
@@ -2,7 +2,8 @@ from copy import copy
 from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
 
 from starlite.handlers import BaseRouteHandler
-from starlite.utils import normalize_path
+from starlite.utils import ensure_unbound, normalize_path
+from starlite.utils.lifecycle_hooks import LifecycleHook
 
 if TYPE_CHECKING:
     from typing import Type
@@ -44,6 +45,9 @@ class Controller:
         "response_class",
         "response_headers",
         "tags",
+        "_after_request",
+        "_after_response",
+        "_before_request",
     )
 
     after_request: Optional["AfterRequestHandler"]
@@ -67,6 +71,9 @@ class Controller:
 
         self.path = normalize_path(self.path or "/")
         self.owner = owner
+        self._after_request = LifecycleHook(ensure_unbound(self.after_request)) if self.after_request else None
+        self._after_response = LifecycleHook(ensure_unbound(self.after_response)) if self.after_response else None
+        self._before_request = LifecycleHook(ensure_unbound(self.before_request)) if self.before_request else None
 
     def get_route_handlers(self) -> List[BaseRouteHandler]:
         """

--- a/starlite/controller.py
+++ b/starlite/controller.py
@@ -3,11 +3,7 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union, cast
 
 from starlite.handlers import BaseRouteHandler
 from starlite.utils import ensure_unbound, normalize_path
-from starlite.utils.lifecycle_hooks import (
-    AfterRequestHook,
-    AfterResponseHook,
-    BeforeRequestHook,
-)
+from starlite.utils.lifecycle_hooks import LifecycleHook
 
 if TYPE_CHECKING:
     from typing import Type
@@ -75,9 +71,9 @@ class Controller:
 
         self.path = normalize_path(self.path or "/")
         self.owner = owner
-        self._after_request = AfterRequestHook(ensure_unbound(self.after_request)) if self.after_request else None
-        self._after_response = AfterResponseHook(ensure_unbound(self.after_response)) if self.after_response else None
-        self._before_request = BeforeRequestHook(ensure_unbound(self.before_request)) if self.before_request else None
+        self._after_request = LifecycleHook(ensure_unbound(self.after_request)) if self.after_request else None
+        self._after_response = LifecycleHook(ensure_unbound(self.after_response)) if self.after_response else None
+        self._before_request = LifecycleHook(ensure_unbound(self.before_request)) if self.before_request else None
 
     def get_route_handlers(self) -> List[BaseRouteHandler]:
         """

--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -11,7 +11,6 @@ from starlette.responses import FileResponse, RedirectResponse
 from starlette.responses import Response as StarletteResponse
 from starlette.responses import StreamingResponse
 from starlette.status import HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT
-from typing_extensions import Literal
 
 from starlite.constants import REDIRECT_STATUS_CODES
 from starlite.datastructures import File, Redirect, StarliteType, Stream, Template
@@ -36,12 +35,15 @@ from starlite.types import (
     Middleware,
     ResponseHeader,
 )
-from starlite.utils.lifecycle_hooks import LifecycleHook
+from starlite.utils.lifecycle_hooks import (
+    AfterRequestHook,
+    AfterResponseHook,
+    BeforeRequestHook,
+    get_lifecycle_hook_from_layer,
+)
 
 if TYPE_CHECKING:
     from starlite.app import Starlite
-    from starlite.controller import Controller
-    from starlite.router import Router
 
 
 class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
@@ -134,10 +136,10 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
             middleware=middleware,
             exception_handlers=exception_handlers,
         )
-        self.after_request = LifecycleHook(after_request) if after_request else None
-        self.after_response = LifecycleHook(after_response) if after_response else None
+        self.after_request = AfterRequestHook(after_request) if after_request else None
+        self.after_response = AfterResponseHook(after_response) if after_response else None
         self.background_tasks = background_tasks
-        self.before_request = LifecycleHook(before_request) if before_request else None
+        self.before_request = BeforeRequestHook(before_request) if before_request else None
         self.cache = cache
         self.cache_key_builder = cache_key_builder
         self.media_type = media_type
@@ -157,13 +159,13 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         self.tags = tags
         # memoized attributes, defaulted to BaseRouteHandler.empty
         self.resolved_after_request: Union[
-            Optional[LifecycleHook], Type[BaseRouteHandler.empty]
+            Optional[AfterRequestHook], Type[BaseRouteHandler.empty]
         ] = BaseRouteHandler.empty
         self.resolved_after_response: Union[
-            Optional[LifecycleHook], Type[BaseRouteHandler.empty]
+            Optional[AfterResponseHook], Type[BaseRouteHandler.empty]
         ] = BaseRouteHandler.empty
         self.resolved_before_request: Union[
-            Optional[LifecycleHook], Type[BaseRouteHandler.empty]
+            Optional[BeforeRequestHook], Type[BaseRouteHandler.empty]
         ] = BaseRouteHandler.empty
         self.resolved_headers: Union[Dict[str, ResponseHeader], Type[BaseRouteHandler.empty]] = BaseRouteHandler.empty
         self.resolved_response_class: Union[Type[Response], Type[BaseRouteHandler.empty]] = BaseRouteHandler.empty
@@ -201,14 +203,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
                 self.resolved_headers.update(layer.response_headers or {})
         return cast(Dict[str, ResponseHeader], self.resolved_headers)
 
-    @staticmethod
-    def _get_lifecycle_hook_from_layer(
-        layer: Union["HTTPRouteHandler", "Controller", "Router", "Starlite"],
-        key: Literal["after_request", "after_response", "before_request"],
-    ) -> Optional[LifecycleHook]:
-        return getattr(layer, f"_{key}", getattr(layer, key))  # type:ignore[no-any-return]
-
-    def resolve_before_request(self) -> Optional[LifecycleHook]:
+    def resolve_before_request(self) -> Optional[BeforeRequestHook]:
         """
         Resolves the before_handler handler by starting from the route handler and moving up.
 
@@ -218,12 +213,12 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         if self.resolved_before_request is BaseRouteHandler.empty:
             self.resolved_before_request = None
             for layer in self.ownership_layers:
-                hook = self._get_lifecycle_hook_from_layer(layer, "before_request")
+                hook = get_lifecycle_hook_from_layer(layer, "before_request")
                 if hook:
                     self.resolved_before_request = hook
         return self.resolved_before_request  # type:ignore[return-value]
 
-    def resolve_after_request(self) -> Optional[LifecycleHook]:
+    def resolve_after_request(self) -> Optional[AfterRequestHook]:
         """
         Resolves the after_request handler by starting from the route handler and moving up.
 
@@ -233,12 +228,12 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         if self.resolved_after_request is BaseRouteHandler.empty:
             self.resolved_after_request = None
             for layer in self.ownership_layers:
-                hook = self._get_lifecycle_hook_from_layer(layer, "after_request")
+                hook = get_lifecycle_hook_from_layer(layer, "after_request")
                 if hook:
                     self.resolved_after_request = hook
         return self.resolved_after_request  # type:ignore[return-value]
 
-    def resolve_after_response(self) -> Optional[LifecycleHook]:
+    def resolve_after_response(self) -> Optional[AfterResponseHook]:
         """
         Resolves the after_response handler by starting from the route handler and moving up.
 
@@ -248,7 +243,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         if self.resolved_after_response is BaseRouteHandler.empty:
             self.resolved_after_response = None
             for layer in self.ownership_layers:
-                hook = self._get_lifecycle_hook_from_layer(layer, "after_response")
+                hook = get_lifecycle_hook_from_layer(layer, "after_response")
                 if hook:
                     self.resolved_after_response = hook
         return self.resolved_after_response  # type:ignore[return-value]

--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -206,7 +206,8 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         layer: Union["HTTPRouteHandler", "Controller", "Router", "Starlite"],
         key: Literal["after_request", "after_response", "before_request"],
     ) -> Optional[LifecycleHook]:
-        return getattr(layer, f"_{key}", getattr(layer, key))  # type:ignore[no-any-return]
+        optional_hook = getattr(layer, f"_{key}", getattr(layer, key))
+        return cast(Optional[LifecycleHook], optional_hook)
 
     def resolve_before_request(self) -> Optional[LifecycleHook]:
         """
@@ -221,7 +222,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
                 hook = self._get_lifecycle_hook_from_layer(layer, "before_request")
                 if hook:
                     self.resolved_before_request = hook
-        return self.resolved_before_request  # type:ignore[return-value]
+        return cast(Optional[LifecycleHook], self.resolved_before_request)
 
     def resolve_after_request(self) -> Optional[LifecycleHook]:
         """
@@ -236,7 +237,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
                 hook = self._get_lifecycle_hook_from_layer(layer, "after_request")
                 if hook:
                     self.resolved_after_request = hook
-        return self.resolved_after_request  # type:ignore[return-value]
+        return cast(Optional[LifecycleHook], self.resolved_after_request)
 
     def resolve_after_response(self) -> Optional[LifecycleHook]:
         """
@@ -251,7 +252,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
                 hook = self._get_lifecycle_hook_from_layer(layer, "after_response")
                 if hook:
                     self.resolved_after_response = hook
-        return self.resolved_after_response  # type:ignore[return-value]
+        return cast(Optional[LifecycleHook], self.resolved_after_response)
 
     @property
     def http_methods(self) -> List[Method]:

--- a/starlite/router.py
+++ b/starlite/router.py
@@ -29,6 +29,7 @@ from starlite.types import (
     ResponseHeader,
 )
 from starlite.utils import find_index, join_paths, normalize_path, unique
+from starlite.utils.lifecycle_hooks import LifecycleHook
 
 
 class Router:
@@ -67,9 +68,9 @@ class Router:
         route_handlers: List[ControllerRouterHandler],
         tags: Optional[List[str]] = None,
     ):
-        self.after_request = after_request
-        self.after_response = after_response
-        self.before_request = before_request
+        self.after_request = LifecycleHook(after_request) if after_request else None
+        self.after_response = LifecycleHook(after_response) if after_response else None
+        self.before_request = LifecycleHook(before_request) if before_request else None
         self.dependencies = dependencies
         self.exception_handlers = exception_handlers
         self.guards = guards

--- a/starlite/router.py
+++ b/starlite/router.py
@@ -29,11 +29,7 @@ from starlite.types import (
     ResponseHeader,
 )
 from starlite.utils import find_index, join_paths, normalize_path, unique
-from starlite.utils.lifecycle_hooks import (
-    AfterRequestHook,
-    AfterResponseHook,
-    BeforeRequestHook,
-)
+from starlite.utils.lifecycle_hooks import LifecycleHook
 
 
 class Router:
@@ -72,9 +68,9 @@ class Router:
         route_handlers: List[ControllerRouterHandler],
         tags: Optional[List[str]] = None,
     ):
-        self.after_request = AfterRequestHook(after_request) if after_request else None
-        self.after_response = AfterResponseHook(after_response) if after_response else None
-        self.before_request = BeforeRequestHook(before_request) if before_request else None
+        self.after_request = LifecycleHook(after_request) if after_request else None
+        self.after_response = LifecycleHook(after_response) if after_response else None
+        self.before_request = LifecycleHook(before_request) if before_request else None
         self.dependencies = dependencies
         self.exception_handlers = exception_handlers
         self.guards = guards

--- a/starlite/router.py
+++ b/starlite/router.py
@@ -29,7 +29,11 @@ from starlite.types import (
     ResponseHeader,
 )
 from starlite.utils import find_index, join_paths, normalize_path, unique
-from starlite.utils.lifecycle_hooks import LifecycleHook
+from starlite.utils.lifecycle_hooks import (
+    AfterRequestHook,
+    AfterResponseHook,
+    BeforeRequestHook,
+)
 
 
 class Router:
@@ -68,9 +72,9 @@ class Router:
         route_handlers: List[ControllerRouterHandler],
         tags: Optional[List[str]] = None,
     ):
-        self.after_request = LifecycleHook(after_request) if after_request else None
-        self.after_response = LifecycleHook(after_response) if after_response else None
-        self.before_request = LifecycleHook(before_request) if before_request else None
+        self.after_request = AfterRequestHook(after_request) if after_request else None
+        self.after_response = AfterResponseHook(after_response) if after_response else None
+        self.before_request = BeforeRequestHook(before_request) if before_request else None
         self.dependencies = dependencies
         self.exception_handlers = exception_handlers
         self.guards = guards

--- a/starlite/routes.py
+++ b/starlite/routes.py
@@ -174,10 +174,7 @@ class HTTPRoute(BaseRoute):
         await response(scope, receive, send)
         after_response_handler = route_handler.resolve_after_response()
         if after_response_handler:
-            if is_async_callable(after_response_handler):
-                await after_response_handler(request)  # type: ignore
-            else:
-                await run_sync(after_response_handler, request)
+            await after_response_handler(request)
 
     async def call_handler(
         self, scope: "Scope", request: Request, parameter_model: KwargsModel, route_handler: HTTPRouteHandler
@@ -193,10 +190,7 @@ class HTTPRoute(BaseRoute):
         before_request_handler = route_handler.resolve_before_request()
         # run the before_request hook handler
         if before_request_handler:
-            if is_async_callable(before_request_handler):
-                response_data = await before_request_handler(request)
-            else:
-                response_data = await run_sync(before_request_handler, request)
+            response_data = await before_request_handler(request)
         if not response_data:
             response_data = await self.get_response_data(
                 route_handler=route_handler, parameter_model=parameter_model, request=request

--- a/starlite/utils/__init__.py
+++ b/starlite/utils/__init__.py
@@ -1,4 +1,4 @@
-from .helpers import is_async_callable
+from .helpers import ensure_unbound, is_async_callable
 from .model import convert_dataclass_to_model, create_parsed_model_field
 from .module_loading import import_string
 from .sequence import find_index, unique
@@ -7,10 +7,11 @@ from .url import join_paths, normalize_path
 __all__ = [
     "convert_dataclass_to_model",
     "create_parsed_model_field",
+    "ensure_unbound",
     "find_index",
     "join_paths",
+    "import_string",
     "is_async_callable",
     "normalize_path",
     "unique",
-    "import_string",
 ]

--- a/starlite/utils/helpers.py
+++ b/starlite/utils/helpers.py
@@ -1,6 +1,7 @@
 import asyncio
 import functools
-from typing import Any
+from inspect import ismethod
+from typing import Any, Callable
 
 
 def is_async_callable(obj: Any) -> bool:
@@ -20,3 +21,18 @@ def is_async_callable(obj: Any) -> bool:
         obj = obj.func
 
     return asyncio.iscoroutinefunction(obj) or (callable(obj) and asyncio.iscoroutinefunction(obj.__call__))
+
+
+def ensure_unbound(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    If `fn` is a method, returns its `__func__` attribute.
+
+    Args:
+        fn (Callable[..., Any]): Any callable
+
+    Returns:
+        Callable[..., Any]: A callable that is not a bound method.
+    """
+    if ismethod(fn):
+        return fn.__func__
+    return fn

--- a/starlite/utils/lifecycle_hooks.py
+++ b/starlite/utils/lifecycle_hooks.py
@@ -6,9 +6,9 @@ from .helpers import is_async_callable
 
 
 class LifecycleHook:
-    def __init__(self, fn: Callable[..., Any]) -> None:
-        self.wrapped = [fn]  # wrap in list to prevent implicit binding
-        self.fn_is_async = is_async_callable(fn)
+    def __init__(self, handler: Callable[..., Any]) -> None:
+        self.wrapped = [handler]  # wrap in list to prevent implicit binding
+        self.is_async_handler = is_async_callable(handler)
 
     @property
     def hook(self) -> Callable[..., Any]:
@@ -16,6 +16,6 @@ class LifecycleHook:
         return self.wrapped[0]
 
     async def __call__(self, *args: Any) -> Any:
-        if self.fn_is_async:
+        if self.is_async_handler:
             return await self.hook(*args)
         return await run_sync(self.hook, *args)

--- a/starlite/utils/lifecycle_hooks.py
+++ b/starlite/utils/lifecycle_hooks.py
@@ -10,12 +10,7 @@ class LifecycleHook:
         self.wrapped = [handler]  # wrap in list to prevent implicit binding
         self.is_async_handler = is_async_callable(handler)
 
-    @property
-    def hook(self) -> Callable[..., Any]:
-        """The lifecycle hook"""
-        return self.wrapped[0]
-
     async def __call__(self, *args: Any) -> Any:
         if self.is_async_handler:
-            return await self.hook(*args)
-        return await run_sync(self.hook, *args)
+            return await self.wrapped[0](*args)
+        return await run_sync(self.wrapped[0], *args)

--- a/starlite/utils/lifecycle_hooks.py
+++ b/starlite/utils/lifecycle_hooks.py
@@ -38,16 +38,16 @@ ResponseType = TypeVar("ResponseType", bound="StarletteResponse")
 
 class LifecycleHook(Generic[HandlerType, ReceiveType, ReturnType]):
     def __init__(self, fn: HandlerType) -> None:
-        self._wrapped = [fn]  # wrap in list to prevent implicit binding
-        self._fn_is_async = is_async_callable(fn)
+        self.wrapped = [fn]  # wrap in list to prevent implicit binding
+        self.fn_is_async = is_async_callable(fn)
 
     @property
     def hook(self) -> Callable[..., Any]:
         """The lifecycle hook"""
-        return self._wrapped[0]
+        return self.wrapped[0]
 
     async def __call__(self, arg: ReceiveType) -> ReturnType:
-        if self._fn_is_async:
+        if self.fn_is_async:
             return await self.hook(arg)  # type:ignore[no-any-return]
         return await run_sync(self.hook, arg)
 

--- a/starlite/utils/lifecycle_hooks.py
+++ b/starlite/utils/lifecycle_hooks.py
@@ -7,6 +7,28 @@ from .helpers import is_async_callable
 
 
 class LifecycleHook:
+    """
+    Container for assignment of lifecycle hook handlers to instances.
+
+    A callable assigned to a class is implicitly converted to a bound method on an instance:
+
+        >>> def a_callable(): ...
+        ...
+        >>> class C:
+        ...   callable = a_callable
+        ...
+        >>> C().callable()
+        Traceback (most recent call last):
+          File "<stdin>", line 1, in <module>
+        TypeError: a_callable() takes 0 positional arguments but 1 was given
+
+    `LifecycleHook` supports the pattern of storing handlers as attributes of the application layers, and caching
+    resolved handlers on `HTTPRouteHandler` instances.
+
+    Additionally, it pre-computes whether the handler function is async, simplifying calling the handler during the
+    request/response cycle.
+    """
+
     def __init__(self, handler: Callable[..., Any]) -> None:
         if is_async_callable(handler):
             self.wrapped = [handler]  # wrap in list to prevent implicit binding

--- a/starlite/utils/lifecycle_hooks.py
+++ b/starlite/utils/lifecycle_hooks.py
@@ -1,12 +1,43 @@
-from typing import Any, Callable
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generic,
+    Optional,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from anyio.to_thread import run_sync
+from typing_extensions import Literal
 
 from .helpers import is_async_callable
 
+if TYPE_CHECKING:
+    from starlette.responses import Response as StarletteResponse
 
-class LifecycleHook:
-    def __init__(self, fn: Callable[..., Any]) -> None:
+    from starlite.app import Starlite
+    from starlite.connection import Request  # noqa: F401
+    from starlite.controller import Controller
+    from starlite.handlers import HTTPRouteHandler
+    from starlite.router import Router
+    from starlite.types import (
+        AfterRequestHandler,
+        AfterResponseHandler,
+        BeforeRequestHandler,
+    )
+
+__all__ = ["AfterRequestHook", "AfterResponseHook", "BeforeRequestHook", "get_lifecycle_hook_from_layer"]
+
+HandlerType = TypeVar("HandlerType", bound=Union["AfterRequestHandler", "AfterResponseHandler", "BeforeRequestHandler"])
+ReceiveType = TypeVar("ReceiveType")
+ReturnType = TypeVar("ReturnType")
+ResponseType = TypeVar("ResponseType", bound="StarletteResponse")
+
+
+class LifecycleHook(Generic[HandlerType, ReceiveType, ReturnType]):
+    def __init__(self, fn: HandlerType) -> None:
         self._wrapped = [fn]  # wrap in list to prevent implicit binding
         self._fn_is_async = is_async_callable(fn)
 
@@ -15,7 +46,44 @@ class LifecycleHook:
         """The lifecycle hook"""
         return self._wrapped[0]
 
-    async def __call__(self, *args: Any) -> Any:
+    async def __call__(self, arg: ReceiveType) -> ReturnType:
         if self._fn_is_async:
-            return await self.hook(*args)
-        return await run_sync(self.hook, *args)
+            return await self.hook(arg)  # type:ignore[no-any-return]
+        return await run_sync(self.hook, arg)
+
+
+AfterRequestHook = LifecycleHook["AfterRequestHandler", ResponseType, ResponseType]
+AfterResponseHook = LifecycleHook["AfterResponseHandler", "Request", None]
+BeforeRequestHook = LifecycleHook["BeforeRequestHandler", "Request", Any]
+
+KeyType = Literal["after_request", "after_response", "before_request"]
+LayerType = Union["Starlite", "Router", "Controller", "HTTPRouteHandler"]
+
+
+@overload
+def get_lifecycle_hook_from_layer(layer: LayerType, key: Literal["after_request"]) -> Optional[AfterRequestHook]:
+    ...
+
+
+@overload
+def get_lifecycle_hook_from_layer(layer: LayerType, key: Literal["after_response"]) -> Optional[AfterResponseHook]:
+    ...
+
+
+@overload
+def get_lifecycle_hook_from_layer(layer: LayerType, key: Literal["before_request"]) -> Optional[BeforeRequestHook]:
+    ...
+
+
+def get_lifecycle_hook_from_layer(layer: LayerType, key: KeyType) -> Optional[LifecycleHook]:
+    """
+    Get `LifecycleHook` instance from layer for attribute name `key`.
+
+    Args:
+        layer (Starlite | Router | Controller | HTTPRouteHandler): Hook retrieved from layer if it exists.
+        key (Literal["after_request", "after_response", "before_request"]): Name of attribute on layer.
+
+    Returns:
+        LifecycleHook | None: The `LifecycleHook` instance if it exists, or `None`.
+    """
+    return getattr(layer, f"_{key}", getattr(layer, key))  # type:ignore[no-any-return]

--- a/starlite/utils/lifecycle_hooks.py
+++ b/starlite/utils/lifecycle_hooks.py
@@ -1,43 +1,12 @@
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Generic,
-    Optional,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import Any, Callable
 
 from anyio.to_thread import run_sync
-from typing_extensions import Literal
 
 from .helpers import is_async_callable
 
-if TYPE_CHECKING:
-    from starlette.responses import Response as StarletteResponse
 
-    from starlite.app import Starlite
-    from starlite.connection import Request  # noqa: F401
-    from starlite.controller import Controller
-    from starlite.handlers import HTTPRouteHandler
-    from starlite.router import Router
-    from starlite.types import (
-        AfterRequestHandler,
-        AfterResponseHandler,
-        BeforeRequestHandler,
-    )
-
-__all__ = ["AfterRequestHook", "AfterResponseHook", "BeforeRequestHook", "get_lifecycle_hook_from_layer"]
-
-HandlerType = TypeVar("HandlerType", bound=Union["AfterRequestHandler", "AfterResponseHandler", "BeforeRequestHandler"])
-ReceiveType = TypeVar("ReceiveType")
-ReturnType = TypeVar("ReturnType")
-ResponseType = TypeVar("ResponseType", bound="StarletteResponse")
-
-
-class LifecycleHook(Generic[HandlerType, ReceiveType, ReturnType]):
-    def __init__(self, fn: HandlerType) -> None:
+class LifecycleHook:
+    def __init__(self, fn: Callable[..., Any]) -> None:
         self.wrapped = [fn]  # wrap in list to prevent implicit binding
         self.fn_is_async = is_async_callable(fn)
 
@@ -46,44 +15,7 @@ class LifecycleHook(Generic[HandlerType, ReceiveType, ReturnType]):
         """The lifecycle hook"""
         return self.wrapped[0]
 
-    async def __call__(self, arg: ReceiveType) -> ReturnType:
+    async def __call__(self, *args: Any) -> Any:
         if self.fn_is_async:
-            return await self.hook(arg)  # type:ignore[no-any-return]
-        return await run_sync(self.hook, arg)
-
-
-AfterRequestHook = LifecycleHook["AfterRequestHandler", ResponseType, ResponseType]
-AfterResponseHook = LifecycleHook["AfterResponseHandler", "Request", None]
-BeforeRequestHook = LifecycleHook["BeforeRequestHandler", "Request", Any]
-
-KeyType = Literal["after_request", "after_response", "before_request"]
-LayerType = Union["Starlite", "Router", "Controller", "HTTPRouteHandler"]
-
-
-@overload
-def get_lifecycle_hook_from_layer(layer: LayerType, key: Literal["after_request"]) -> Optional[AfterRequestHook]:
-    ...
-
-
-@overload
-def get_lifecycle_hook_from_layer(layer: LayerType, key: Literal["after_response"]) -> Optional[AfterResponseHook]:
-    ...
-
-
-@overload
-def get_lifecycle_hook_from_layer(layer: LayerType, key: Literal["before_request"]) -> Optional[BeforeRequestHook]:
-    ...
-
-
-def get_lifecycle_hook_from_layer(layer: LayerType, key: KeyType) -> Optional[LifecycleHook]:
-    """
-    Get `LifecycleHook` instance from layer for attribute name `key`.
-
-    Args:
-        layer (Starlite | Router | Controller | HTTPRouteHandler): Hook retrieved from layer if it exists.
-        key (Literal["after_request", "after_response", "before_request"]): Name of attribute on layer.
-
-    Returns:
-        LifecycleHook | None: The `LifecycleHook` instance if it exists, or `None`.
-    """
-    return getattr(layer, f"_{key}", getattr(layer, key))  # type:ignore[no-any-return]
+            return await self.hook(*args)
+        return await run_sync(self.hook, *args)

--- a/starlite/utils/lifecycle_hooks.py
+++ b/starlite/utils/lifecycle_hooks.py
@@ -1,0 +1,21 @@
+from typing import Any, Callable
+
+from anyio.to_thread import run_sync
+
+from .helpers import is_async_callable
+
+
+class LifecycleHook:
+    def __init__(self, fn: Callable[..., Any]) -> None:
+        self._wrapped = [fn]  # wrap in list to prevent implicit binding
+        self._fn_is_async = is_async_callable(fn)
+
+    @property
+    def hook(self) -> Callable[..., Any]:
+        """The lifecycle hook"""
+        return self._wrapped[0]
+
+    async def __call__(self, *args: Any) -> Any:
+        if self._fn_is_async:
+            return await self.hook(*args)
+        return await run_sync(self.hook, *args)

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+from starlite.utils.helpers import ensure_unbound
+
+
+def test_ensure_unbound_plain_fn() -> None:
+    def f() -> None:
+        ...
+
+    assert ensure_unbound(f) is f
+
+
+def test_ensure_unbound_fn_assigned_to_class_body() -> None:
+    def f(arg: Any) -> None:
+        ...
+
+    class Test:
+        fn = f
+
+    assert ensure_unbound(Test().fn) is f
+
+
+def test_ensure_unbound_assigned_to_instance() -> None:
+    def f(arg: Any) -> None:
+        ...
+
+    class Test:
+        fn: Any
+
+    inst = Test()
+
+    inst.fn = f
+
+    assert ensure_unbound(inst.fn) is f

--- a/tests/utils/test_lifecycle_hooks.py
+++ b/tests/utils/test_lifecycle_hooks.py
@@ -1,0 +1,53 @@
+from functools import partial
+from typing import Awaitable, Callable
+
+import pytest
+from anyio.to_thread import run_sync
+
+from starlite.utils.lifecycle_hooks import LifecycleHook
+
+
+@pytest.fixture
+def sync_callable() -> Callable[[str], str]:
+    def f(s: str) -> str:
+        return f"sync callable: {s}"
+
+    return f
+
+
+@pytest.fixture
+def sync_hook(sync_callable: Callable[[str], str]) -> LifecycleHook:
+    return LifecycleHook(sync_callable)
+
+
+@pytest.fixture
+def async_callable() -> Callable[[str], Awaitable[str]]:
+    async def f(s: str) -> str:
+        return f"async callable: {s}"
+
+    return f
+
+
+@pytest.fixture
+def async_hook(async_callable: Callable[[str], Awaitable[str]]) -> LifecycleHook:
+    return LifecycleHook(async_callable)
+
+
+def test_init_lifecycle_hook_sync_callable(sync_callable: Callable[[str], str], sync_hook: LifecycleHook) -> None:
+    assert isinstance(sync_hook.wrapped[0], partial)
+    assert sync_hook.wrapped[0].func is run_sync
+    assert sync_hook.wrapped[0].args == (sync_callable,)
+
+
+def test_init_lifecycle_hook_async_callable(
+    async_callable: Callable[[str], Awaitable[str]], async_hook: LifecycleHook
+) -> None:
+    assert async_hook.wrapped[0] is async_callable
+
+
+async def test_call_sync_hook(sync_hook: LifecycleHook) -> None:
+    assert await sync_hook("called") == "sync callable: called"
+
+
+async def test_call_async_hook(async_hook: LifecycleHook) -> None:
+    assert await async_hook("called") == "async callable: called"


### PR DESCRIPTION
Wraps lifecycle hooks as a workaround for implicit binding of functions to instances, and for centralizing the sync/async variable call logic.

Adds a helper for ensuring a callable is unbound.

This work is byproduct of my comment on PR #279 about using `staticmethod` which was incorrect as `staticmethod` is to prevent binding to the type, not the instance such as we are doing here. Turns out there isn't really a clean way to do it so I thought I'd experiment a bit.

Open to feedback, and will build explicit tests for the new constructs if you guys are onboard with the changes.

