### PR TITLE
PoC: Cython 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ site/
 .DS_Store
 .python-version
 coverage.*
+**/*.so

--- a/.gitignore
+++ b/.gitignore
@@ -3,20 +3,22 @@
 .idea/
 .mypy_cache/
 .pytest_cache/
+.scannerwork/
 .tox/
 .venv/
 .vscode/
 __pycache__/
+build/
 dist/
 node_modules/
 results/
 site/
-.scannerwork/
 
 # files
+**/*.c
+**/*.so
 *.iml
-.coverage
 .DS_Store
+.coverage
 .python-version
 coverage.*
-**/*.so

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
         exclude: "\\.idea/(.)*"
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.2
+    rev: v2.37.3
     hooks:
       - id: pyupgrade
         args: ["--py37-plus"]
@@ -27,6 +27,7 @@ repos:
     rev: v2.1.0
     hooks:
       - id: codespell
+        args: [-L, crate]
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.12.1
     hooks:
@@ -41,11 +42,11 @@ repos:
       - id: bandit
         exclude: "test_*"
         args: ["-iii", "-ll", "-s=B308,B703"]
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.0.4 # Possible releases: https://github.com/hadialqattan/pycln/releases
-    hooks:
-      - id: pycln
-        args: [--config=pyproject.toml]
+  #  - repo: https://github.com/hadialqattan/pycln
+  #    rev: v2.0.4 # Possible releases: https://github.com/hadialqattan/pycln/releases
+  #    hooks:
+  #      - id: pycln
+  #        args: [--config=pyproject.toml]
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:
@@ -92,7 +93,9 @@ repos:
             pyyaml,
             starlette,
             sqlalchemy,
+            setuptools_rust,
             tortoise_orm,
+            cython,
           ]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v0.971"

--- a/build.py
+++ b/build.py
@@ -11,6 +11,12 @@ from typing import List
 
 # enable clang compiler optimizations
 CLANG_COMPILE_ARGS = ["-O2"]
+BUILD_TARGETS = [
+    "starlite/routes.py",
+    "starlite/response.py",
+    "starlite/parsers.py",
+    "starlite/signature.py",
+]
 
 
 def build() -> None:
@@ -25,8 +31,8 @@ def build() -> None:
 
         extension_modules: List[Extension] = []
 
-        for filename in Path("starlite").rglob("*.py"):
-            module_path = str(filename.with_suffix("")).replace("/", ".")
+        for filename in BUILD_TARGETS:
+            module_path = filename.removesuffix(".py").replace("/", ".")
             extension_module = Extension(
                 name=module_path, sources=[str(filename)], extra_compile_args=CLANG_COMPILE_ARGS
             )

--- a/build.py
+++ b/build.py
@@ -1,0 +1,69 @@
+"""
+Build script is adapted from: https://github.com/aotuai/example-cython-poetry-pypi/blob/main/build.py
+
+See: https://aotu.ai/en/blog/2021/01/19/publishing-a-proprietary-python-package-on-pypi-using-poetry/
+For further details
+"""
+
+import multiprocessing
+from pathlib import Path
+from typing import List
+
+from Cython.Build import cythonize
+from Cython.Distutils.build_ext import new_build_ext as cython_build_ext
+from setuptools import Distribution, Extension
+
+# enable clang compiler optimizations
+CLANG_COMPILE_ARGS = ["-O2"]
+
+
+def get_extension_modules() -> List[Extension]:
+    """
+    Collect all .py files in the starlite folder and turn them into setuptools.Extensions
+    """
+
+    extension_modules: List[Extension] = []
+
+    for filename in Path("starlite").rglob("*.py"):
+        module_path = str(filename.with_suffix("")).replace("/", ".")
+        extension_module = Extension(name=module_path, sources=[str(filename)], extra_compile_args=CLANG_COMPILE_ARGS)
+        extension_modules.append(extension_module)
+
+    return extension_modules
+
+
+def build() -> None:
+    """
+    Entry build for poetry build
+    """
+    extension_modules = cythonize(
+        module_list=get_extension_modules(),
+        build_dir=Path("dist"),
+        # Don't generate an .html output file. This will contain source.
+        annotate=False,
+        # Parallelize our build
+        nthreads=multiprocessing.cpu_count() * 2,
+        # Tell Cython we're using Python 3
+        compiler_directives={"language_level": "3"},
+        force=True,
+    )
+
+    # Use Setuptools to collect files
+    distribution = Distribution(
+        {
+            "ext_modules": extension_modules,
+            "cmdclass": {
+                "build_ext": cython_build_ext,
+            },
+        }
+    )
+
+    # Grab the build_ext command and copy all files back to source dir. This is
+    # done so that Poetry grabs the files during the next step in its build.
+    distribution.run_command("build_ext")
+    build_ext_cmd = distribution.get_command_obj("build_ext")
+    build_ext_cmd.copy_extensions_to_source()
+
+
+if __name__ == "__main__":
+    build()

