### PR TITLE
Remove all trailing slashes when normalizing paths

### DIFF
--- a/starlite/utils/url.py
+++ b/starlite/utils/url.py
@@ -6,11 +6,11 @@ def normalize_path(path: str) -> str:
     """
     Normalizes a given path by ensuring it starts with a slash and does not end with a slash
     """
-    if path == "/":
+    if path == "":
         return path
+    path = path.rstrip("/")
     if not path.startswith("/"):
         path = "/" + path
-    path = path.rstrip("/")
     path = re.sub("//+", "/", path)
     return path
 

--- a/starlite/utils/url.py
+++ b/starlite/utils/url.py
@@ -1,3 +1,4 @@
+import re
 from typing import Sequence
 
 
@@ -9,10 +10,8 @@ def normalize_path(path: str) -> str:
         return path
     if not path.startswith("/"):
         path = "/" + path
-    if path.endswith("/"):
-        path = path[: len(path) - 1]
-    while "//" in path:
-        path = path.replace("//", "/")
+    path = path.rstrip("/")
+    path = re.sub("//+", "/", path)
     return path
 
 

--- a/starlite/utils/url.py
+++ b/starlite/utils/url.py
@@ -6,8 +6,6 @@ def normalize_path(path: str) -> str:
     """
     Normalizes a given path by ensuring it starts with a slash and does not end with a slash
     """
-    if path == "":
-        return path
     path = path.rstrip("/")
     if not path.startswith("/"):
         path = "/" + path
@@ -19,8 +17,4 @@ def join_paths(paths: Sequence[str]) -> str:
     """
     Normalizes and joins path fragments
     """
-    normalized_fragments = []
-    for fragment in paths:
-        fragment = normalize_path(fragment)
-        normalized_fragments.append(fragment)
-    return "".join(normalized_fragments)
+    return normalize_path("/".join(paths))

--- a/tests/utils/test_url.py
+++ b/tests/utils/test_url.py
@@ -12,16 +12,28 @@ from starlite.utils.url import join_paths, normalize_path
         ("/path/", "sub/", "/path/sub"),
         ("path/", "sub/", "/path/sub"),
         ("path", "sub/", "/path/sub"),
+        ("/", "/root/sub", "/root/sub"),
     ],
 )
 def test_join_url_fragments(base: str, fragment: str, expected: str) -> None:
     assert join_paths([base, fragment]) == expected
 
 
+def test_join_empty_list() -> None:
+    assert join_paths([]) == "/"
+
+
+def test_join_single() -> None:
+    assert join_paths([""]) == "/"
+    assert join_paths(["/"]) == "/"
+    assert join_paths(["root"]) == "/root"
+    assert join_paths(["root//other"]) == "/root/other"
+
+
 @pytest.mark.parametrize(
     "base,expected",
     [
-        ("", ""),
+        ("", "/"),
         ("/path", "/path"),
         ("path/", "/path"),
         ("path", "/path"),

--- a/tests/utils/test_url.py
+++ b/tests/utils/test_url.py
@@ -18,6 +18,9 @@ def test_join_url_fragments(base: str, fragment: str, expected: str) -> None:
     assert join_paths([base, fragment]) == expected
 
 
-@pytest.mark.parametrize("base,expected", [("/path", "/path"), ("path/", "/path"), ("path", "/path")])
+@pytest.mark.parametrize(
+    "base,expected",
+    [("/path", "/path"), ("path/", "/path"), ("path", "/path"), ("path////path", "/path/path"), ("path//", "/path")],
+)
 def test_normalize_path(base: str, expected: str) -> None:
     assert normalize_path(base) == expected

--- a/tests/utils/test_url.py
+++ b/tests/utils/test_url.py
@@ -20,7 +20,15 @@ def test_join_url_fragments(base: str, fragment: str, expected: str) -> None:
 
 @pytest.mark.parametrize(
     "base,expected",
-    [("/path", "/path"), ("path/", "/path"), ("path", "/path"), ("path////path", "/path/path"), ("path//", "/path")],
+    [
+        ("", ""),
+        ("/path", "/path"),
+        ("path/", "/path"),
+        ("path", "/path"),
+        ("path////path", "/path/path"),
+        ("path//", "/path"),
+        ("///", "/"),
+    ],
 )
 def test_normalize_path(base: str, expected: str) -> None:
     assert normalize_path(base) == expected


### PR DESCRIPTION
`normalize_path` is supposed to make sure the path does not end in a
slash, but it only removes the last character if it is a slash.

Additionally, replace all strings of 2+ slashes with a single slash in
one pass, rather than replacing groups of two iteratively