### PR TITLE
Only add new routes to the route_map

### DIFF
--- a/tests/static_files/test_static_files.py
+++ b/tests/static_files/test_static_files.py
@@ -54,6 +54,28 @@ def test_path_inside_static(tmpdir: Any) -> None:
         app.register(handler)
 
 
+def test_multiple_configs(tmpdir: Any) -> None:
+    root1 = tmpdir.mkdir("1")
+    root2 = tmpdir.mkdir("2")
+    path1 = root1.join("test.txt")
+    path1.write("content1")
+    path2 = root2.join("test.txt")
+    path2.write("content2")
+
+    static_files_config = [
+        StaticFilesConfig(path="/1", directories=[root1]),
+        StaticFilesConfig(path="/2", directories=[root2]),
+    ]
+    with create_test_client([], static_files_config=static_files_config) as client:
+        response = client.get("/1/test.txt")
+        assert response.status_code == 200
+        assert response.text == "content1"
+
+        response = client.get("/2/test.txt")
+        assert response.status_code == 200
+        assert response.text == "content2"
+
+
 def test_static_substring_of_self(tmpdir: Any) -> None:
     path = tmpdir.mkdir("static_part").mkdir("static")
     path = path.join("test.txt")


### PR DESCRIPTION
This avoids re-adding routes which are already in the route map.

Before, every route would be re-added on each call to `construct_route_map` (which is called on each call to `register`). `register` was called once per route handler in `Router.__init__`, once for the openapi handler (if configured), and once per static files configuration, as well as whenever a new route is registered outside the `__init__` call. Instead, this keeps a set of routes which have already been added to the route_map, and avoids re-adding them when calling `construct_route_map`

This also avoids a bug when `register` is called after a static path has been registered (when more than one static path is registered, or `.register` is called to add an additional handler), where `ImproperlyConfiguredException` with message: `Cannot have configured routes below a static path` would be incorrectly thrown when trying to add the static path to the route map a second time.

I'm open to suggestions if there's a better way to do this than filtering out known routes.