### PR TITLE
Fixed poetry option typo in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ against different python versions. To achieve this you can use the `tox` config 
 4. Restart shell.
 5. Remove any existing poetry environment: `$ poetry env remove python`
 6. Tell poetry to use system python: `$ poetry env use system`
-7. Install the dependencies `$ poetry install --extra testing`
+7. Install the dependencies `$ poetry install --extras testing`
 
 ### Tox Commands
 


### PR DESCRIPTION
The contributing docs [here](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.md#testing-multiple-python-versions) say to run `poetry install --extra testing`, but outputs this error after being run: `The "--extra" option does not exist.`

I believe it needs to be changed to `poetry install --extras testing`.