### PR TITLE
Fix bugs involving "*" and path params in routes

### DIFF
--- a/starlite/app.py
+++ b/starlite/app.py
@@ -6,7 +6,7 @@ from starlette.middleware import Middleware as StarletteMiddleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
-from starlite.asgi import RouteMapDict, StarliteASGIRouter, _path_param
+from starlite.asgi import PathParamPlaceholder, RouteMapNode, StarliteASGIRouter
 from starlite.config import (
     CacheConfig,
     CompressionConfig,
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from pydantic_openapi_schema.v3_1_0.open_api import OpenAPI
     from starlette.types import ASGIApp, Receive, Scope, Send
 
-    from starlite.asgi import ComponentsSet, _PathParam
+    from starlite.asgi import ComponentsSet, PathParamPlaceholderType
     from starlite.handlers.base import BaseRouteHandler
     from starlite.handlers.websocket import WebsocketRouteHandler
     from starlite.routes.base import PathParameterDefinition
@@ -166,7 +166,7 @@ class Starlite(Router):
         self.compression_config = compression_config
         self.plain_routes: Set[str] = set()
         self.plugins = plugins or []
-        self.route_map: RouteMapDict = {}
+        self.route_map: RouteMapNode = {}
         self.routes: List[BaseRoute] = []
         self.state = State()
 
@@ -269,7 +269,7 @@ class Starlite(Router):
 
         return ExceptionHandlerMiddleware(app=app, exception_handlers=exception_handlers, debug=self.debug)
 
-    def _add_node_to_route_map(self, route: BaseRoute) -> RouteMapDict:
+    def _add_node_to_route_map(self, route: BaseRoute) -> RouteMapNode:
         """Adds a new route path (e.g. '/foo/bar/{param:int}') into the
         route_map tree.
 
@@ -281,19 +281,21 @@ class Starlite(Router):
         current_node = self.route_map
         path = route.path
         if route.path_parameters or path in self._static_paths:
-            components = cast("List[Union[str, _PathParam, PathParameterDefinition]]", ["/", *route.path_components])
+            components = cast(
+                "List[Union[str, PathParamPlaceholderType, PathParameterDefinition]]", ["/", *route.path_components]
+            )
             for component in components:
                 components_set = cast("ComponentsSet", current_node["_components"])
 
                 if isinstance(component, dict):
                     # Represent path parameters using a special value
-                    component = _path_param
+                    component = PathParamPlaceholder
 
                 components_set.add(component)
 
                 if component not in current_node:
                     current_node[component] = {"_components": set()}
-                current_node = cast("RouteMapDict", current_node[component])
+                current_node = cast("RouteMapNode", current_node[component])
                 if "_static_path" in current_node:
                     raise ImproperlyConfiguredException("Cannot have configured routes below a static path")
         else:
@@ -304,7 +306,7 @@ class Starlite(Router):
         self._configure_route_map_node(route, current_node)
         return current_node
 
-    def _configure_route_map_node(self, route: BaseRoute, node: RouteMapDict) -> None:
+    def _configure_route_map_node(self, route: BaseRoute, node: RouteMapNode) -> None:
         """Set required attributes and route handlers on route_map tree
         node."""
         if "_path_parameters" not in node:

--- a/starlite/asgi.py
+++ b/starlite/asgi.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 # Sentinel object to represent a path param in the route map
 class _PathParam:
-    def __repr__(self) -> str:
+    def __repr__(self) -> str:  # pragma: no cover
         return "*"
 
 

--- a/starlite/asgi.py
+++ b/starlite/asgi.py
@@ -1,5 +1,15 @@
 from inspect import getfullargspec, isawaitable, ismethod
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    MutableMapping,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 from starlette.routing import Router as StarletteRouter
 
@@ -11,13 +21,24 @@ from starlite.exceptions import (
 )
 
 if TYPE_CHECKING:
-    from typing import Set
 
     from starlette.types import ASGIApp, Receive, Scope, Send
 
     from starlite.app import Starlite
     from starlite.routes.base import PathParameterDefinition
     from starlite.types import LifeCycleHandler
+
+
+# Sentinel object to represent a path param in the route map
+class _PathParam:
+    def __repr__(self) -> str:
+        return "*"
+
+
+_path_param = _PathParam()
+
+RouteMapDict = MutableMapping[Union[str, _PathParam], Any]
+ComponentsSet = Set[Union[str, _PathParam]]
 
 
 class StarliteASGIRouter(StarletteRouter):
@@ -33,7 +54,7 @@ class StarliteASGIRouter(StarletteRouter):
         self.app = app
         super().__init__(on_startup=on_startup, on_shutdown=on_shutdown)
 
-    def _traverse_route_map(self, path: str, scope: "Scope") -> Tuple[Dict[str, Any], List[str]]:
+    def _traverse_route_map(self, path: str, scope: "Scope") -> Tuple[RouteMapDict, List[str]]:
         """Traverses the application route mapping and retrieves the correct
         node for the request url.
 
@@ -43,22 +64,22 @@ class StarliteASGIRouter(StarletteRouter):
         current_node = self.app.route_map
         components = ["/", *[component for component in path.split("/") if component]]
         for component in components:
-            components_set = cast("Set[str]", current_node["_components"])
+            components_set = cast("ComponentsSet", current_node["_components"])
             if component in components_set:
-                current_node = cast("Dict[str, Any]", current_node[component])
+                current_node = cast("RouteMapDict", current_node[component])
                 if "_static_path" in current_node:
                     self._handle_static_path(scope=scope, node=current_node)
                     break
                 continue
-            if "*" in components_set:
+            if _path_param in components_set:
                 path_params.append(component)
-                current_node = cast("Dict[str, Any]", current_node["*"])
+                current_node = cast("RouteMapDict", current_node[_path_param])
                 continue
             raise NotFoundException()
         return current_node, path_params
 
     @staticmethod
-    def _handle_static_path(scope: "Scope", node: Dict[str, Any]) -> None:
+    def _handle_static_path(scope: "Scope", node: RouteMapDict) -> None:
         """Normalize the static path and update scope so file resolution will
         work as expected.
 
@@ -112,7 +133,7 @@ class StarliteASGIRouter(StarletteRouter):
         if path != "/" and path.endswith("/"):
             path = path.rstrip("/")
         if path in self.app.plain_routes:
-            current_node: Dict[str, Any] = self.app.route_map[path]
+            current_node: RouteMapDict = self.app.route_map[path]
             path_params: List[str] = []
         else:
             current_node, path_params = self._traverse_route_map(path=path, scope=scope)

--- a/starlite/routes/base.py
+++ b/starlite/routes/base.py
@@ -1,6 +1,6 @@
 import re
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, List, Optional, Tuple, Type, Union
 from uuid import UUID
 
 from typing_extensions import TypedDict
@@ -8,7 +8,7 @@ from typing_extensions import TypedDict
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.kwargs import KwargsModel
 from starlite.signature import get_signature_model
-from starlite.utils import normalize_path
+from starlite.utils import join_paths, normalize_path
 
 if TYPE_CHECKING:
     from starlette.types import Receive, Scope, Send
@@ -37,6 +37,7 @@ class BaseRoute(ABC):
         "path",
         "path_format",
         "path_parameters",
+        "path_components",
         "scope_type",
     )
 
@@ -57,7 +58,10 @@ class BaseRoute(ABC):
             scope_type:
             methods:
         """
-        self.path, self.path_format, self.path_parameters = self._parse_path(path)
+        self.path, self.path_format, self.path_components = self._parse_path(path)
+        self.path_parameters: List[PathParameterDefinition] = [
+            component for component in self.path_components if isinstance(component, dict)
+        ]
         self.handler_names = handler_names
         self.scope_type = scope_type
         self.methods = set(methods or [])
@@ -98,38 +102,54 @@ class BaseRoute(ABC):
         )
 
     @staticmethod
