### PR TITLE
Removes import from pydantic-openapi-schema `v3_0_3` subpackage.

### DIFF
--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -15,7 +15,7 @@ from typing import (
 )
 
 from pydantic import validate_arguments
-from pydantic_openapi_schema.v3_0_3 import SecurityRequirement
+from pydantic_openapi_schema.v3_1_0 import SecurityRequirement
 from starlette.responses import Response as StarletteResponse
 from starlette.status import (
     HTTP_200_OK,


### PR DESCRIPTION
This is in prep for `v3.0.3` to be removed from pydantic-openapi-schema.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
