### PR TITLE
Split `openapi.create_paramter_for_handler` into several methods to reduce complexity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 node_modules/
 results/
 site/
+.scannerwork/
 
 # files
 *.iml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ the local environment in each of the tox environments.
 
 #### run pre-commit only
 
-`$ poetry run -e lint`
+`$ poetry run tox -e lint`
 
 ---
 

--- a/starlite/openapi/parameters.py
+++ b/starlite/openapi/parameters.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from pydantic.fields import ModelField
 
     from starlite.handlers import BaseRouteHandler
+    from starlite.provide import Provide
 
 
 def create_path_parameter_schema(
@@ -115,6 +116,64 @@ def create_parameter(
     )
 
 
+def _get_unlayered_params(
+    field_name: str,
+    model_field: "ModelField",
+    dependencies: Dict[str, "Provide"],
+    route_handler: "BaseRouteHandler",
+    path_parameters: List[Dict[str, Any]],
+    generate_examples: bool,
+) -> List[Parameter]:
+    if field_name not in dependencies:
+        return [
+            create_parameter(
+                model_field=model_field,
+                parameter_name=field_name,
+                path_parameters=path_parameters,
+                generate_examples=generate_examples,
+            )
+        ]
+    dependency_fields = cast(BaseModel, dependencies[field_name].signature_model).__fields__
+    return create_parameter_for_handler(route_handler, dependency_fields, path_parameters, generate_examples)
+
+
+def _get_layered_param(
+    field_name: str,
+    signature_model_field: "ModelField",
+    layered_parameters: Dict[str, "ModelField"],
+    path_parameters: List[Dict[str, Any]],
+    generate_examples: bool,
+) -> Parameter:
+    layer_field_info = layered_parameters[field_name].field_info
+    signature_field_info = signature_model_field.field_info
+
+    field_info = layer_field_info
+    # allow users to manually override Parameter definition using Parameter
+    if signature_field_info.extra.get(EXTRA_KEY_IS_PARAMETER):
+        field_info = signature_field_info
+
+    field_info.default = (
+        signature_field_info.default
+        if signature_field_info.default not in [Undefined, Ellipsis]
+        else layer_field_info.default
+    )
+
+    model_field = copy(signature_model_field)
+    model_field.field_info = field_info
+
+    extra = field_info.extra
+    parameter_name = (
+        extra.get(ParamType.QUERY) or extra.get(ParamType.HEADER) or extra.get(ParamType.COOKIE) or field_name
+    )
+
+    return create_parameter(
+        model_field=model_field,
+        parameter_name=parameter_name,
+        path_parameters=path_parameters,
+        generate_examples=generate_examples,
+    )
+
+
 def create_parameter_for_handler(
     route_handler: "BaseRouteHandler",
     handler_fields: Dict[str, "ModelField"],
@@ -135,21 +194,16 @@ def create_parameter_for_handler(
         if extra.get("is_dependency") and field_name not in dependencies:
             # never document explicit dependencies
             continue
-        if field_name in dependencies:
-            dependency_fields = cast(BaseModel, dependencies[field_name].signature_model).__fields__
-            for parameter in create_parameter_for_handler(
-                route_handler, dependency_fields, path_parameters, generate_examples
-            ):
-                parameters.add(parameter)
-        else:
-            parameters.add(
-                create_parameter(
-                    model_field=model_field,
-                    parameter_name=field_name,
-                    path_parameters=path_parameters,
-                    generate_examples=generate_examples,
-                )
-            )
+        for parameter in _get_unlayered_params(
+            field_name=field_name,
+            model_field=model_field,
+            dependencies=dependencies,
+            route_handler=route_handler,
+            path_parameters=path_parameters,
+            generate_examples=generate_examples,
+        ):
+            parameters.add(parameter)
+
     for field_name, model_field in filter(
         lambda items: items[0] not in RESERVED_KWARGS and items[0] not in handler_fields, layered_parameters.items()
     ):
@@ -164,35 +218,14 @@ def create_parameter_for_handler(
     for field_name, signature_model_filed in filter(
         lambda items: items[0] not in RESERVED_KWARGS and items[0] in layered_parameters, handler_fields.items()
     ):
-
-        layer_field_info = layered_parameters[field_name].field_info
-        signature_field_info = signature_model_filed.field_info
-
-        field_info = layer_field_info
-        # allow users to manually override Parameter definition using Parameter
-        if signature_field_info.extra.get(EXTRA_KEY_IS_PARAMETER):
-            field_info = signature_field_info
-
-        field_info.default = (
-            signature_field_info.default
-            if signature_field_info.default not in [Undefined, Ellipsis]
-            else layer_field_info.default
-        )
-
-        model_field = copy(signature_model_filed)
-        model_field.field_info = field_info
-
-        extra = field_info.extra
-        parameter_name = (
-            extra.get(ParamType.QUERY) or extra.get(ParamType.HEADER) or extra.get(ParamType.COOKIE) or field_name
-        )
-
         parameters.add(
-            create_parameter(
-                model_field=model_field,
-                parameter_name=parameter_name,
+            _get_layered_param(
+                field_name=field_name,
+                signature_model_field=signature_model_filed,
+                layered_parameters=layered_parameters,
                 path_parameters=path_parameters,
                 generate_examples=generate_examples,
             )
         )
+
     return parameters.list()

--- a/starlite/openapi/parameters.py
+++ b/starlite/openapi/parameters.py
@@ -125,8 +125,9 @@ def get_recursive_handler_parameters(
     generate_examples: bool,
 ) -> List[Parameter]:
     """Create and return parameters for a handler. If the provided field is not a dependency,
-    a normal parameter is created and returned as a list, otherwise a recursive call
-    may be triggered by the parent call function"""
+    a normal parameter is created and returned as a list, otherwise
+    `create_parameter_for_handler()` is called to generate parameters for the dependency."""
+
     if field_name not in dependencies:
         return [
             create_parameter(

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ envlist = py37,py38,py39,py310,lint
 [testenv]
 whitelist_externals = poetry
 commands =
-  poetry install -v -E brotli
-  poetry run pytest .
+    poetry install -v -E testing
+    poetry run pytest .
 
 [testenv:lint]
 deps = pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py37,py38,py39,py310,lint
 [testenv]
 whitelist_externals = poetry
 commands =
-  poetry install -v
+  poetry install -v -E brotli
   poetry run pytest .
 
 [testenv:lint]


### PR DESCRIPTION
once again a simple refactor which was mentioned as needed by https://github.com/starlite-api/starlite/issues/203 and fixes [this](https://sonarcloud.io/project/issues?resolved=false&severities=CRITICAL&id=starlite-api_starlite&open=AYH3kLXqoMi-EPUvUENi)

the first filter, which extracts params that are `not in layered_parameters`, had its logic moved to a method called `_get_unlayered_params` but i'm not sure if it's the best naming decision 