--- a/build.py
+++ b/build.py
@@ -9,60 +9,53 @@ import multiprocessing
 from pathlib import Path
 from typing import List
 
-from Cython.Build import cythonize
-from Cython.Distutils.build_ext import new_build_ext as cython_build_ext
-from setuptools import Distribution, Extension
-
 # enable clang compiler optimizations
 CLANG_COMPILE_ARGS = ["-O2"]
-
-
-def get_extension_modules() -> List[Extension]:
-    """
-    Collect all .py files in the starlite folder and turn them into setuptools.Extensions
-    """
-
-    extension_modules: List[Extension] = []
-
-    for filename in Path("starlite").rglob("*.py"):
-        module_path = str(filename.with_suffix("")).replace("/", ".")
-        extension_module = Extension(name=module_path, sources=[str(filename)], extra_compile_args=CLANG_COMPILE_ARGS)
-        extension_modules.append(extension_module)
-
-    return extension_modules
 
 
 def build() -> None:
     """
     Entry build for poetry build
     """
-    extension_modules = cythonize(
-        module_list=get_extension_modules(),
-        build_dir=Path("dist"),
-        # Don't generate an .html output file. This will contain source.
-        annotate=False,
-        # Parallelize our build
-        nthreads=multiprocessing.cpu_count() * 2,
-        # Tell Cython we're using Python 3
-        compiler_directives={"language_level": "3"},
-        force=True,
-    )
+    # pylint: disable=import-outside-toplevel
+    try:
+        from Cython.Build import cythonize
+        from Cython.Distutils.build_ext import new_build_ext as cython_build_ext
+        from setuptools import Distribution, Extension
 
-    # Use Setuptools to collect files
-    distribution = Distribution(
-        {
-            "ext_modules": extension_modules,
-            "cmdclass": {
-                "build_ext": cython_build_ext,
-            },
-        }
-    )
+        extension_modules: List[Extension] = []
 
-    # Grab the build_ext command and copy all files back to source dir. This is
-    # done so that Poetry grabs the files during the next step in its build.
-    distribution.run_command("build_ext")
-    build_ext_cmd = distribution.get_command_obj("build_ext")
-    build_ext_cmd.copy_extensions_to_source()
+        for filename in Path("starlite").rglob("*.py"):
+            module_path = str(filename.with_suffix("")).replace("/", ".")
+            extension_module = Extension(
+                name=module_path, sources=[str(filename)], extra_compile_args=CLANG_COMPILE_ARGS
+            )
+            extension_modules.append(extension_module)
+
+        # Use Setuptools to collect files
+        distribution = Distribution(
+            {
+                "ext_modules": cythonize(
+                    module_list=extension_modules,
+                    build_dir=Path("dist"),
+                    annotate=False,
+                    nthreads=multiprocessing.cpu_count() * 2,
+                    compiler_directives={"language_level": "3"},
+                    force=True,
+                ),
+                "cmdclass": {
+                    "build_ext": cython_build_ext,
+                },
+            }
+        )
+
+        # Grab the build_ext command and copy all files back to source dir. This is
+        # done so that Poetry grabs the files during the next step in its build.
+        distribution.run_command("build_ext")
+        build_ext_cmd = distribution.get_command_obj("build_ext")
+        build_ext_cmd.copy_extensions_to_source()
+    except ImportError:
+        pass
 
 
 if __name__ == "__main__":

