### PR TITLE
Support for SwaggerUI

### DIFF
--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -1,3 +1,4 @@
+import copy
 from typing import TYPE_CHECKING
 
 from orjson import OPT_INDENT_2, dumps
@@ -36,6 +37,60 @@ class OpenAPIController(Controller):
     def retrieve_schema_json(self, request: Request) -> "OpenAPI":
         """Returns the openapi schema"""
         return self.schema_from_request(request)
+
+    @get(path="/swagger", media_type=MediaType.HTML, include_in_schema=False)
+    def swagger_ui(self, request: Request) -> str:
+        """Endpoint that serves SwaggerUI"""
+        schema = self.schema_from_request(request)
+        if self.dumped_schema == "":
+            # Note: Fix for Swagger rejection OpenAPI >=3.1
+            # We force the version to be lower to get the default JS bundle to accept it
+            # This works flawlessly as the main blocker for Swagger support for OpenAPI 3.1 is JSON schema support
+            # Since we use the YAML format this is not an issue for us and we can do this trick to get support right now
+            # We use deepcopy to avoid changing the actual schema on the request. Since this is a cached call the effect is minimal
+            schema = copy.deepcopy(schema)
+            schema.openapi = "3.0.3"
+            self.dumped_schema = dumps(schema.json(by_alias=True, exclude_none=True), option=OPT_INDENT_2).decode(
+                "utf-8"
+            )
+        head = f"""
+          <head>
+            <title>{schema.info.title}</title>
+            <meta charset="utf-8"/>
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <link href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/swagger-ui.css" rel="stylesheet">
+            <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/swagger-ui-bundle.js"></script>
+            <style>
+                {self.styles}
+            </style>
+          </head>
+        """
+        body = f"""
+          <body>
+            <div id='swagger-container'></div>
+            <script>
+            const ui = SwaggerUIBundle({{
+                spec: JSON.parse({self.dumped_schema}),
+                dom_id: '#swagger-container',
+                layout: 'BaseLayout',
+                deepLinking: true,
+                showExtensions: true,
+                showCommonExtensions: true,
+                presets: [
+                    SwaggerUIBundle.presets.apis,
+                    SwaggerUIBundle.SwaggerUIStandalonePreset
+                ],
+            }})
+            </script>
+          </body>
+        """
+        return f"""
+        <!DOCTYPE html>
+            <html>
+                {head}
+                {body}
+            </html>
+        """
 
     @get(media_type=MediaType.HTML, include_in_schema=False)
     def redoc(self, request: Request) -> str:  # pragma: no cover

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -1,4 +1,3 @@
-import copy
 from typing import TYPE_CHECKING
 
 from orjson import OPT_INDENT_2, dumps
@@ -48,9 +47,9 @@ class OpenAPIController(Controller):
             # This works flawlessly as the main blocker for Swagger support for OpenAPI 3.1 is JSON schema support
             # Since we use the YAML format this is not an issue for us and we can do this trick to get support right now
             # We use deepcopy to avoid changing the actual schema on the request. Since this is a cached call the effect is minimal
-            schema = copy.deepcopy(schema)
-            schema.openapi = "3.0.3"
-            self.dumped_schema = dumps(schema.json(by_alias=True, exclude_none=True), option=OPT_INDENT_2).decode(
+            schema_copy = schema.copy()
+            schema_copy.openapi = "3.0.3"
+            self.dumped_schema = dumps(schema_copy.json(by_alias=True, exclude_none=True), option=OPT_INDENT_2).decode(
                 "utf-8"
             )
         head = f"""


### PR DESCRIPTION
As per #300, this adds basic support for SwaggerUI by monkey-patch-downgrading the version to one that is not instantly rejected by the default SwaggerUI bundle. This is valid because 3.1 support for SwaggerUI is largely blocked by the newly-introduced JSON schema support, which we don't use in Starlite (it's all YAML). More info in the tracking issue [here](https://github.com/swagger-api/swagger-ui/issues/5891).

Other than that I tried to stick as close as possible to the ReDoc implementation, leaving out things like extra config values or OAuth support to be added at a later time.

One thing that may be slightly weird for developers using this functionality is the route where this is currently served at `/schema/swagger`. Since `/schema` is already taken by ReDoc (and I assume we can't namespace it since that'd break compatibility) I put it there, but it's slightly different from the ReDoc convention right now. One option would be to also introduce `/schema/redoc` to at least make the routes consistent, with the default ReDoc UI being kept on the root of the controller.