### PR TITLE
Separate OpenAPIController routes and rendering

### DIFF
--- a/docs/usage/12-openapi.md
+++ b/docs/usage/12-openapi.md
@@ -163,3 +163,17 @@ app = Starlite(
     openapi_config=OpenAPIConfig(openapi_controller=MyOpenAPIController),
 )
 ```
+
+You can override the `root` handler to serve other included UIs or your own [template](./15-templating.md):
+
+```python
+from starlite OpenAPIController
+
+
+class MyOpenAPIController(OpenAPIController):
+    path = "/"
+    
+    @get(path="/", media_type=MediaType.HTML, include_in_schema=False)
+    def root(self, request: Request) -> str:
+        return self.render_swagger_ui(request)
+```

--- a/docs/usage/12-openapi.md
+++ b/docs/usage/12-openapi.md
@@ -164,15 +164,16 @@ app = Starlite(
 )
 ```
 
-You can override the `root` handler to serve other included UIs or your own [template](./15-templating.md):
+The root handler serves Redoc by default via `render_redoc`. You can override the `root` handler to serve other included documentation, such as Swagger UI by returning `render_swagger_ui` or Stoplight Elements with `render_stoplight_elements`. You can also have it serve your own [template](./15-templating.md):
 
 ```python
-from starlite OpenAPIController
+from starlite import OpenAPIController, Request, get
+from starlite.enums import MediaType
 
 
 class MyOpenAPIController(OpenAPIController):
     path = "/"
-    
+
     @get(path="/", media_type=MediaType.HTML, include_in_schema=False)
     def root(self, request: Request) -> str:
         return self.render_swagger_ui(request)

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -54,6 +54,10 @@ class OpenAPIController(Controller):
     @get(path="/swagger", media_type=MediaType.HTML, include_in_schema=False)
     def swagger_ui(self, request: Request) -> str:
         """Endpoint that serves SwaggerUI"""
+        return self.render_swagger_ui(request)
+
+    def render_swagger_ui(self, request: Request) -> str:
+        """Method that renders SwaggerUI from schema"""
         schema = self.schema_from_request(request)
         # Note: Fix for Swagger rejection OpenAPI >=3.1
         # We force the version to be lower to get the default JS bundle to accept it
@@ -108,6 +112,10 @@ class OpenAPIController(Controller):
     @get(path="/elements/", media_type=MediaType.HTML, include_in_schema=False)
     def stoplight_elements(self, request: Request) -> str:
         """Endpoint that serves Stoplight Elements OpenAPI UI"""
+        return self.render_stoplight_elements(request)
+
+    def render_stoplight_elements(self, request: Request) -> str:
+        """Method that renders Stoplight Elements OpenAPI UI from schema"""
         schema = self.schema_from_request(request)
         head = f"""
           <head>
@@ -140,6 +148,10 @@ class OpenAPIController(Controller):
     @get(path=["/", "/redoc"], media_type=MediaType.HTML, include_in_schema=False)
     def redoc(self, request: Request) -> str:  # pragma: no cover
         """Endpoint that serves Redoc"""
+        return self.render_redoc(request)
+
+    def render_redoc(self, request: Request) -> str:  # pragma: no cover
+        """Method that renders Redoc from schema"""
         schema = self.schema_from_request(request)
         if self._dumped_schema == "":
             self._dumped_schema = dumps(schema.json(by_alias=True, exclude_none=True), option=OPT_INDENT_2).decode(

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -34,6 +34,11 @@ class OpenAPIController(Controller):
             raise ImproperlyConfiguredException("Starlite has not been instantiated with OpenAPIConfig")
         return request.app.openapi_schema
 
+    @get(path="/", media_type=MediaType.HTML, include_in_schema=False)
+    def root(self, request: Request) -> str:
+        """Endpoint that serves root content"""
+        return self.render_redoc(request)
+
     @get(path="/openapi.yaml", media_type=OpenAPIMediaType.OPENAPI_YAML, include_in_schema=False)
     def retrieve_schema_yaml(self, request: Request) -> "OpenAPI":
         """Returns the openapi schema"""
@@ -145,7 +150,7 @@ class OpenAPIController(Controller):
             </html>
         """
 
-    @get(path=["/", "/redoc"], media_type=MediaType.HTML, include_in_schema=False)
+    @get(path="/redoc", media_type=MediaType.HTML, include_in_schema=False)
     def redoc(self, request: Request) -> str:  # pragma: no cover
         """Endpoint that serves Redoc"""
         return self.render_redoc(request)

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -36,7 +36,11 @@ class OpenAPIController(Controller):
 
     @get(path="/", media_type=MediaType.HTML, include_in_schema=False)
     def root(self, request: Request) -> str:
-        """Endpoint that serves root content"""
+        """
+        This route handler serves Redoc API documentation at the root path.
+        Override this handler to serve custom templates or other API documentation, such as
+        `render_swagger_ui`, `render_stoplight_elements`, a template, or your own content.
+        """
         return self.render_redoc(request)
 
     @get(path="/openapi.yaml", media_type=OpenAPIMediaType.OPENAPI_YAML, include_in_schema=False)

--- a/tests/openapi/test_controller.py
+++ b/tests/openapi/test_controller.py
@@ -1,4 +1,3 @@
-import pytest
 from starlette.status import HTTP_200_OK
 
 from starlite.app import DEFAULT_OPENAPI_CONFIG
@@ -7,10 +6,16 @@ from starlite.testing import create_test_client
 from tests.openapi.utils import PersonController, PetController
 
 
-@pytest.mark.parametrize("url", ["/schema", "/schema/redoc"])
-def test_openapi_redoc(url: str) -> None:
+def test_openapi_root() -> None:
     with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
-        response = client.get(url)
+        response = client.get("/schema")
+        assert response.status_code == HTTP_200_OK
+        assert response.headers["content-type"].startswith(MediaType.HTML.value)
+
+
+def test_openapi_redoc() -> None:
+    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+        response = client.get("/schema/redoc")
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"].startswith(MediaType.HTML.value)
 


### PR DESCRIPTION
Issue #356.

This PR splits `redoc` and the base path/root handlers. The `root` handler serves the original `redoc` content, but enables easier overriding of the rendering and routing on the `OpenAPIController`.

- separate UI rendering and routing
- add routed `root` method
- separate testing of `/` and `redoc`
-  add `root` override example