--- a/poetry.lock
+++ b/poetry.lock
@@ -111,6 +111,14 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
+name = "cython"
+version = "0.29.30"
+description = "The Cython compiler for writing C extensions for the Python language."
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "distlib"
 version = "0.3.5"
 description = "Distribution utilities"
@@ -863,7 +871,7 @@ standard = ["websockets (>=10.0)", "httptools (>=0.4.0)", "watchfiles (>=0.13)",
 
 [[package]]
 name = "virtualenv"
-version = "20.16.0"
+version = "20.16.2"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -917,7 +925,7 @@ testing = ["requests", "brotli"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "1f0c593f270a528dac4bcefac81a9e1c3b73ef867e497fd5a3edd68d7dcf6033"
+content-hash = "892a1c95f34fbc432d7ecfab8b8aa968be3068e187cdcd80f1ba1aead8b9563f"
 
 [metadata.files]
 aiosqlite = [
@@ -1057,6 +1065,48 @@ coverage = [
     {file = "coverage-6.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:edfdabe7aa4f97ed2b9dd5dde52d2bb29cb466993bb9d612ddd10d0085a683cf"},
     {file = "coverage-6.4.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:e2618cb2cf5a7cc8d698306e42ebcacd02fb7ef8cfc18485c59394152c70be97"},
     {file = "coverage-6.4.2.tar.gz", hash = "sha256:6c3ccfe89c36f3e5b9837b9ee507472310164f352c9fe332120b764c9d60adbe"},
+]
+cython = [
+    {file = "Cython-0.29.30-cp27-cp27m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e5cb144728a335d7a7fd0a61dff6abb7a9aeff9acd46d50b886b7d9a95bb7311"},
+    {file = "Cython-0.29.30-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d52d5733dcb144deca8985f0a197c19cf71e6bd6bd9d8034f3f67b2dea68d12b"},
+    {file = "Cython-0.29.30-cp27-cp27mu-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0cd6c932e945af15ae4ddcf8fdc0532bda48784c92ed0a53cf4fae897067ccd1"},
+    {file = "Cython-0.29.30-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a30092c6e2d24255fbfe0525f9a750554f96a263ed986d12ac3c9f7d9a85a424"},
+    {file = "Cython-0.29.30-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:abcaf99f90cddc0f53600613eaafc81d27c4ac0671f0df8bce5466d4e86d54a1"},
+    {file = "Cython-0.29.30-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:9826981308802c61a76f967875b31b7c683b7fc369eabaa6cbc22efeb12c90e8"},
+    {file = "Cython-0.29.30-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:d166d9f853db436f5e10733a9bd615699ddb4238feadcbdf5ae50dc0b18b18f5"},
+    {file = "Cython-0.29.30-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0b83a342a071c4f14e7410568e0c0bd95e2f20c0b32944e3a721649a1357fda4"},
+    {file = "Cython-0.29.30-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:ffa8c09617833ff0824aa7926fa4fa9d2ec3929c67168e89105f276b7f36a63e"},
+    {file = "Cython-0.29.30-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:6b389a94b42909ff56d3491fde7c44802053a103701a7d210dcdd449a5b4f7b4"},
+    {file = "Cython-0.29.30-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:7eff71c39b98078deaad1d1bdbf10864d234e2ab5d5257e980a6926a8523f697"},
+    {file = "Cython-0.29.30-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8e08f18d249b9b65e272a5a60f3360a8922c4c149036b98fc821fe1afad5bdae"},
+    {file = "Cython-0.29.30-cp35-cp35m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3993aafd68a7311ef94e00e44a137f6a50a69af0575ebcc8a0a074ad4152a2b2"},
+    {file = "Cython-0.29.30-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:5c7cfd908efc77306ddd41ef07f5a7a352c9205ced5c1e00a0e5ece4391707c4"},
+    {file = "Cython-0.29.30-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:e605635a92ae862cb46d84d1d6883324518f9aaff4a71cede6d61df20b6a410c"},
+    {file = "Cython-0.29.30-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:786ee7b0cdb508b6de64c0f1f9c74f207186dfafad1ef938f25b7494cc481a80"},
+    {file = "Cython-0.29.30-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:1e078943bbde703ca08d43e719480eb8b187d9023cbd91798619f5b5e18d0d71"},
+    {file = "Cython-0.29.30-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5183356c756b56c2df12d96300d602e47ffb89943c5a0bded66faca5d3da7be0"},
+    {file = "Cython-0.29.30-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e36755e71fd20eceb410cc441b7f2586654c2edb013f4663842fdaf60b96c1ca"},
+    {file = "Cython-0.29.30-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e29d3487f357108b711f2f29319811d92166643d29aec1b8e063aad46a346775"},
+    {file = "Cython-0.29.30-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:5a8a3709ad9343a1dc02b8ec9cf6bb284be248d2c64af85464d9c3525eec74a5"},
+    {file = "Cython-0.29.30-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:b17639b6a155abaa61a89f6f1323fb57b138d0529911ca03978d594945d062ba"},
+    {file = "Cython-0.29.30-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:9462e9cf284d9b1d2c5b53d62188e3c09cc5c7a0018ba349d99b73cf930238de"},
+    {file = "Cython-0.29.30-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:58d2b734250c1093bc69c1c3a6f5736493b9f8b34eb765f0a28a4a09468c0b00"},
+    {file = "Cython-0.29.30-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:28db751e2d8365b39664d9cb62dc1668688b8fcc5b954e9ca9d20e0b8e03d8b0"},
+    {file = "Cython-0.29.30-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:5f2dae7dd56860018d5fd5032a71f11fdc224020932b463d0511a1536f27df85"},
+    {file = "Cython-0.29.30-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:d0859a958e0155b6ae4dee04170ccfac2c3d613a7e3bee8749614530b9e3b4a4"},
+    {file = "Cython-0.29.30-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:d0f34b44078e3e0b2f1be2b99044619b37127128e7d55c54bbd2438adcaf31d3"},
+    {file = "Cython-0.29.30-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:80a7255ad84620f53235c0720cdee2bc7431d9e3db7b3742823a606c329eb539"},
+    {file = "Cython-0.29.30-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3d0239c7a22a0f3fb1deec75cab0078eba4dd17868aa992a54a178851e0c8684"},
+    {file = "Cython-0.29.30-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c299c5b250ae9f81c38200441b6f1d023aeee9d8e7f61c04001c7437181ccb06"},
+    {file = "Cython-0.29.30-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:019d330ac580b2ca4a457c464ac0b8c35009d820ef5d09f328d6e31a10e1ce89"},
+    {file = "Cython-0.29.30-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:71fd1d910aced510c001936667fc7f2901c49b2ca7a2ad67358979c94a7f42ac"},
+    {file = "Cython-0.29.30-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:60d370c33d56077d30e5f425026e58c2559e93b4784106f61581cf54071f6270"},
+    {file = "Cython-0.29.30-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_24_i686.whl", hash = "sha256:20778297c8bcba201ca122a2f792a9899d6e64c68a92363dd7eb24306d54d7ce"},
+    {file = "Cython-0.29.30-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9f1fe924c920b699af27aefebd722df4cfbb85206291623cd37d1a7ddfd57792"},
+    {file = "Cython-0.29.30-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c79685dd4631a188e2385dc6a232896c7b67ea2e3e5f8b5555b4b743f475d6d7"},
+    {file = "Cython-0.29.30-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:88c5e2f92f16cd999ddfc43d572639679e8a057587088e627e98118e46a803e6"},
+    {file = "Cython-0.29.30-py2.py3-none-any.whl", hash = "sha256:acb72e0b42079862cf2f894964b41f261e941e75677e902c5f4304b3eb00af33"},
+    {file = "Cython-0.29.30.tar.gz", hash = "sha256:2235b62da8fe6fa8b99422c8e583f2fb95e143867d337b5c75e4b9a1a865f9e3"},
 ]
 distlib = [
     {file = "distlib-0.3.5-py2.py3-none-any.whl", hash = "sha256:b710088c59f06338ca514800ad795a132da19fda270e3ce4affc74abf955a26c"},
@@ -1562,8 +1612,8 @@ uvicorn = [
     {file = "uvicorn-0.18.2.tar.gz", hash = "sha256:cade07c403c397f9fe275492a48c1b869efd175d5d8a692df649e6e7e2ed8f4e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.16.0-py2.py3-none-any.whl", hash = "sha256:2202dbc33c4f9aaa13289d244d64f2ade8b0169e88d0213b505099b384c5ae04"},
-    {file = "virtualenv-20.16.0.tar.gz", hash = "sha256:6cfedd21e7584124a1d1e8f3b6e74c0bf8aeea44d9884b6d2d7241de5361a73c"},
+    {file = "virtualenv-20.16.2-py2.py3-none-any.whl", hash = "sha256:635b272a8e2f77cb051946f46c60a54ace3cb5e25568228bd6b57fc70eca9ff3"},
+    {file = "virtualenv-20.16.2.tar.gz", hash = "sha256:0ef5be6d07181946891f5abc8047fda8bc2f0b4b9bf222c64e6e8963baee76db"},
 ]
 watchdog = [
     {file = "watchdog-2.1.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a735a990a1095f75ca4f36ea2ef2752c99e6ee997c46b0de507ba40a09bf7330"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,17 @@ classifiers = [
     "Topic :: Software Development",
     "Typing :: Typed",
 ]
-include = ["CHANGELOG.md"]
+include = ["CHANGELOG.md", {path = "starlite/**/*.so", format = "wheel"}]
+exclude = ["starlite/**/*.py"]
 packages = [
     { include = "starlite" },
 ]
+
+[tool.poetry.build]
+# The allows us to build C extensions (using Cython). Unstable feature
+# https://github.com/python-poetry/poetry/issues/2740#issuecomment-666551481
+script = "build.py"
+generate-setup-file = false
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
@@ -59,6 +66,7 @@ freezegun = "*"
 pytest-mock = "*"
 tox = "*"
 requests = "*"
+cython = "*"
 
 [tool.poetry.extras]
 testing = ["requests", "brotli"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,14 @@ classifiers = [
     "Topic :: Software Development",
     "Typing :: Typed",
 ]
-include = ["CHANGELOG.md", {path = "starlite/**/*.so", format = "wheel"}]
-exclude = ["starlite/**/*.py"]
 packages = [
     { include = "starlite" },
+]
+include = [
+    "CHANGELOG.md",
+    {path = "starlite/**/*.so", format = "wheel"},
+    "starlite/**/*.py",
+    "py.typed"
 ]
 
 [tool.poetry.build]

--- a/starlite/routes.py
+++ b/starlite/routes.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 from uuid import UUID
 
 from anyio.to_thread import run_sync
-from pydantic import validate_arguments
 from pydantic.typing import AnyCallable
 from starlette.requests import HTTPConnection
 from starlette.responses import Response as StarletteResponse
@@ -49,7 +48,6 @@ class BaseRoute:
         "scope_type",
     )
 
-    @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
         *,
@@ -131,7 +129,6 @@ class HTTPRoute(BaseRoute):
         # see: https://stackoverflow.com/questions/472000/usage-of-slots
     )
 
-    @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
         *,
@@ -288,7 +285,6 @@ class WebSocketRoute(BaseRoute):
         # see: https://stackoverflow.com/questions/472000/usage-of-slots
     )
 
-    @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
         *,
@@ -334,7 +330,6 @@ class ASGIRoute(BaseRoute):
         # see: https://stackoverflow.com/questions/472000/usage-of-slots
     )
 
-    @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
         *,

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -11,7 +11,7 @@ def test_parse_query_params() -> None:
         "polluting": False,
     }
     request = create_test_request(query=query)  # type: ignore
-    result = parse_query_params(connection=request)
+    result = parse_query_params(request)
     assert result == {
         "value": ["10"],
         "veggies": ["tomato", "potato", "aubergine"],


### PR DESCRIPTION
This PR is a PoC for Cython compilation. 

To test it locally clone, `poetry install` and then run `poetry build`. It will create a dist folder with the compiled wheel, and leave *.so files in the `starlite` folder. You can then run the test suite - which will pass even after deleting the *.py files that have been compiled. 

We need to test and see if there are significant performance gains from using Cython here. Note the following:

1. Cython cant handle classes with generics
2. Cython is not compatible with the pydantic `validate_arguments` decorator

Whats required to make this something that we can actually build upon?

1. update of CI to build wheels for all required targets and testing of these.
2. update of the release scripts
