### PR TITLE
Issue-#361: Fix stream 'iterator' typing

### DIFF
--- a/docs/reference/datastructures.md
+++ b/docs/reference/datastructures.md
@@ -75,3 +75,7 @@
         members:
             - documentation_only
             - value
+
+::: starlite.datastructures.UploadFile
+    options:
+        show_source: false

--- a/docs/usage/4-request-data/3-multipart-form-data.md
+++ b/docs/usage/4-request-data/3-multipart-form-data.md
@@ -30,8 +30,7 @@ interface for working with files. Therefore, you need to type your file uploads 
 To access a single file simply type `data` as `UploadFile`:
 
 ```python
-from starlette.datastructures import UploadFile
-from starlite import Body, post, RequestEncodingType
+from starlite import Body, UploadFile, post, RequestEncodingType
 
 
 @post(path="/file-upload")

--- a/docs/usage/5-responses/8-streaming-responses.md
+++ b/docs/usage/5-responses/8-streaming-responses.md
@@ -1,8 +1,9 @@
 # Streaming Responses
 
-To return a streaming response use the `Stream` class:
+To return a streaming response use the `Stream` class. The Stream class receives a single required kwarg - `iterator`:
 
 ```python
+from typing import AsyncGenerator
 from asyncio import sleep
 from starlite import get
 from starlite.datastructures import Stream
@@ -10,7 +11,7 @@ from datetime import datetime
 from orjson import dumps
 
 
-async def my_iterator() -> bytes:
+async def my_generator() -> AsyncGenerator[bytes, None]:
     while True:
         await sleep(0.01)
         yield dumps({"current_time": datetime.now()})
@@ -18,17 +19,20 @@ async def my_iterator() -> bytes:
 
 @get(path="/time")
 def stream_time() -> Stream:
-    return Stream(iterator=my_iterator)
+    return Stream(iterator=my_generator())
 ```
 
-The Stream class receives a single required kwarg - `iterator`, which should be either a sync or an async iterator.
+<!-- prettier-ignore -->
+!!! note
+    You can use different kinds of values of the `iterator` keyword - it can be a callable returning a sync or async
+    generator. The generator itself. A sync or async iterator class, or and instance of this class.
 
 ## The Stream Class
 
 `Stream` is a container class used to generate streaming responses and their respective OpenAPI documentation. You can
 pass the following kwargs to it:
 
-- `iterator`: An either, either sync or async, that handles streaming data, **required**.
+- `iterator`: A sync or async iterator instance, iterator class, generator or callable returning a generator, **required**.
 - `background`: A callable wrapped in an instance of `starlite.datastructures.BackgroundTask` or a list
   of `BackgroundTask` instances wrapped in `starlite.datastructures.BackgroundTasks`. The callable(s) will be called after
   the response is executed. Note - if you return a value from a `before_request` hook, background tasks passed to the

--- a/starlite/__init__.py
+++ b/starlite/__init__.py
@@ -8,6 +8,7 @@ from starlite.datastructures import (
     State,
     Stream,
     Template,
+    UploadFile,
 )
 
 from .app import Starlite
@@ -120,6 +121,7 @@ __all__ = [
     "Stream",
     "Template",
     "TemplateConfig",
+    "UploadFile",
     "ValidationException",
     "WebSocket",
     "WebSocketRoute",

--- a/starlite/openapi/schema.py
+++ b/starlite/openapi/schema.py
@@ -15,6 +15,7 @@ from pydantic import (
 )
 from pydantic.fields import FieldInfo, ModelField, Undefined
 from pydantic_factories import ModelFactory
+from pydantic_factories.exceptions import ParameterError
 from pydantic_factories.utils import is_optional, is_pydantic_model, is_union
 from pydantic_openapi_schema.utils.utils import OpenAPI310PydanticSchema
 from pydantic_openapi_schema.v3_1_0.example import Example
@@ -190,8 +191,12 @@ def create_examples_for_field(field: ModelField) -> List[Example]:
     """
     Use the pydantic-factories package to create an example value for the given schema
     """
-    value = normalize_example_value(ExampleFactory.get_field_value(field))
-    return [Example(description=f"Example {field.name} value", value=value)]
+    try:
+
+        value = normalize_example_value(ExampleFactory.get_field_value(field))
+        return [Example(description=f"Example {field.name} value", value=value)]
+    except ParameterError:
+        return []
 
 
 def create_schema(

--- a/tests/kwargs/test_multipart_data.py
+++ b/tests/kwargs/test_multipart_data.py
@@ -2,10 +2,10 @@ from typing import Any, Dict, List, Type
 
 import pytest
 from pydantic import BaseConfig, BaseModel
-from starlette.datastructures import UploadFile
 from starlette.status import HTTP_201_CREATED
 
 from starlite import Body, RequestEncodingType, post
+from starlite.datastructures import UploadFile
 from starlite.testing import create_test_client
 from tests import Person, PersonFactory
 from tests.kwargs import Form

--- a/tests/openapi/test_request_body.py
+++ b/tests/openapi/test_request_body.py
@@ -1,10 +1,28 @@
-from starlite import Starlite
+from pydantic import BaseModel
+
+from starlite import Body, RequestEncodingType, Starlite, post
+from starlite.datastructures import UploadFile
 from starlite.openapi.request_body import create_request_body
 from tests.openapi.utils import PersonController
 
 
+class FormData(BaseModel):
+    cv: UploadFile
+    image: UploadFile
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+@post(path="/file-upload")
+async def handle_file_upload(
+    data: FormData = Body(media_type=RequestEncodingType.MULTI_PART),
+) -> None:
+    return None
+
+
 def test_create_request_body() -> None:
-    for route in Starlite(route_handlers=[PersonController]).routes:
+    for route in Starlite(route_handlers=[PersonController, handle_file_upload]).routes:
         for route_handler, _ in route.route_handler_map.values():  # type: ignore
             handler_fields = route_handler.signature_model.__fields__
             if "data" in handler_fields:


### PR DESCRIPTION
This PR fixes `Stream` not handling callables correctly and being mistyped.

Resolves #361 