### PR TITLE
Changes for improved typing in `AsyncCallable`.

### DIFF
--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -112,9 +112,9 @@ async def _normalize_response_data(data: Any, plugins: List["PluginProtocol"]) -
         if plugin:
             if is_async_callable(plugin.to_dict):
                 if isinstance(data, (list, tuple)):
-                    data = [await plugin.to_dict(datum) for datum in data]  # type: ignore
+                    data = [await plugin.to_dict(datum) for datum in data]
                 else:
-                    data = await plugin.to_dict(data)  # type: ignore
+                    data = await plugin.to_dict(data)
             else:
                 if isinstance(data, (list, tuple)):
                     data = [plugin.to_dict(datum) for datum in data]

--- a/starlite/utils/predicates.py
+++ b/starlite/utils/predicates.py
@@ -2,9 +2,9 @@ import asyncio
 import functools
 import sys
 from inspect import isclass
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Union
 
-from typing_extensions import get_args, get_origin
+from typing_extensions import TypeGuard, get_args, get_origin
 
 if TYPE_CHECKING:
     from pydantic.typing import AnyCallable
@@ -17,7 +17,7 @@ else:  # pragma: no cover
     UNION_TYPES = {Union}
 
 
-def is_async_callable(value: "AnyCallable") -> bool:
+def is_async_callable(value: "AnyCallable") -> TypeGuard[Callable[..., Awaitable[Any]]]:
     """Extends `asyncio.iscoroutinefunction()` to additionally detect async
     `partial` objects and class instances with `async def __call__()` defined.
 
@@ -25,7 +25,7 @@ def is_async_callable(value: "AnyCallable") -> bool:
         value: Any
 
     Returns:
-        bool
+        If type of `value` can be narrowed to return an awaitable, or not.
     """
     while isinstance(value, functools.partial):
         value = value.func


### PR DESCRIPTION
- makes `utils.predicates.is_async_callable()` a type guard
- makes `AsyncCallable` generic on `P` and `T`.

I've been able to remove all the type ignores except for the `partial()` assignment one.