-    def _validate_path_parameters(parameters: List[str]) -> None:
-        """Validates that path parameters adhere to the required format and
+    def _validate_path_parameter(param: str) -> None:
+        """Validates that a path parameter adheres to the required format and
         datatypes.
 
-        Raises ImproperlyConfiguredException if any parameter is found
-        with invalid format
+        Raises:
+            ImproperlyConfiguredException: If the parameter has an invalid format.
         """
-        for param in parameters:
-            if len(param.split(":")) != 2:
-                raise ImproperlyConfiguredException(
-                    "Path parameters should be declared with a type using the following pattern: '{parameter_name:type}', e.g. '/my-path/{my_param:int}'"
-                )
-            param_name, param_type = (p.strip() for p in param.split(":"))
-            if len(param_name) == 0:
-                raise ImproperlyConfiguredException("Path parameter names should be of length greater than zero")
-            if param_type not in param_type_map:
-                raise ImproperlyConfiguredException(
-                    "Path parameters should be declared with an allowed type, i.e. 'str', 'int', 'float' or 'uuid'"
-                )
+        if len(param.split(":")) != 2:
+            raise ImproperlyConfiguredException(
+                "Path parameters should be declared with a type using the following pattern: '{parameter_name:type}', e.g. '/my-path/{my_param:int}'"
+            )
+        param_name, param_type = (p.strip() for p in param.split(":"))
+        if len(param_name) == 0:
+            raise ImproperlyConfiguredException("Path parameter names should be of length greater than zero")
+        if param_type not in param_type_map:
+            raise ImproperlyConfiguredException(
+                "Path parameters should be declared with an allowed type, i.e. 'str', 'int', 'float' or 'uuid'"
+            )
 
     @classmethod
-    def _parse_path(cls, path: str) -> Tuple[str, str, List[PathParameterDefinition]]:
+    def _parse_path(cls, path: str) -> Tuple[str, str, List[Union[str, PathParameterDefinition]]]:
         """Normalizes and parses a path."""
         path = normalize_path(path)
-        path_format = path
-        path_parameters = []
-        identified_params = param_match_regex.findall(path)
-        cls._validate_path_parameters(identified_params)
-        for param in identified_params:
-            param_name, param_type = (p.strip() for p in param.split(":"))
-            path_format = path_format.replace(param, param_name)
-            path_parameters.append(
-                PathParameterDefinition(name=param_name, type=param_type_map[param_type], full=param)
-            )
-        return path, path_format, path_parameters
+
+        parsed_components: List[Union[str, PathParameterDefinition]] = []
+
+        # Handle each component in the route path
+        components = [component for component in path.split("/") if component]
+        for component in components:
+            param_match = param_match_regex.fullmatch(component)
+            if param_match:
+                # Parse and validate components that are path params
+                param = param_match.group(1)
+                cls._validate_path_parameter(param)
+                param_name, param_type = (p.strip() for p in param.split(":"))
+                parsed_components.append(
+                    PathParameterDefinition(name=param_name, type=param_type_map[param_type], full=param)
+                )
+            else:
+                # Just append strings
+                parsed_components.append(component)
+
+        # Build the url used for the OpenAPI schema
+        path_format = join_paths(
+            [
+                f"{{{component['name']}}}" if isinstance(component, dict) else component
+                for component in parsed_components
+            ]
+        )
+
+        return path, path_format, parsed_components

--- a/starlite/routes/base.py
+++ b/starlite/routes/base.py
@@ -146,10 +146,7 @@ class BaseRoute(ABC):
 
         # Build the url used for the OpenAPI schema
         path_format = join_paths(
-            [
-                f"{{{component['name']}}}" if isinstance(component, dict) else component
-                for component in parsed_components
-            ]
+            f"{{{component['name']}}}" if isinstance(component, dict) else component for component in parsed_components
         )
 
         return path, path_format, parsed_components

--- a/starlite/utils/url.py
+++ b/starlite/utils/url.py
@@ -1,5 +1,5 @@
 import re
-from typing import Sequence
+from typing import Iterable
 
 
 def normalize_path(path: str) -> str:
@@ -19,6 +19,6 @@ def normalize_path(path: str) -> str:
     return path
 
 
-def join_paths(paths: Sequence[str]) -> str:
+def join_paths(paths: Iterable[str]) -> str:
     """Normalizes and joins path fragments."""
     return normalize_path("/".join(paths))

--- a/tests/route/test_route_map.py
+++ b/tests/route/test_route_map.py
@@ -8,24 +8,24 @@ from hypothesis import strategies as st
 from hypothesis.strategies import DrawFn
 
 from starlite import HTTPRoute, get
-from starlite.asgi import RouteMapDict, _path_param, _PathParam
+from starlite.asgi import PathParamPlaceholder, PathParamPlaceholderType, RouteMapNode
 from starlite.middleware import ExceptionHandlerMiddleware
 from starlite.testing import create_test_client
 
-param_pat = re.compile(r"{.*?:int}")
+param_pattern = re.compile(r"{.*?:int}")
 
 RouteMapTestCase = Tuple[str, str, Set[str]]
 
 
-def is_path_in_route_map(route_map: RouteMapDict, path: str, path_params: Set[str]) -> bool:
+def is_path_in_route_map(route_map: RouteMapNode, path: str, path_params: Set[str]) -> bool:
     if not path_params:
         return path in route_map
     components = cast(
-        "List[Union[str, _PathParam]]",
+        "List[Union[str, PathParamPlaceholderType]]",
         [
             "/",
             *[
-                _path_param if param_pat.fullmatch(component) else component
+                PathParamPlaceholder if param_pattern.fullmatch(component) else component
                 for component in path.split("/")
                 if component
             ],
@@ -48,7 +48,7 @@ def route_test_paths(draw: DrawFn) -> List[RouteMapTestCase]:
         segments = components + [f"{{{p}:int}}" for p in params]
         shuffle(segments)
         router_path = "/" + "/".join(segments)
-        request_path = param_pat.sub("1", router_path)
+        request_path = param_pattern.sub("1", router_path)
         return router_path, request_path, {f"{p}:int" for p in params}
 
     parameter_names = ["a", "b", "c", "d", "e"]

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -184,3 +184,28 @@ def test_conflicting_paths() -> None:
 
     with pytest.raises(ImproperlyConfiguredException):
         create_test_client(handler_fn)
+
+
+@pytest.mark.parametrize(
+    "handler_path, request_path, expected_status_code, expected_param",
+    [
+        ("/name:str/{name:str}", "/name:str/test", HTTP_200_OK, "test"),
+        ("/user/*/{name:str}", "/user/foo/bar", HTTP_404_NOT_FOUND, None),
+    ],
+)
+def test_special_chars(
+    handler_path: str, request_path: str, expected_status_code: int, expected_param: Optional[str]
+) -> None:
+    @get(path=handler_path, media_type=MediaType.TEXT)
+    def handler_fn(name: str) -> str:
+        return name
+
+    with create_test_client(handler_fn) as client:
+        response = client.get(request_path)
+        assert response.status_code == expected_status_code
+
+        if response.ok:
+            if expected_param is not None:
+                assert response.text == expected_param
+            else:
+                assert response.content == b""

--- a/tests/test_path_resolution.py
+++ b/tests/test_path_resolution.py
@@ -191,6 +191,7 @@ def test_conflicting_paths() -> None:
     [
         ("/name:str/{name:str}", "/name:str/test", HTTP_200_OK, "test"),
         ("/user/*/{name:str}", "/user/foo/bar", HTTP_404_NOT_FOUND, None),
+        ("/user/*/{name:str}", "/user/*/bar", HTTP_200_OK, "bar"),
     ],
 )
 def test_special_chars(
@@ -205,7 +206,4 @@ def test_special_chars(
         assert response.status_code == expected_status_code
 
         if response.ok:
-            if expected_param is not None:
-                assert response.text == expected_param
-            else:
-                assert response.content == b""
+            assert response.text == expected_param


### PR DESCRIPTION
- Instead of using "*" as the key in the route map for path params, use a sentinel object which will never be equal to any other value
- When creating routes, parse the route path into a sequence of strings and parameter definitions. Re-use this when building the route map instead of parsing the path again.
- Allow starlite.utils.url.join_paths to accept an iterable of strings.

This should fix some of the issues in #373. In another PR I will look at making a proper class for route map nodes, so that their config can use slots and not share the same dict key space as path components.