### PR TITLE
Issue 188: resolve exceptions swallowing args

### DIFF
--- a/starlite/exceptions.py
+++ b/starlite/exceptions.py
@@ -14,9 +14,9 @@ from starlette.status import (
 
 
 class StarLiteException(Exception):
-    def __init__(self, detail: str = ""):
+    def __init__(self, *args: Any, detail: str = "", **kwargs: Dict[str, Any]):
         self.detail = detail
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
     def __repr__(self) -> str:
         if self.detail:
@@ -28,20 +28,23 @@ class MissingDependencyException(StarLiteException, ImportError):
     pass
 
 
-class HTTPException(StarLiteException, StarletteHTTPException):
+class HTTPException(StarletteHTTPException, StarLiteException):
     status_code = HTTP_500_INTERNAL_SERVER_ERROR
     extra: Optional[Union[Dict[str, Any], List[Any]]] = None
 
-    def __init__(  # pylint: disable=super-init-not-called
+    def __init__(
         self,
+        *args: Any,
         detail: Optional[str] = None,
         status_code: Optional[int] = None,
         extra: Optional[Union[Dict[str, Any], List[Any]]] = None,
+        **kwargs: Dict[str, Any],
     ):
-        if status_code:
-            self.status_code = status_code
-        self.detail = detail or HTTPStatus(self.status_code).phrase
+        if not detail:
+            detail = args[0] if len(args) > 0 else HTTPStatus(status_code or self.status_code).phrase
         self.extra = extra
+        super().__init__(status_code or self.status_code, *args, **kwargs)  # type: ignore
+        self.detail = detail
 
     def __repr__(self) -> str:
         return f"{self.status_code} - {self.__class__.__name__} - {self.detail}"
@@ -80,5 +83,5 @@ class ServiceUnavailableException(HTTPException):
 
 
 class TemplateNotFound(InternalServerException):
-    def __init__(self, template_name: str):
-        super().__init__(detail=f"Template {template_name} not found.")
+    def __init__(self, *args: Any, template_name: str, **kwargs: Dict[str, Any]):
+        super().__init__(*args, detail=f"Template {template_name} not found.", **kwargs)  # type: ignore

--- a/starlite/exceptions.py
+++ b/starlite/exceptions.py
@@ -16,12 +16,15 @@ from starlette.status import (
 class StarLiteException(Exception):
     def __init__(self, *args: Any, detail: str = "", **kwargs: Dict[str, Any]):
         self.detail = detail
-        super().__init__(*args, **kwargs)
+        super().__init__(*(str(arg) for arg in args if arg), detail, **kwargs)
 
     def __repr__(self) -> str:
         if self.detail:
             return f"{self.__class__.__name__} - {self.detail}"
         return self.__class__.__name__
+
+    def __str__(self) -> str:
+        return " ".join(self.args).strip()
 
 
 class MissingDependencyException(StarLiteException, ImportError):
@@ -45,6 +48,7 @@ class HTTPException(StarletteHTTPException, StarLiteException):
         self.extra = extra
         super().__init__(status_code or self.status_code, *args, **kwargs)  # type: ignore
         self.detail = detail
+        self.args = (f"{self.status_code}: {self.detail}", *args)
 
     def __repr__(self) -> str:
         return f"{self.status_code} - {self.__class__.__name__} - {self.detail}"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -14,13 +14,24 @@ from starlite.exceptions import (
 
 
 @given(detail=st.one_of(st.none(), st.text()))
-def test_starlite_exception(detail: Optional[str]) -> None:
+def test_starlite_exception_repr(detail: Optional[str]) -> None:
     result = StarLiteException(detail=detail)  # type: ignore
     assert result.detail == detail
     if detail:
         assert result.__repr__() == f"{result.__class__.__name__} - {result.detail}"
     else:
         assert result.__repr__() == result.__class__.__name__
+
+
+def test_starlite_exception_str() -> None:
+    result = StarLiteException("an unknown exception occurred")
+    assert str(result) == "an unknown exception occurred"
+
+    result = StarLiteException(detail="an unknown exception occurred")
+    assert str(result) == "an unknown exception occurred"
+
+    result = StarLiteException(200, detail="an unknown exception occurred")
+    assert str(result) == "200 an unknown exception occurred"
 
 
 @given(status_code=st.integers(min_value=400, max_value=404), detail=st.one_of(st.none(), st.text()))
@@ -30,6 +41,7 @@ def test_http_exception(status_code: int, detail: Optional[str]) -> None:
     assert isinstance(result, StarLiteException)
     assert isinstance(result, StarletteHTTPException)
     assert result.__repr__() == f"{result.status_code} - {result.__class__.__name__} - {result.detail}"
+    assert str(result) == f"{result.status_code}: {result.detail}".strip()
 
 
 @given(detail=st.one_of(st.none(), st.text()))


### PR DESCRIPTION
This PR addresses #188 by calling `super().__init__(...)` in the exception constructors, and handling *args and **kwargs. 