### PR TITLE
Update `to_response` and datastructures

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,0 +1,6 @@
+# this file is used to create an image for running the docs.
+FROM squidfunk/mkdocs-material
+
+RUN pip install --upgrade pip && pip install --no-cache-dir mkdocstrings[python]
+
+ENTRYPOINT ["mkdocs"]

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,6 +1,6 @@
 # this file is used to create an image for running the docs.
 FROM squidfunk/mkdocs-material
 
-RUN pip install --upgrade pip && pip install --no-cache-dir mkdocstrings[python]
+RUN pip install --upgrade pip && pip install --no-cache-dir mkdocstrings[python] black
 
 ENTRYPOINT ["mkdocs"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,10 +34,11 @@ consult the theme docs as a first step.
 
 ### Running the Docs Locally
 
-To run the docs locally, use docker and follow these steps:
+To run the docs locally, simply use the `docker-compose` configuration in place by executing `docker compose up`.
+On the first run it will pull and build the image, but afterwards this should be quite fast.
 
-- pull the theme image with `docker pull squidfunk/mkdocs-material`
-- run the docs site locally with `docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material`
+Note: if you want your terminal back use `docker compose up --detach` but then you will need to bring the docs down
+with `docker compose down` rather than ctrl+C.
 
 ### Writing and Editing Docs
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  docs:
+    build:
+      dockerfile: .docker/Dockerfile
+      context: .
+    ports:
+      - 8000:8000
+    volumes:
+      - .:/docs
+    command:
+      - "serve"
+      - "--dev-addr=0.0.0.0:8000"

--- a/docs/reference/connection.md
+++ b/docs/reference/connection.md
@@ -1,5 +1,25 @@
 # connection
 
 ::: starlite.connection.Request
+    options:
+        show_source: false
+        members:
+            - app
+            - user
+            - auth
+            - query_params
+            - method
+            - json
 
 ::: starlite.connection.WebSocket
+    options:
+        show_source: false
+        members:
+            - app
+            - user
+            - auth
+            - query_params
+            - receive_json
+            - send_json
+            - receive
+            - send

--- a/docs/reference/connection.md
+++ b/docs/reference/connection.md
@@ -1,3 +1,5 @@
 # connection
 
 ::: starlite.connection.Request
+
+::: starlite.connection.WebSocket

--- a/docs/reference/datastructures.md
+++ b/docs/reference/datastructures.md
@@ -1,19 +1,77 @@
 # datastructures
 
 ::: starlite.datastructures.BackgroundTask
+    options:
+        show_source: false
+        members:
+            - __init__
 
 ::: starlite.datastructures.BackgroundTasks
+    options:
+        show_source: false
+        members:
+            - __init__
 
 ::: starlite.datastructures.State
 
 ::: starlite.datastructures.Cookie
+    options:
+        show_source: false
+        members:
+            - key
+            - value
+            - max_age
+            - expires
+            - path
+            - domain
+            - secure
+            - httponly
+            - samesite
+            - description
+            - documentation_only
 
 ::: starlite.datastructures.File
+    options:
+        show_source: false
+        members:
+            - background
+            - headers
+            - cookies
+            - path
+            - filename
+            - stat_result
 
 ::: starlite.datastructures.Redirect
+    options:
+        show_source: false
+        members:
+            - background
+            - headers
+            - cookies
+            - path
 
 ::: starlite.datastructures.Stream
+    options:
+        show_source: false
+        members:
+            - background
+            - headers
+            - cookies
+            - iterator
 
 ::: starlite.datastructures.Template
+    options:
+        show_source: false
+        members:
+            - background
+            - headers
+            - cookies
+            - name
+            - context
 
 ::: starlite.datastructures.ResponseHeader
+    options:
+        show_source: false
+        members:
+            - documentation_only
+            - value

--- a/docs/reference/enums.md
+++ b/docs/reference/enums.md
@@ -1,1 +1,13 @@
 # enums
+
+::: starlite.enums.HttpMethod
+
+::: starlite.enums.MediaType
+
+::: starlite.enums.OpenAPIMediaType
+
+::: starlite.enums.RequestEncodingType
+
+::: starlite.enums.ScopeType
+
+::: starlite.enums.ParamType

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -1,12 +1,37 @@
 # types
 
+::: starlite.types.T
+
 ::: starlite.types.H
+
 ::: starlite.types.AfterRequestHandler
+
+::: starlite.types.AfterRequestHandler
+
 ::: starlite.types.AfterResponseHandler
+
 ::: starlite.types.BeforeRequestHandler
+
 ::: starlite.types.CacheKeyBuilder
+
 ::: starlite.types.ControllerRouterHandler
+
 ::: starlite.types.ExceptionHandler
+
 ::: starlite.types.Guard
+
+::: starlite.types.Method
+
+::: starlite.types.ReservedKwargs
+
+::: starlite.types.ReservedKwargs
+
+::: starlite.types.AsyncAnyCallable
+
 ::: starlite.types.LifeCycleHandler
+
+::: starlite.types.MiddlewareProtocol
+
+::: starlite.types.Partial
+
 ::: starlite.types.Middleware

--- a/poetry.lock
+++ b/poetry.lock
@@ -727,7 +727,7 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydantic-factories"
-version = "1.4.1"
+version = "1.5.0"
 description = "Mock data generation for pydantic based models"
 category = "main"
 optional = false
@@ -1785,8 +1785,8 @@ pydantic = [
     {file = "pydantic-1.9.1.tar.gz", hash = "sha256:1ed987c3ff29fff7fd8c3ea3a3ea877ad310aae2ef9889a119e22d3f2db0691a"},
 ]
 pydantic-factories = [
-    {file = "pydantic-factories-1.4.1.tar.gz", hash = "sha256:0ac03224ba5677de3d43d304beb4648c0dcbdf0e997e5c6d34af0d09794ccb81"},
-    {file = "pydantic_factories-1.4.1-py3-none-any.whl", hash = "sha256:775e550c359ad32cb23e723dfba7b3bda2043880e5db7dd64d2d2948f87b894f"},
+    {file = "pydantic-factories-1.5.0.tar.gz", hash = "sha256:46d81a27d82e7521f46792fc8eb5b241a5e475ab5c758e60b47a61b691d1ebaa"},
+    {file = "pydantic_factories-1.5.0-py3-none-any.whl", hash = "sha256:48e056c82d27bda5ceb2480fe6eb06a0c91e0a0b24d6536b5fcdfc5dd5752773"},
 ]
 pydantic-openapi-schema = [
     {file = "pydantic-openapi-schema-1.0.0.tar.gz", hash = "sha256:28cb8b52e18c66e04215ac3e150dd6f9ea8d5075069f08aaff8e1a1290e17f89"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ disable = [
     "logging-fstring-interpolation",
     "ungrouped-imports",
     "too-many-lines",
+    "cyclic-import",
 ]
 enable = "useless-suppression"
 extension-pkg-allow-list = ["pydantic","orjson","picologging"]

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -332,8 +332,8 @@ class Starlite(Router):
             value: an instance of [Router][starlite.router.Router], a subclasses of
         [Controller][starlite.controller.Controller] or any function decorated by the route handler decorators.
 
-        Returns: None
-
+        Returns:
+            None
         """
         routes = super().register(value=value)
         for route in routes:

--- a/starlite/connection.py
+++ b/starlite/connection.py
@@ -36,8 +36,8 @@ class Request(StarletteRequest, Generic[User, Auth]):
         """
         Allows access to user data.
 
-        Notes:
-            If 'user' is not set in scope via an 'AuthMiddleware', raises an exception
+        Raises:
+            [ImproperlyConfiguredException][starlite.exceptions.ImproperlyConfiguredException]: If 'user' is not set in scope via an 'AuthMiddleware', raises an exception
 
         Returns:
             A type correlating to the generic variable User.
@@ -51,8 +51,8 @@ class Request(StarletteRequest, Generic[User, Auth]):
         """
         Allows access to auth data.
 
-        Notes:
-            If 'auth' is not set in scope via an 'AuthMiddleware', raises an exception
+        Raises:
+            [ImproperlyConfiguredException][starlite.exceptions.ImproperlyConfiguredException]: If 'auth' is not set in scope via an 'AuthMiddleware', raises an exception
 
         Returns:
             A type correlating to the generic variable Auth.
@@ -113,8 +113,8 @@ class WebSocket(StarletteWebSocket, Generic[User, Auth]):
         """
         Allows access to user data.
 
-        Notes:
-            If 'user' is not set in scope via an 'AuthMiddleware', raises an exception
+        Raises:
+            [ImproperlyConfiguredException][starlite.exceptions.ImproperlyConfiguredException]: If 'user' is not set in scope via an 'AuthMiddleware', raises an exception
 
         Returns:
             A type correlating to the generic variable User.
@@ -128,8 +128,8 @@ class WebSocket(StarletteWebSocket, Generic[User, Auth]):
         """
         Allows access to auth data.
 
-        Notes:
-            If 'auth' is not set in scope via an 'AuthMiddleware', raises an exception
+        Raises:
+            [ImproperlyConfiguredException][starlite.exceptions.ImproperlyConfiguredException]: If 'auth' is not set in scope via an 'AuthMiddleware', raises an exception
 
         Returns:
             A type correlating to the generic variable Auth.

--- a/starlite/datastructures.py
+++ b/starlite/datastructures.py
@@ -279,6 +279,10 @@ class Template(ResponseContainer["TemplateResponse"]):
             status_code: A response status code.
             app: The [Starlite][starlite.app.Starlite] application instance.
 
+        Raises:
+            [ImproperlyConfiguredException][starlite.exceptions.ImproperlyConfiguredException]: if app.template_engine
+            is not configured.
+
         Returns:
             A TemplateResponse instance
         """

--- a/starlite/datastructures.py
+++ b/starlite/datastructures.py
@@ -1,25 +1,39 @@
+# pylint: disable=unused-argument, import-outside-toplevel
 import os
+from abc import ABC, abstractmethod
 from copy import copy
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncIterator,
     Callable,
     Dict,
+    Generic,
     Iterator,
     List,
     Optional,
+    TypeVar,
     Union,
     cast,
 )
 
 from pydantic import BaseConfig, BaseModel, FilePath, validator
+from pydantic.generics import GenericModel
 from pydantic_openapi_schema.v3_1_0 import Header
 from starlette.background import BackgroundTask as StarletteBackgroundTask
 from starlette.background import BackgroundTasks as StarletteBackgroundTasks
 from starlette.datastructures import State as StarletteStateClass
+from starlette.responses import FileResponse, RedirectResponse
+from starlette.responses import Response as StarletteResponse
+from starlette.responses import StreamingResponse
 from typing_extensions import Literal, ParamSpec
 
 P = ParamSpec("P")
+
+if TYPE_CHECKING:
+    from starlite.app import Starlite
+    from starlite.enums import MediaType
+    from starlite.response import TemplateResponse
 
 
 class BackgroundTask(StarletteBackgroundTask):
@@ -98,11 +112,10 @@ class Cookie(BaseModel):
     """defines the Cookie instance as for OpenAPI documentation purpose only"""
 
 
-class File(BaseModel):
-    """
-    Container type for returning File responses
-    """
+R = TypeVar("R", bound=StarletteResponse)
 
+
+class ResponseContainer(GenericModel, ABC, Generic[R]):
     class Config(BaseConfig):
         arbitrary_types_allowed = True
         copy_on_model_validation = False
@@ -113,10 +126,35 @@ class File(BaseModel):
         [BackgroundTasks][starlite.datastructures.BackgroundTasks] to execute after the response is finished.
         Defaults to None.
     """
-    headers: Dict[str, str] = {}
+    headers: Dict[str, Any] = {}
     """A string/string dictionary of response headers. Header keys are insensitive. Defaults to None."""
     cookies: List[Cookie] = []
     """A list of Cookie instances to be set under the response 'Set-Cookie' header. Defaults to None."""
+
+    @abstractmethod
+    def to_response(
+        self, headers: Dict[str, Any], media_type: Union["MediaType", str], status_code: int, app: "Starlite"
+    ) -> R:  # pragma: no cover
+        """
+        Abstract method that should be implemented by subclasses. Returns a Starlette compatible Response instance.
+
+        Args:
+            headers: A dictionary of headers.
+            media_type: A string or member of the [MediaType][starlite.enums.MediaType] enum.
+            status_code: A response status code.
+            app: The [Starlite][starlite.app.Starlite] application instance.
+
+        Returns:
+            A Response Object
+        """
+        raise NotImplementedError("not implemented")
+
+
+class File(ResponseContainer[FileResponse]):
+    """
+    Container type for returning File responses
+    """
+
     path: FilePath
     """Path to the file to send"""
     filename: str
@@ -131,76 +169,132 @@ class File(BaseModel):
         """Set the stat_result value for the given filepath"""
         return value or os.stat(cast("str", values.get("path")))
 
+    def to_response(
+        self,
+        headers: Dict[str, Any],
+        media_type: Union["MediaType", str],
+        status_code: int,
+        app: "Starlite",
+    ) -> FileResponse:
+        """
+        Creates a FileResponse instance.
 
-class Redirect(BaseModel):
+        Args:
+            headers: A dictionary of headers.
+            media_type: A string or member of the [MediaType][starlite.enums.MediaType] enum.
+            status_code: A response status code.
+            app: The [Starlite][starlite.app.Starlite] application instance.
+
+        Returns:
+            A FileResponse instance
+        """
+        return FileResponse(
+            background=self.background,
+            filename=self.filename,
+            headers=headers,
+            media_type=media_type,
+            path=self.path,
+            stat_result=self.stat_result,
+            status_code=status_code,
+        )
+
+
+class Redirect(ResponseContainer[RedirectResponse]):
     """
     Container type for returning Redirect responses
     """
 
-    class Config(BaseConfig):
-        arbitrary_types_allowed = True
-        copy_on_model_validation = False
-
-    background: Optional[Union[BackgroundTask, BackgroundTasks]] = None
-    """
-        A [BackgroundTask][starlite.datastructures.BackgroundTask] instance or
-        [BackgroundTasks][starlite.datastructures.BackgroundTasks] to execute after the response is finished.
-        Defaults to None.
-    """
-    headers: Dict[str, str] = {}
-    """A string/string dictionary of response headers. Header keys are insensitive. Defaults to None."""
-    cookies: List[Cookie] = []
-    """A list of Cookie instances to be set under the response 'Set-Cookie' header. Defaults to None."""
     path: str
     """Redirection path"""
 
+    def to_response(
+        self, headers: Dict[str, Any], media_type: Union["MediaType", str], status_code: int, app: "Starlite"
+    ) -> RedirectResponse:
+        """
+        Creates a RedirectResponse instance.
 
-class Stream(BaseModel):
+        Args:
+            headers: A dictionary of headers.
+            media_type: A string or member of the [MediaType][starlite.enums.MediaType] enum.
+            status_code: A response status code.
+            app: The [Starlite][starlite.app.Starlite] application instance.
+
+        Returns:
+            A RedirectResponse instance
+        """
+        return RedirectResponse(headers=headers, status_code=status_code, url=self.path, background=self.background)
+
+
+class Stream(ResponseContainer[StreamingResponse]):
     """
     Container type for returning Stream responses
     """
 
-    class Config(BaseConfig):
-        arbitrary_types_allowed = True
-        copy_on_model_validation = False
-
-    background: Optional[Union[BackgroundTask, BackgroundTasks]] = None
-    """
-        A [BackgroundTask][starlite.datastructures.BackgroundTask] instance or
-        [BackgroundTasks][starlite.datastructures.BackgroundTasks] to execute after the response is finished.
-        Defaults to None.
-    """
-    headers: Dict[str, str] = {}
-    """A string/string dictionary of response headers. Header keys are insensitive. Defaults to None."""
-    cookies: List[Cookie] = []
-    """A list of Cookie instances to be set under the response 'Set-Cookie' header. Defaults to None."""
     iterator: Union[Iterator[Any], AsyncIterator[Any]]
     """Iterator returning stream chunks"""
 
+    def to_response(
+        self, headers: Dict[str, Any], media_type: Union["MediaType", str], status_code: int, app: "Starlite"
+    ) -> StreamingResponse:
+        """
+        Creates a StreamingResponse instance.
 
-class Template(BaseModel):
+        Args:
+            headers: A dictionary of headers.
+            media_type: A string or member of the [MediaType][starlite.enums.MediaType] enum.
+            status_code: A response status code.
+            app: The [Starlite][starlite.app.Starlite] application instance.
+
+        Returns:
+            A StreamingResponse instance
+        """
+        return StreamingResponse(
+            background=self.background,
+            content=self.iterator,
+            headers=headers,
+            media_type=media_type,
+            status_code=status_code,
+        )
+
+
+class Template(ResponseContainer["TemplateResponse"]):
     """
     Container type for returning Template responses
     """
 
-    class Config(BaseConfig):
-        arbitrary_types_allowed = True
-        copy_on_model_validation = False
-
-    background: Optional[Union[BackgroundTask, BackgroundTasks]] = None
-    """
-        A [BackgroundTask][starlite.datastructures.BackgroundTask] instance or
-        [BackgroundTasks][starlite.datastructures.BackgroundTasks] to execute after the response is finished.
-        Defaults to None.
-    """
-    headers: Dict[str, str] = {}
-    """A string/string dictionary of response headers. Header keys are insensitive. Defaults to None."""
-    cookies: List[Cookie] = []
-    """A list of Cookie instances to be set under the response 'Set-Cookie' header. Defaults to None."""
     name: str
     """Path-like name for the template to be rendered, e.g. "index.html"."""
     context: Optional[Dict[str, Any]] = None
     """A dictionary of key/value pairs to be passed to the temple engine's render method. Defaults to None."""
+
+    def to_response(
+        self, headers: Dict[str, Any], media_type: Union["MediaType", str], status_code: int, app: "Starlite"
+    ) -> "TemplateResponse":
+        """
+        Creates a TemplateResponse instance.
+
+        Args:
+            headers: A dictionary of headers.
+            media_type: A string or member of the [MediaType][starlite.enums.MediaType] enum.
+            status_code: A response status code.
+            app: The [Starlite][starlite.app.Starlite] application instance.
+
+        Returns:
+            A TemplateResponse instance
+        """
+        from starlite import ImproperlyConfiguredException
+        from starlite.response import TemplateResponse
+
+        if not app.template_engine:
+            raise ImproperlyConfiguredException("Template engine is not configured")
+        return TemplateResponse(
+            background=self.background,
+            context=self.context,
+            headers=headers,
+            status_code=status_code,
+            template_engine=app.template_engine,
+            template_name=self.name,
+        )
 
 
 class ResponseHeader(Header):

--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -5,9 +5,7 @@ from inspect import Signature, isawaitable, isclass
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union, cast
 
 from pydantic import validate_arguments
-from starlette.responses import FileResponse, RedirectResponse
 from starlette.responses import Response as StarletteResponse
-from starlette.responses import StreamingResponse
 from starlette.status import HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT
 
 from starlite.constants import REDIRECT_STATUS_CODES
@@ -17,9 +15,8 @@ from starlite.datastructures import (
     Cookie,
     File,
     Redirect,
+    ResponseContainer,
     ResponseHeader,
-    Stream,
-    Template,
 )
 from starlite.enums import HttpMethod, MediaType
 from starlite.exceptions import (
@@ -35,7 +32,7 @@ from starlite.lifecycle_hooks import (
 )
 from starlite.plugins import PluginProtocol, get_plugin_for_value
 from starlite.provide import Provide
-from starlite.response import Response, TemplateResponse
+from starlite.response import Response
 from starlite.types import (
     AfterRequestHandler,
     AfterResponseHandler,
@@ -261,6 +258,9 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         Returns all header parameters in the scope of the handler function
 
         This method is memoized so the computation occurs only once.
+
+        Returns:
+            A dictionary mapping keys to [ResponseHeader][starlite.datastructures.ResponseHeader] instances
         """
         if self._resolved_response_headers is Empty:
             self._resolved_response_headers = {}
@@ -273,6 +273,9 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         Returns a list of Cookie instances. Filters the list to ensure each cookie key is unique.
 
         This method is memoized so the computation occurs only once.
+
+        Returns:
+            A list of [Cookie][starlite.datastructures.Cookie] instances.
         """
         if self._resolved_response_cookies is Empty:
             self._resolved_response_cookies = []
@@ -289,7 +292,10 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         Resolves the before_handler handler by starting from the route handler and moving up.
 
         If a handler is found it is returned, otherwise None is set.
-        This method is memoized so the computation occurs only once
+        This method is memoized so the computation occurs only once.
+
+        Returns:
+            An optional [before request lifecycle hook handler][starlite.life_cycle.BeforeRequestHook]
         """
         if self._resolved_before_request is Empty:
             self._resolved_before_request = BeforeRequestHook.resolve_for_handler(self, "before_request")
@@ -300,7 +306,10 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         Resolves the after_request handler by starting from the route handler and moving up.
 
         If a handler is found it is returned, otherwise None is set.
-        This method is memoized so the computation occurs only once
+        This method is memoized so the computation occurs only once.
+
+        Returns:
+            An optional [after request lifecycle hook handler][starlite.life_cycle.AfterRequestHook]
         """
         if self._resolved_after_request is Empty:
             self._resolved_after_request = AfterRequestHook.resolve_for_handler(self, "after_request")
@@ -311,7 +320,10 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         Resolves the after_response handler by starting from the route handler and moving up.
 
         If a handler is found it is returned, otherwise None is set.
-        This method is memoized so the computation occurs only once
+        This method is memoized so the computation occurs only once.
+
+        Returns:
+            An optional [after response lifecycle hook handler][starlite.life_cycle.AfterResponseHook]
         """
         if self._resolved_after_response is Empty:
             self._resolved_after_response = AfterResponseHook.resolve_for_handler(self, "after_response")
@@ -320,52 +332,72 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
     @property
     def http_methods(self) -> List["Method"]:
         """
-        Returns a list of the RouteHandler's HttpMethod members
+        Returns:
+            A list of the RouteHandler's [HttpMethod][starlite.types.Method] strings
         """
         return cast("List[Method]", self.http_method if isinstance(self.http_method, list) else [self.http_method])
 
     async def to_response(self, data: Any, app: "Starlite", plugins: List[PluginProtocol]) -> StarletteResponse:
         """
-        Given a data kwarg, determine its type and return the appropriate response
+        Determines the correct response type and returns it
+
+        Args:
+            data: An arbitrary value that is either a [Response][starlite.response.Response] instance,
+                a Starlette response, a [ResponseContainer][starlite.datastructures.ResponseContainer]
+                or a value for a response body.
+            app: The [Starlite][starlite.app.Starlite] application instance
+            plugins: [plugins][starlite.plugins.base.PluginProtocol]
+
+        Returns:
+            A Starlette compatible Response object
         """
-        if isawaitable(data):
-            data = await data
+
+        data = await self._normalize_response_data(data=data, plugins=plugins)
+
         media_type = self.media_type.value if isinstance(self.media_type, Enum) else self.media_type
-        headers = {k: v.value for k, v in self.resolve_response_headers().items() if not v.documentation_only}
+        headers = self.resolve_response_headers()
         cookies = self.resolve_response_cookies()
-        response: StarletteResponse
-        if isinstance(data, (StarletteResponse, Redirect, File, Stream, Template)):
-            response = self._get_response_from_data(
-                app=app,
-                cookies=cookies,
-                data=data,
-                headers=headers,
-                media_type=media_type,
-            )
+
+        if isinstance(data, ResponseContainer):
+            headers = {**self._normalize_headers(headers), **data.headers}
+            response = data.to_response(app=app, headers=headers, status_code=self.status_code, media_type=media_type)
+        elif isinstance(data, StarletteResponse):
+            response = data
         else:
-            plugin = get_plugin_for_value(value=data, plugins=plugins)
-            if plugin:
-                if is_async_callable(plugin.to_dict):
-                    if isinstance(data, (list, tuple)):
-                        data = [await plugin.to_dict(datum) for datum in data]  # type: ignore
-                    else:
-                        data = await plugin.to_dict(data)  # type: ignore
-                else:
-                    if isinstance(data, (list, tuple)):
-                        data = [plugin.to_dict(datum) for datum in data]
-                    else:
-                        data = plugin.to_dict(data)
-            response_class = self.resolve_response_class()
-            response = response_class(
-                background=self.background,
-                content=data,
-                headers=headers,
-                media_type=media_type,
-                status_code=self.status_code,
-            )
-            for cookie in self._normalize_cookies(cookies, []):
+            response = self._create_response(data=data, headers=self._normalize_headers(headers), media_type=media_type)
+
+        if cookies:
+            if hasattr(data, "cookies"):
+                normalized_cookies = self._normalize_cookies(data.cookies, cookies)
+            else:
+                normalized_cookies = self._normalize_cookies(cookies, [])
+
+            for cookie in normalized_cookies:
                 response.set_cookie(**cookie)
+
         return await self._process_after_request_hook(response)
+
+    def _create_response(self, data: Any, headers: Dict[str, Any], media_type: Union[MediaType, str]) -> Response:
+        """
+        Creates a response based on the passed in data
+
+        Args:
+            data: Value for the response body
+            headers: A mapping of key value pairs to set as the response headers
+            media_type: A string or [MediaType][starlite.enums.MediaType] enum member
+
+        Returns: Response
+
+        """
+
+        response_class = self.resolve_response_class()
+        return response_class(
+            background=self.background,
+            content=data,
+            headers=headers,
+            media_type=media_type,
+            status_code=self.status_code,
+        )
 
     def _validate_handler_function(self) -> None:
         """
@@ -394,6 +426,37 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
             raise ImproperlyConfiguredException("'data' kwarg is unsupported for 'GET' request handlers")
 
     @staticmethod
+    async def _normalize_response_data(data: Any, plugins: List[PluginProtocol]) -> Any:
+        """
+        Normalizes the response's data by awaiting any async values and resolving and plugins
+
+        Args:
+            data: An arbitrary value
+            plugins: A list of [plugins][starlite.plugins.base.PluginProtocol]
+
+        Returns:
+            Value for the response body
+        """
+        if isawaitable(data):
+            data = await data
+
+        if plugins:
+            plugin = get_plugin_for_value(value=data, plugins=plugins)
+            if plugin:
+                if is_async_callable(plugin.to_dict):
+                    if isinstance(data, (list, tuple)):
+                        data = [await plugin.to_dict(datum) for datum in data]  # type: ignore
+                    else:
+                        data = await plugin.to_dict(data)  # type: ignore
+                else:
+                    if isinstance(data, (list, tuple)):
+                        data = [plugin.to_dict(datum) for datum in data]
+                    else:
+                        data = plugin.to_dict(data)
+
+        return data
+
+    @staticmethod
     def _normalize_cookies(local_cookies: List[Cookie], layered_cookies: List[Cookie]) -> List[Dict[str, Any]]:
         """
         Given two lists of cookies, ensures the uniqueness of cookies by key
@@ -409,63 +472,19 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
                 normalized_cookies.append(cookie.dict(exclude_none=True, exclude={"documentation_only", "description"}))
         return normalized_cookies
 
-    def _get_response_from_data(
-        self,
-        app: "Starlite",
-        cookies: List[Cookie],
-        data: Union[StarletteResponse, Redirect, File, Stream, Template],
-        headers: dict,
-        media_type: Union[MediaType, str],
-    ) -> StarletteResponse:
+    @staticmethod
+    def _normalize_headers(headers: Dict[str, "ResponseHeader"]) -> Dict[str, Any]:
         """
-        Determines the correct response type to return given data
+        Given a dictionary of ResponseHeader, filters them and returns a dictionary of values
+
+        Args:
+            headers: A dictionary of [ResponseHeader][starlite.datastructures.ResponseHeader] values
+
+        Returns:
+            A string keyed dictionary of normalized values
+
         """
-        if isinstance(data, (Redirect, File, Stream, Template)):
-            headers.update(data.headers)
-            normalized_cookies = self._normalize_cookies(data.cookies, cookies)
-            if isinstance(data, Redirect):
-                response: "StarletteResponse" = RedirectResponse(
-                    headers=headers, status_code=self.status_code, url=data.path, background=data.background
-                )
-            elif isinstance(data, File):
-                response = FileResponse(
-                    background=data.background,
-                    filename=data.filename,
-                    headers=headers,
-                    media_type=media_type,
-                    path=data.path,
-                    stat_result=data.stat_result,
-                )
-            elif isinstance(data, Stream):
-                response = StreamingResponse(
-                    background=data.background,
-                    content=data.iterator,
-                    headers=headers,
-                    media_type=media_type,
-                    status_code=self.status_code,
-                )
-            else:
-                if not app.template_engine:
-                    raise ImproperlyConfiguredException("Template engine is not configured")
-                response = TemplateResponse(
-                    background=data.background,
-                    context=data.context,
-                    headers=headers,
-                    status_code=self.status_code,
-                    template_engine=app.template_engine,
-                    template_name=data.name,
-                )
-        elif isinstance(data, Response):
-            response = data
-            normalized_cookies = self._normalize_cookies(data.cookies, cookies)
-        else:
-            response = data
-            normalized_cookies = self._normalize_cookies(cookies, [])
-
-        for cookie in normalized_cookies:
-            response.set_cookie(**cookie)
-
-        return response
+        return {k: v.value for k, v in headers.items() if not v.documentation_only}
 
     async def _process_after_request_hook(
         self,
@@ -473,6 +492,12 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
     ) -> StarletteResponse:
         """
         Receives a response and handles after_request, if defined.
+
+        Args:
+            response: A Starlette compatible response object
+
+        Returns:
+            A Starlette compatible response object
         """
         after_request = self.resolve_after_request()
         if after_request:

--- a/tests/connection/websocket/test_websocket.py
+++ b/tests/connection/websocket/test_websocket.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 import pytest
 from starlette.websockets import WebSocketDisconnect
 
@@ -5,9 +7,12 @@ from starlite import websocket
 from starlite.connection import WebSocket
 from starlite.testing import create_test_client
 
+if TYPE_CHECKING:
+    from typing_extensions import Literal
+
 
 @pytest.mark.parametrize("mode", ["text", "binary"])
-def test_websocket_send_receive_json(mode: str) -> None:
+def test_websocket_send_receive_json(mode: "Literal['text', 'binary']") -> None:
     @websocket(path="/")
     async def websocket_handler(socket: WebSocket) -> None:
         await socket.accept()
@@ -25,7 +30,7 @@ def test_websocket_receive_json_invalid_mode() -> None:
     @websocket(path="/")
     async def websocket_handler(socket: WebSocket) -> None:
         await socket.accept()
-        await socket.receive_json(mode="weezer")
+        await socket.receive_json(mode="weezer")  # type: ignore
 
     with pytest.raises(WebSocketDisconnect) as exc, create_test_client(
         route_handlers=[websocket_handler]
@@ -42,7 +47,7 @@ def test_websocket_send_json_invalid_mode() -> None:
     @websocket(path="/")
     async def websocket_handler(socket: WebSocket) -> None:
         await socket.accept()
-        await socket.send_json({"whoo": "psie"}, mode="matchbox 20")
+        await socket.send_json({"whoo": "psie"}, mode="matchbox 20")  # type: ignore
 
     with pytest.raises(WebSocketDisconnect) as exc, create_test_client(
         route_handlers=[websocket_handler]

--- a/tests/connection/websocket/test_websocket.py
+++ b/tests/connection/websocket/test_websocket.py
@@ -39,7 +39,7 @@ def test_websocket_receive_json_invalid_mode() -> None:
 
     assert (
         str(exc)
-        == """<ExceptionInfo WebSocketDisconnect(4500, '500 - InternalServerException - The "mode" argument should be "text" or "binary".') tblen=3>"""
+        == """<ExceptionInfo WebSocketDisconnect(4500, '500 - ImproperlyConfiguredException - The "mode" argument should be "text" or "binary".') tblen=3>"""
     )
 
 
@@ -56,7 +56,7 @@ def test_websocket_send_json_invalid_mode() -> None:
 
     assert (
         str(exc)
-        == """<ExceptionInfo WebSocketDisconnect(4500, '500 - InternalServerException - The "mode" argument should be "text" or "binary".') tblen=3>"""
+        == """<ExceptionInfo WebSocketDisconnect(4500, '500 - ImproperlyConfiguredException - The "mode" argument should be "text" or "binary".') tblen=3>"""
     )
 
 

--- a/tests/handlers/http/test_to_response.py
+++ b/tests/handlers/http/test_to_response.py
@@ -107,7 +107,7 @@ async def test_to_response_returning_redirect_response() -> None:
     def test_function() -> Redirect:
         return Redirect(
             path="/somewhere-else",
-            headers={"file-header": "abc"},
+            headers={"response-header": "abc"},
             cookies=[Cookie(key="redirect-cookie", value="xyz")],
             background=background_task,
         )
@@ -119,7 +119,7 @@ async def test_to_response_returning_redirect_response() -> None:
         assert isinstance(response, RedirectResponse)
         assert response.headers["location"] == "/somewhere-else"
         assert response.headers["local-header"] == "123"
-        assert response.headers["file-header"] == "abc"
+        assert response.headers["response-header"] == "abc"
         cookies = response.headers.getlist("set-cookie")
         assert len(cookies) == 2
         assert cookies[0] == "redirect-cookie=xyz; Path=/; SameSite=lax"
@@ -142,7 +142,7 @@ async def test_to_response_returning_file_response() -> None:
         return File(
             path=current_file_path,
             filename=filename,
-            headers={"file-header": "abc"},
+            headers={"response-header": "abc"},
             cookies=[Cookie(key="file-cookie", value="xyz")],
             background=background_task,
         )
@@ -156,7 +156,7 @@ async def test_to_response_returning_file_response() -> None:
         assert response.path == current_file_path
         assert response.filename == filename
         assert response.headers["local-header"] == "123"
-        assert response.headers["file-header"] == "abc"
+        assert response.headers["response-header"] == "abc"
         cookies = response.headers.getlist("set-cookie")
         assert len(cookies) == 3
         assert cookies[0] == "file-cookie=xyz; Path=/; SameSite=lax"
@@ -194,7 +194,7 @@ async def test_to_response_streaming_response(iterator: Any, should_raise: bool)
         def test_function() -> Stream:
             return Stream(
                 iterator=iterator,
-                headers={"file-header": "abc"},
+                headers={"response-header": "abc"},
                 cookies=[Cookie(key="streaming-cookie", value="xyz")],
                 background=background_task,
             )
@@ -205,7 +205,7 @@ async def test_to_response_streaming_response(iterator: Any, should_raise: bool)
             response = await route_handler.to_response(data=route_handler.fn(), plugins=[], app=None)  # type: ignore
             assert isinstance(response, StreamingResponse)
             assert response.headers["local-header"] == "123"
-            assert response.headers["file-header"] == "abc"
+            assert response.headers["response-header"] == "abc"
             cookies = response.headers.getlist("set-cookie")
             assert len(cookies) == 3
             assert cookies[0] == "streaming-cookie=xyz; Path=/; SameSite=lax"
@@ -229,7 +229,7 @@ async def func_to_response_template_response() -> None:
         return Template(
             name="test.template",
             context={},
-            headers={"file-header": "abc"},
+            headers={"response-header": "abc"},
             cookies=[Cookie(key="template-cookie", value="xyz")],
             background=background_task,
         )
@@ -240,7 +240,7 @@ async def func_to_response_template_response() -> None:
         response = await route_handler.to_response(data=route_handler.fn(), plugins=[], app=None)  # type: ignore
         assert isinstance(response, TemplateResponse)
         assert response.headers["local-header"] == "123"
-        assert response.headers["file-header"] == "abc"
+        assert response.headers["response-header"] == "abc"
         cookies = response.headers.getlist("set-cookie")
         assert len(cookies) == 2
         assert cookies[0] == "template-cookie=xyz; Path=/; SameSite=lax"


### PR DESCRIPTION
This is a followup PR that cleans the `to_response` method and implements @peterschutt's suggestions for datastructures.  I additionally add some docs and a docker compose setup to run the docs locally (didnt work due to plugins).

You'll note i removed the `validate_arguements` from the respone classes. This was causing a lot of problems with typing, and it additionally hurts performance I think. 