### PR TITLE
Docs - fix link to `exception-handlers`

### DIFF
--- a/docs/usage/0-the-starlite-app/0-the-starlite-app.md
+++ b/docs/usage/0-the-starlite-app/0-the-starlite-app.md
@@ -31,7 +31,7 @@ The Starlite constructor accepts the following additional kwargs:
 - `cors_config`: An instance of `starlite.config.CORSConfig`. If set this enables the [CORSMiddleware](../7-middleware.md#built-in-middlewares).
 - `debug`: A boolean flag toggling debug mode on and off, if True, 404 errors will be rendered as HTML with a stack trace. This option should _not_ be used in production. Defaults to `False`.
 - `dependencies`: A dictionary mapping dependency providers. See [dependency-injection](../6-dependency-injection.md).
-- `exception_handlers`: A dictionary mapping exceptions or exception codes to handler functions. See [exception-handlers](../17-exceptions#exception-handling).
+- `exception_handlers`: A dictionary mapping exceptions or exception codes to handler functions. See [exception-handlers](../../17-exceptions#exception-handling).
 - `guards`: A list of guard callable. See [guards](../9-guards.md).
 - `middleware`: A list of middlewares. See [middleware](../7-middleware.md).
 - `on_shutdown`: A list of callables that are called during the application shutdown. See [startup-and-shutdown](./1-startup-and-shutdown.md).

--- a/docs/usage/1-routing/2-routers.md
+++ b/docs/usage/1-routing/2-routers.md
@@ -26,7 +26,7 @@ The `starlite.router.Router` constructor also accepts the following kwargs:
 - `after_response`: A [after response lifecycle hook handler](../13-lifecycle-hooks.md#after-response).
 - `before_request`: A [before request lifecycle hook handler](../13-lifecycle-hooks.md#before-request).
 - `dependencies`: A dictionary mapping dependency providers. See [dependency-injection](../6-dependency-injection.md).
-- `exception_handlers`: A dictionary mapping exceptions or exception codes to handler functions. See [exception-handlers](../17-exceptions#exception-handling).
+- `exception_handlers`: A dictionary mapping exceptions or exception codes to handler functions. See [exception-handlers](../../17-exceptions#exception-handling).
 - `guards`: A list of guard callable. See [guards](../9-guards.md).
 - `middleware`: A list of middlewares. See [middleware](../7-middleware.md).
 - `parameters`: A mapping of parameters definition that will be available on all sub route handlers. See [layered parameters](../3-parameters.md#layered-parameters).

--- a/docs/usage/1-routing/3-controllers.md
+++ b/docs/usage/1-routing/3-controllers.md
@@ -56,7 +56,7 @@ Aside from the `path` class variable see above, you can also also define the fol
 - `after_response`: A [after response lifecycle hook handler](../13-lifecycle-hooks.md#after-response).
 - `before_request`: A [before request lifecycle hook handler](../13-lifecycle-hooks.md#before-request).
 - `dependencies`: A dictionary mapping dependency providers. See [dependency-injection](../6-dependency-injection.md).
-- `exception_handlers`: A dictionary mapping exceptions or exception codes to handler functions. See [exception-handlers](../17-exceptions#exception-handling).
+- `exception_handlers`: A dictionary mapping exceptions or exception codes to handler functions. See [exception-handlers](../../17-exceptions#exception-handling).
 - `guards`: A list of guard callable. See [guards](../9-guards.md).
 - `middleware`: A list of middlewares. See [middleware](../7-middleware.md).
 - `parameters`: A mapping of parameters definition that will be available on all sub route handlers. See [layered parameters](../3-parameters.md#layered-parameters).

--- a/docs/usage/2-route-handlers/1_http_route_handlers.md
+++ b/docs/usage/2-route-handlers/1_http_route_handlers.md
@@ -58,7 +58,7 @@ Additionally, you can pass the following optional kwargs:
   event loop. This has an effect only for sync handler functions.
   See [using sync handler functions](#using-sync-handler-functions).
 - `exception_handlers`: A dictionary mapping exceptions or exception codes to handler functions.
-  See [exception-handlers](../17-exceptions#exception-handling).
+  See [exception-handlers](../../17-exceptions#exception-handling).
 
 And the following kwargs, which affect [OpenAPI schema generation](../12-openapi.md#route-handler-configuration)
 

--- a/docs/usage/7-middleware.md
+++ b/docs/usage/7-middleware.md
@@ -255,7 +255,7 @@ app = Starlite(
 ## Middlewares and Exceptions
 
 When an exception is raised by a route handler or dependency and is then transformed into a response by
-an [exception handler](17-exceptions#exception-handling), middlewares are still applied to it. The one limitation on
+an [exception handler](../17-exceptions#exception-handling), middlewares are still applied to it. The one limitation on
 this though are the two exceptions that can be raised by the ASGI router - `404 Not Found` and `405 Method Not Allowed`.
 These exceptions are raised before them middleware stack is called, and are only handled by exceptions handlers defined
 on the Starlite app instance itself. Thus if you need to modify the responses generated for these exceptions, you will


### PR DESCRIPTION
The existing links to the `17-exceptions` page are currently broken. This PR fixes them