### PR TITLE
OpenAPIConfig.use_handler_docstrings

### DIFF
--- a/docs/usage/12-openapi.md
+++ b/docs/usage/12-openapi.md
@@ -39,6 +39,7 @@ Aside from `title` and `version`, both of which are **required** kwargs, you can
 - `summary`: Summary text.
 - `tags`: A list of `Tag` model instances.
 - `terms_of_service`: A url to a page containing the terms of service.
+- `use_handler_docstrings`: Operation description will be drawn from route handler docstring if not otherwise provided.
 - `webhooks`: A string keyed dictionary of `PathItem` model instances.
 
 <!-- prettier-ignore -->

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -1,7 +1,5 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type, Union, cast
 
-from openapi_schema_pydantic.util import construct_open_api_with_schema_class
-from openapi_schema_pydantic.v3.v3_1_0.open_api import OpenAPI
 from pydantic import validate_arguments
 from pydantic.fields import FieldInfo  # noqa: TC002
 from pydantic.typing import AnyCallable
@@ -26,7 +24,6 @@ from starlite.handlers.asgi import ASGIRouteHandler, asgi
 from starlite.handlers.http import HTTPRouteHandler
 from starlite.middleware import ExceptionHandlerMiddleware
 from starlite.middleware.compression.base import CompressionMiddleware
-from starlite.openapi.path_item import create_path_item
 from starlite.plugins.base import PluginProtocol
 from starlite.provide import Provide
 from starlite.response import Response
@@ -48,6 +45,8 @@ from starlite.utils import normalize_path
 from starlite.utils.templates import create_template_engine
 
 if TYPE_CHECKING:
+    from openapi_schema_pydantic.v3.v3_1_0.open_api import OpenAPI
+
     from starlite.handlers.base import BaseRouteHandler
     from starlite.handlers.websocket import WebsocketRouteHandler
 
@@ -129,9 +128,9 @@ class Starlite(Router):
 
         self.asgi_router = StarliteASGIRouter(on_shutdown=on_shutdown or [], on_startup=on_startup or [], app=self)
         self.asgi_handler = self.create_asgi_handler()
-        self.openapi_schema: Optional[OpenAPI] = None
+        self.openapi_schema: Optional["OpenAPI"] = None
         if openapi_config:
-            self.openapi_schema = self.create_openapi_schema_model(openapi_config=openapi_config)
+            self.openapi_schema = openapi_config.create_openapi_schema_model(self)
             self.register(openapi_config.openapi_controller)
         if static_files_config:
             for config in static_files_config if isinstance(static_files_config, list) else [static_files_config]:
@@ -308,20 +307,3 @@ class Starlite(Router):
                     plugins=self.plugins,
                     dependency_names=route_handler.dependency_name_set,
                 ).create_signature_model()
-
-    def create_openapi_schema_model(self, openapi_config: OpenAPIConfig) -> OpenAPI:
-        """
-        Updates the OpenAPI schema with all paths registered on the root router
-        """
-        openapi_schema = openapi_config.to_openapi_schema()
-        openapi_schema.paths = {}
-        for route in self.routes:
-            if (
-                isinstance(route, HTTPRoute)
-                and any(route_handler.include_in_schema for route_handler, _ in route.route_handler_map.values())
-                and (route.path_format or "/") not in openapi_schema.paths
-            ):
-                openapi_schema.paths[route.path_format or "/"] = create_path_item(
-                    route=route, create_examples=openapi_config.create_examples, plugins=self.plugins
-                )
-        return cast(OpenAPI, construct_open_api_with_schema_class(openapi_schema))

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -56,9 +56,10 @@ class OpenAPIController(Controller):
         schema = self.schema_from_request(request)
         # Note: Fix for Swagger rejection OpenAPI >=3.1
         # We force the version to be lower to get the default JS bundle to accept it
-        # This works flawlessly as the main blocker for Swagger support for OpenAPI 3.1 is JSON schema support
-        # Since we use the YAML format this is not an issue for us and we can do this trick to get support right now
-        # We use deepcopy to avoid changing the actual schema on the request. Since this is a cached call the effect is minimal
+        # This works flawlessly as the main blocker for Swagger support for OpenAPI 3.1 is JSON schema support.
+        # Since we use the YAML format this is not an issue for us, and we can do this trick to get support right now.
+        # We use deepcopy to avoid changing the actual schema on the request. Since this is a cached call the effect is
+        # minimal.
         if self._dumped_modified_schema == "":
             schema_copy = schema.copy()
             schema_copy.openapi = "3.0.3"

--- a/tests/openapi/test_path_item.py
+++ b/tests/openapi/test_path_item.py
@@ -1,16 +1,22 @@
 from typing import cast
 
+import pytest
+
 from starlite import HTTPRoute, Starlite
 from starlite.openapi.path_item import create_path_item
 from starlite.utils import find_index
 from tests.openapi.utils import PersonController
 
 
-def test_create_path_item() -> None:
+@pytest.fixture
+def route() -> HTTPRoute:
     app = Starlite(route_handlers=[PersonController], openapi_config=None)
     index = find_index(app.routes, lambda x: x.path_format == "/{service_id}/person/{person_id}")
-    route = cast(HTTPRoute, app.routes[index])
-    schema = create_path_item(route=route, create_examples=True, plugins=[])
+    return cast(HTTPRoute, app.routes[index])
+
+
+def test_create_path_item(route: HTTPRoute) -> None:
+    schema = create_path_item(route=route, create_examples=True, plugins=[], use_handler_docstrings=False)
     assert schema.delete
     assert schema.delete.operationId == "Delete Person"
     assert schema.get
@@ -19,3 +25,19 @@ def test_create_path_item() -> None:
     assert schema.patch.operationId == "Partial Update Person"
     assert schema.put
     assert schema.put.operationId == "Update Person"
+
+
+def test_create_path_item_use_handler_docstring_false(route: HTTPRoute) -> None:
+    schema = create_path_item(route=route, create_examples=True, plugins=[], use_handler_docstrings=False)
+    assert schema.get
+    assert schema.get.description is None
+    assert schema.patch
+    assert schema.patch.description == "Description in decorator"
+
+
+def test_create_path_item_use_handler_docstring_true(route: HTTPRoute) -> None:
+    schema = create_path_item(route=route, create_examples=True, plugins=[], use_handler_docstrings=True)
+    assert schema.get
+    assert schema.get.description == "Description in docstring"
+    assert schema.patch
+    assert schema.patch.description == "Description in decorator"

--- a/tests/openapi/utils.py
+++ b/tests/openapi/utils.py
@@ -90,11 +90,11 @@ class PersonController(Controller):
 
     @get(path="/{person_id:str}")
     def get_person_by_id(self, person_id: str) -> Person:
-        pass
+        """Description in docstring"""
 
-    @patch(path="/{person_id:str}")
+    @patch(path="/{person_id:str}", description="Description in decorator")
     def partial_update_person(self, person_id: str, data: Partial[Person]) -> Person:
-        pass
+        """Description in docstring"""
 
     @put(path="/{person_id:str}")
     def update_person(self, person_id: str, data: Person) -> Person:


### PR DESCRIPTION
Adds ability to configure openapi schema generation to use the route handler docstring for operation description.

If `False` docstrings are ignored, this is default behavior for backward compatibility.

If `True`, `HTTPRouteHandler.description` takes precedence if set, otherwise the docstring is used.