### PR TITLE
Add basic sanity check tests for ReDoc and Swagger UI routes

### DIFF
--- a/tests/openapi/test_openapi_ui.py
+++ b/tests/openapi/test_openapi_ui.py
@@ -1,0 +1,20 @@
+from starlette.status import HTTP_200_OK
+
+from starlite.app import DEFAULT_OPENAPI_CONFIG
+from starlite.enums import MediaType
+from starlite.testing import create_test_client
+from tests.openapi.utils import PersonController, PetController
+
+
+def test_openapi_redoc() -> None:
+    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+        response = client.get("/schema")
+        assert response.status_code == HTTP_200_OK
+        assert response.headers["content-type"].startswith(MediaType.HTML.value)
+
+
+def test_openapi_swagger() -> None:
+    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+        response = client.get("/schema/swagger")
+        assert response.status_code == HTTP_200_OK
+        assert response.headers["content-type"].startswith(MediaType.HTML.value)


### PR DESCRIPTION
Tests for #303 / #302

These tests check whether the UI handlers:
- don't throw an Exception
- return 200 OK
- return HTML of some form