### PR TITLE
Fix for duplicated detail in http exception str

### DIFF
--- a/starlite/exceptions/exceptions.py
+++ b/starlite/exceptions/exceptions.py
@@ -59,7 +59,8 @@ class HTTPException(StarletteHTTPException, StarLiteException):
             extra (dict[str, Any], list[Any] | None, optional): extra info for HTTP response.
         """
         if not detail:
-            detail = args[0] if len(args) > 0 else HTTPStatus(status_code or self.status_code).phrase
+            detail = args[0] if args else HTTPStatus(status_code or self.status_code).phrase
+            args = args[1:]
         self.extra = extra
         super().__init__(status_code or self.status_code, *args)
         self.detail = detail

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -36,6 +36,11 @@ def test_starlite_exception_str() -> None:
     assert str(result) == "200 an unknown exception occurred"
 
 
+def test_http_exception_str() -> None:
+    exc = HTTPException("message")
+    assert str(exc) == "500: message"
+
+
 @given(status_code=st.integers(min_value=400, max_value=404), detail=st.one_of(st.none(), st.text()))
 def test_http_exception(status_code: int, detail: Optional[str]) -> None:
     assert HTTPException().status_code == HTTP_500_INTERNAL_SERVER_ERROR


### PR DESCRIPTION
Fixes where calling `str` on an `HTTPException` would cause a duplicated error message, e.g.,:

> starlite.exceptions.exceptions.ImproperlyConfiguredException: 500: Provider for key first is already defined under the different key third. If you wish to override a provider, it must have the same key. Provider for key first is already defined under the different key third. If you wish to override a provider, it must have the same key.
