### PR TITLE
remove empty aliases

### DIFF
--- a/starlite/params.py
+++ b/starlite/params.py
@@ -90,7 +90,6 @@ def Parameter(
     extra.update(value_type=value_type)
     return Field(
         default,
-        alias="",
         title=title,  # type: ignore
         description=description,  # type: ignore
         const=const,  # type: ignore
@@ -176,7 +175,6 @@ def Body(
     extra.update(content_encoding=content_encoding)
     return Field(
         default,
-        alias="",
         title=title,  # type: ignore
         description=description,  # type: ignore
         const=const,  # type: ignore


### PR DESCRIPTION
As per https://github.com/pydantic/pydantic/issues/4253 (change in https://github.com/pydantic/pydantic/pull/4252) an empty alias `''` is now treated differently from `None` - e.g. no alias.

Therefore for starlite to be be compatible with pydantic v1.10, we need to remove these empty alias values.

This should be backwards compatible with earlier versions of pydantic since until v.10 an empty alias was treated as identical to `''`.