### PR TITLE
Browser refuses set cookie if the size of session is larger than max-size limit 4096 allowed by the browser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ pyyaml = "*"
 requests = { version = "*", optional = true }
 starlette = "*"
 typing-extensions = "*"
-pre-commit = "^2.20.0"
+itsdangerous = "^2.1.2"
 
 [tool.poetry.dev-dependencies]
 freezegun = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ pyyaml = "*"
 requests = { version = "*", optional = true }
 starlette = "*"
 typing-extensions = "*"
+pre-commit = "^2.20.0"
 
 [tool.poetry.dev-dependencies]
 freezegun = "*"


### PR DESCRIPTION
# PR Checklist

- [✅ ] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ✅] Have you got 100% test coverage on new code?

# Minimal Reproducible Example
Run it as is. Visit `/` which redirects to `/health`. The assertion error will be raised if the cookies were refused by the browser.

```python
import secrets

import uvicorn
from starlette.middleware.sessions import SessionMiddleware
from starlette.status import HTTP_308_PERMANENT_REDIRECT
from starlite import DefineMiddleware, get, Request, Starlite
from starlite.datastructures import Redirect

# Set size of cookie value here, currently set to 1512 bytes to fail the
# assertion.
overflow = secrets.token_hex(1512)


@get(path='/', status_code=HTTP_308_PERMANENT_REDIRECT)
async def root(request: Request) -> Redirect:
    # Fill the session with large string to exceed the size of max-size limit
    # of the cookie in browser which is 4096 bytes.
    request.session['overflow'] = overflow
    return Redirect(path='/health')


@get(path='/health')
async def health_check(request: Request) -> str:
    # If the browser refused cookie in the response of the previous route
    # handler, this assertion will fail. This assertion will only pass if the
    # size of overflow is reduced to keep the session size less than 4096
    # bytes.
    assert tuple(request.session.items()) == (('overflow', overflow),)
    return 'health checked'

app = Starlite(route_handlers=[health_check, root],
               middleware=[DefineMiddleware(SessionMiddleware, secret_key=secrets.token_hex(16))],
               debug=True)

if __name__ == '__main__':
    uvicorn.run(app)
```

# What's Working?
Response is registered by the browser but it refuses to set cookie in the response if it exceeds the max 4096 size limit.
