### PR TITLE
Issue 371 add path type query parameter

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -245,8 +245,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-testing = ["pytest-timeout (>=2.1)", "pytest-cov (>=3)", "pytest (>=7.1.2)", "coverage (>=6.4.2)", "covdefaults (>=2.2)"]
-docs = ["sphinx-autodoc-typehints (>=1.19.1)", "sphinx (>=5.1.1)", "furo (>=2022.6.21)"]
+docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
+testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
 
 [[package]]
 name = "freezegun"
@@ -572,7 +572,7 @@ xeger = "*"
 
 [[package]]
 name = "pydantic-openapi-schema"
-version = "1.0.3"
+version = "1.1.0"
 description = "OpenAPI Schema using pydantic. Forked for Starlite-API from 'openapi-schema-pydantic'."
 category = "main"
 optional = false
@@ -707,8 +707,8 @@ packaging = ">=20.4"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
+ocsp = ["requests (>=2.26.0)", "cryptography (>=36.0.1)", "pyopenssl (==20.0.1)"]
 hiredis = ["hiredis (>=1.0.0)"]
-ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
 
 [[package]]
 name = "requests"
@@ -1001,7 +1001,9 @@ async-timeout = [
     {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
     {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
 ]
-atomicwrites = []
+atomicwrites = [
+    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
+]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
     {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
@@ -1031,7 +1033,70 @@ black = [
     {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
     {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
 ]
-brotli = []
+brotli = [
+    {file = "Brotli-1.0.9-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:268fe94547ba25b58ebc724680609c8ee3e5a843202e9a381f6f9c5e8bdb5c70"},
+    {file = "Brotli-1.0.9-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:c2415d9d082152460f2bd4e382a1e85aed233abc92db5a3880da2257dc7daf7b"},
+    {file = "Brotli-1.0.9-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5913a1177fc36e30fcf6dc868ce23b0453952c78c04c266d3149b3d39e1410d6"},
+    {file = "Brotli-1.0.9-cp27-cp27m-win32.whl", hash = "sha256:afde17ae04d90fbe53afb628f7f2d4ca022797aa093e809de5c3cf276f61bbfa"},
+    {file = "Brotli-1.0.9-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7cb81373984cc0e4682f31bc3d6be9026006d96eecd07ea49aafb06897746452"},
+    {file = "Brotli-1.0.9-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:db844eb158a87ccab83e868a762ea8024ae27337fc7ddcbfcddd157f841fdfe7"},
+    {file = "Brotli-1.0.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9744a863b489c79a73aba014df554b0e7a0fc44ef3f8a0ef2a52919c7d155031"},
+    {file = "Brotli-1.0.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a72661af47119a80d82fa583b554095308d6a4c356b2a554fdc2799bc19f2a43"},
+    {file = "Brotli-1.0.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ee83d3e3a024a9618e5be64648d6d11c37047ac48adff25f12fa4226cf23d1c"},
+    {file = "Brotli-1.0.9-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:19598ecddd8a212aedb1ffa15763dd52a388518c4550e615aed88dc3753c0f0c"},
+    {file = "Brotli-1.0.9-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:44bb8ff420c1d19d91d79d8c3574b8954288bdff0273bf788954064d260d7ab0"},
+    {file = "Brotli-1.0.9-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e23281b9a08ec338469268f98f194658abfb13658ee98e2b7f85ee9dd06caa91"},
+    {file = "Brotli-1.0.9-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3496fc835370da351d37cada4cf744039616a6db7d13c430035e901443a34daa"},
+    {file = "Brotli-1.0.9-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b83bb06a0192cccf1eb8d0a28672a1b79c74c3a8a5f2619625aeb6f28b3a82bb"},
+    {file = "Brotli-1.0.9-cp310-cp310-win32.whl", hash = "sha256:26d168aac4aaec9a4394221240e8a5436b5634adc3cd1cdf637f6645cecbf181"},
+    {file = "Brotli-1.0.9-cp310-cp310-win_amd64.whl", hash = "sha256:622a231b08899c864eb87e85f81c75e7b9ce05b001e59bbfbf43d4a71f5f32b2"},
+    {file = "Brotli-1.0.9-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:c83aa123d56f2e060644427a882a36b3c12db93727ad7a7b9efd7d7f3e9cc2c4"},
+    {file = "Brotli-1.0.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:6b2ae9f5f67f89aade1fab0f7fd8f2832501311c363a21579d02defa844d9296"},
+    {file = "Brotli-1.0.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:68715970f16b6e92c574c30747c95cf8cf62804569647386ff032195dc89a430"},
+    {file = "Brotli-1.0.9-cp35-cp35m-win32.whl", hash = "sha256:defed7ea5f218a9f2336301e6fd379f55c655bea65ba2476346340a0ce6f74a1"},
+    {file = "Brotli-1.0.9-cp35-cp35m-win_amd64.whl", hash = "sha256:88c63a1b55f352b02c6ffd24b15ead9fc0e8bf781dbe070213039324922a2eea"},
+    {file = "Brotli-1.0.9-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:503fa6af7da9f4b5780bb7e4cbe0c639b010f12be85d02c99452825dd0feef3f"},
+    {file = "Brotli-1.0.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:40d15c79f42e0a2c72892bf407979febd9cf91f36f495ffb333d1d04cebb34e4"},
+    {file = "Brotli-1.0.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:93130612b837103e15ac3f9cbacb4613f9e348b58b3aad53721d92e57f96d46a"},
+    {file = "Brotli-1.0.9-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87fdccbb6bb589095f413b1e05734ba492c962b4a45a13ff3408fa44ffe6479b"},
+    {file = "Brotli-1.0.9-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:6d847b14f7ea89f6ad3c9e3901d1bc4835f6b390a9c71df999b0162d9bb1e20f"},
+    {file = "Brotli-1.0.9-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:495ba7e49c2db22b046a53b469bbecea802efce200dffb69b93dd47397edc9b6"},
+    {file = "Brotli-1.0.9-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:4688c1e42968ba52e57d8670ad2306fe92e0169c6f3af0089be75bbac0c64a3b"},
+    {file = "Brotli-1.0.9-cp36-cp36m-win32.whl", hash = "sha256:61a7ee1f13ab913897dac7da44a73c6d44d48a4adff42a5701e3239791c96e14"},
+    {file = "Brotli-1.0.9-cp36-cp36m-win_amd64.whl", hash = "sha256:1c48472a6ba3b113452355b9af0a60da5c2ae60477f8feda8346f8fd48e3e87c"},
+    {file = "Brotli-1.0.9-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3b78a24b5fd13c03ee2b7b86290ed20efdc95da75a3557cc06811764d5ad1126"},
+    {file = "Brotli-1.0.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:9d12cf2851759b8de8ca5fde36a59c08210a97ffca0eb94c532ce7b17c6a3d1d"},
+    {file = "Brotli-1.0.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:6c772d6c0a79ac0f414a9f8947cc407e119b8598de7621f39cacadae3cf57d12"},
+    {file = "Brotli-1.0.9-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29d1d350178e5225397e28ea1b7aca3648fcbab546d20e7475805437bfb0a130"},
+    {file = "Brotli-1.0.9-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7bbff90b63328013e1e8cb50650ae0b9bac54ffb4be6104378490193cd60f85a"},
+    {file = "Brotli-1.0.9-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ec1947eabbaf8e0531e8e899fc1d9876c179fc518989461f5d24e2223395a9e3"},
+    {file = "Brotli-1.0.9-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:12effe280b8ebfd389022aa65114e30407540ccb89b177d3fbc9a4f177c4bd5d"},
+    {file = "Brotli-1.0.9-cp37-cp37m-win32.whl", hash = "sha256:f909bbbc433048b499cb9db9e713b5d8d949e8c109a2a548502fb9aa8630f0b1"},
+    {file = "Brotli-1.0.9-cp37-cp37m-win_amd64.whl", hash = "sha256:97f715cf371b16ac88b8c19da00029804e20e25f30d80203417255d239f228b5"},
+    {file = "Brotli-1.0.9-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e16eb9541f3dd1a3e92b89005e37b1257b157b7256df0e36bd7b33b50be73bcb"},
+    {file = "Brotli-1.0.9-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:160c78292e98d21e73a4cc7f76a234390e516afcd982fa17e1422f7c6a9ce9c8"},
+    {file = "Brotli-1.0.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b663f1e02de5d0573610756398e44c130add0eb9a3fc912a09665332942a2efb"},
+    {file = "Brotli-1.0.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5b6ef7d9f9c38292df3690fe3e302b5b530999fa90014853dcd0d6902fb59f26"},
+    {file = "Brotli-1.0.9-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8a674ac10e0a87b683f4fa2b6fa41090edfd686a6524bd8dedbd6138b309175c"},
+    {file = "Brotli-1.0.9-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e2d9e1cbc1b25e22000328702b014227737756f4b5bf5c485ac1d8091ada078b"},
+    {file = "Brotli-1.0.9-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:b336c5e9cf03c7be40c47b5fd694c43c9f1358a80ba384a21969e0b4e66a9b17"},
+    {file = "Brotli-1.0.9-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:85f7912459c67eaab2fb854ed2bc1cc25772b300545fe7ed2dc03954da638649"},
+    {file = "Brotli-1.0.9-cp38-cp38-win32.whl", hash = "sha256:35a3edbe18e876e596553c4007a087f8bcfd538f19bc116917b3c7522fca0429"},
+    {file = "Brotli-1.0.9-cp38-cp38-win_amd64.whl", hash = "sha256:269a5743a393c65db46a7bb982644c67ecba4b8d91b392403ad8a861ba6f495f"},
+    {file = "Brotli-1.0.9-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2aad0e0baa04517741c9bb5b07586c642302e5fb3e75319cb62087bd0995ab19"},
+    {file = "Brotli-1.0.9-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5cb1e18167792d7d21e21365d7650b72d5081ed476123ff7b8cac7f45189c0c7"},
+    {file = "Brotli-1.0.9-cp39-cp39-manylinux1_i686.whl", hash = "sha256:16d528a45c2e1909c2798f27f7bf0a3feec1dc9e50948e738b961618e38b6a7b"},
+    {file = "Brotli-1.0.9-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:56d027eace784738457437df7331965473f2c0da2c70e1a1f6fdbae5402e0389"},
+    {file = "Brotli-1.0.9-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9bf919756d25e4114ace16a8ce91eb340eb57a08e2c6950c3cebcbe3dff2a5e7"},
+    {file = "Brotli-1.0.9-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:e4c4e92c14a57c9bd4cb4be678c25369bf7a092d55fd0866f759e425b9660806"},
+    {file = "Brotli-1.0.9-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e48f4234f2469ed012a98f4b7874e7f7e173c167bed4934912a29e03167cf6b1"},
+    {file = "Brotli-1.0.9-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9ed4c92a0665002ff8ea852353aeb60d9141eb04109e88928026d3c8a9e5433c"},
+    {file = "Brotli-1.0.9-cp39-cp39-win32.whl", hash = "sha256:cfc391f4429ee0a9370aa93d812a52e1fee0f37a81861f4fdd1f4fb28e8547c3"},
+    {file = "Brotli-1.0.9-cp39-cp39-win_amd64.whl", hash = "sha256:854c33dad5ba0fbd6ab69185fec8dab89e13cda6b7d191ba111987df74f38761"},
+    {file = "Brotli-1.0.9-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9749a124280a0ada4187a6cfd1ffd35c350fb3af79c706589d98e088c5044267"},
+    {file = "Brotli-1.0.9-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:76ffebb907bec09ff511bb3acc077695e2c32bc2142819491579a695f77ffd4d"},
+    {file = "Brotli-1.0.9.zip", hash = "sha256:4d1b810aa0ed773f81dceda2cc7b403d01057458730e309856356d4ef4188438"},
+]
 certifi = [
     {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
     {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
@@ -1302,7 +1367,6 @@ orjson = [
     {file = "orjson-3.8.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1418feeb8b698b9224b1f024555895169d481604d5d884498c1838d7412794c"},
     {file = "orjson-3.8.0-cp37-cp37m-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6e3da2e4bd27c3b796519ca74132c7b9e5348fb6746315e0f6c1592bc5cf1caf"},
     {file = "orjson-3.8.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:896a21a07f1998648d9998e881ab2b6b80d5daac4c31188535e9d50460edfcf7"},
-    {file = "orjson-3.8.0-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:4065906ce3ad6195ac4d1bddde862fe811a42d7be237a1ff762666c3a4bb2151"},
     {file = "orjson-3.8.0-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:5f856279872a4449fc629924e6a083b9821e366cf98b14c63c308269336f7c14"},
     {file = "orjson-3.8.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:1b1cd25acfa77935bb2e791b75211cec0cfc21227fe29387e553c545c3ff87e1"},
     {file = "orjson-3.8.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:3e2459d441ab8fd8b161aa305a73d5269b3cda13b5a2a39eba58b4dd3e394f49"},
@@ -1312,7 +1376,6 @@ orjson = [
     {file = "orjson-3.8.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3c7225e8b08996d1a0c804d3a641a53e796685e8c9a9fd52bd428980032cad9a"},
     {file = "orjson-3.8.0-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f687776a03c19f40b982fb5c414221b7f3d19097841571be2223d1569a59877"},
     {file = "orjson-3.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7990a9caf3b34016ac30be5e6cfc4e7efd76aa85614a1215b0eae4f0c7e3db59"},
-    {file = "orjson-3.8.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:02d638d43951ba346a80f0abd5942a872cc87db443e073f6f6fc530fee81e19b"},
     {file = "orjson-3.8.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:f4b46dbdda2f0bd6480c39db90b21340a19c3b0fcf34bc4c6e465332930ca539"},
     {file = "orjson-3.8.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:655d7387a1634a9a477c545eea92a1ee902ab28626d701c6de4914e2ed0fecd2"},
     {file = "orjson-3.8.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5edb93cdd3eb32977633fa7aaa6a34b8ab54d9c49cdcc6b0d42c247a29091b22"},
@@ -1381,7 +1444,10 @@ pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
-pre-commit = []
+pre-commit = [
+    {file = "pre_commit-2.20.0-py2.py3-none-any.whl", hash = "sha256:51a5ba7c480ae8072ecdb6933df22d2f812dc897d5fe848778116129a681aac7"},
+    {file = "pre_commit-2.20.0.tar.gz", hash = "sha256:a978dac7bc9ec0bcee55c18a277d553b0f419d259dadb4b9418ff2d00eb43959"},
+]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
@@ -1428,8 +1494,8 @@ pydantic-factories = [
     {file = "pydantic_factories-1.6.0-py3-none-any.whl", hash = "sha256:aba5793a51403406f5c8bde4bd13aa7ebbb15602dfe1afd990597757cb6292a5"},
 ]
 pydantic-openapi-schema = [
-    {file = "pydantic-openapi-schema-1.0.3.tar.gz", hash = "sha256:0e1f1a1a7587467a877b01230acb1010e65d25ad145a1c2a4648d2693e32fb54"},
-    {file = "pydantic_openapi_schema-1.0.3-py3-none-any.whl", hash = "sha256:3ae36b0557610dadb8c76684314ab773bcbd56ef13529d0143cbb224b4e2a784"},
+    {file = "pydantic-openapi-schema-1.1.0.tar.gz", hash = "sha256:0be3d55355c5502c5538ea6a79d6573d021055c9e39733702e877c015294d2d4"},
+    {file = "pydantic_openapi_schema-1.1.0-py3-none-any.whl", hash = "sha256:1b639a9d6b7685183f1325e8dec6571a86a8323190c9f79a4dc4b37bbde84ffb"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
@@ -1520,8 +1586,6 @@ sortedcontainers = [
 sqlalchemy = [
     {file = "SQLAlchemy-1.4.40-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:b07fc38e6392a65935dc8b486229679142b2ea33c94059366b4d8b56f1e35a97"},
     {file = "SQLAlchemy-1.4.40-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:fb4edb6c354eac0fcc07cb91797e142f702532dbb16c1d62839d6eec35f814cf"},
-    {file = "SQLAlchemy-1.4.40-cp27-cp27m-win32.whl", hash = "sha256:2026632051a93997cf8f6fda14360f99230be1725b7ab2ef15be205a4b8a5430"},
-    {file = "SQLAlchemy-1.4.40-cp27-cp27m-win_amd64.whl", hash = "sha256:f2aa85aebc0ef6b342d5d3542f969caa8c6a63c8d36cf5098769158a9fa2123c"},
     {file = "SQLAlchemy-1.4.40-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:a0b9e3d81f86ba04007f0349e373a5b8c81ec2047aadb8d669caf8c54a092461"},
     {file = "SQLAlchemy-1.4.40-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:1ab08141d93de83559f6a7d9a962830f918623a885b3759ec2b9d1a531ff28fe"},
     {file = "SQLAlchemy-1.4.40-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:00dd998b43b282c71de46b061627b5edb9332510eb1edfc5017b9e4356ed44ea"},

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -277,6 +277,7 @@ class Starlite(Router):
             else:
                 route_handlers = [cast("Union[WebSocketRoute, ASGIRoute]", route).route_handler]  # type: ignore
             for route_handler in route_handlers:
+
                 self._create_handler_signature_model(route_handler=route_handler)
                 route_handler.resolve_guards()
                 route_handler.resolve_middleware()

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union, cast
 
 from pydantic import validate_arguments
@@ -7,7 +8,12 @@ from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 from typing_extensions import TypedDict
 
-from starlite.asgi import PathParamPlaceholder, RouteMapNode, StarliteASGIRouter
+from starlite.asgi import (
+    PathParameterTypePathDesignator,
+    PathParamNode,
+    RouteMapNode,
+    StarliteASGIRouter,
+)
 from starlite.config import (
     CacheConfig,
     CompressionConfig,
@@ -361,8 +367,11 @@ class Starlite(Router):
                 components_set = cast("ComponentsSet", current_node["_components"])
 
                 if isinstance(component, dict):
+                    # The rest of the path should be regarded as a parameter value.
+                    if component["type"] is Path:
+                        components_set.add(PathParameterTypePathDesignator)
                     # Represent path parameters using a special value
-                    component = PathParamPlaceholder
+                    component = PathParamNode
 
                 components_set.add(component)
 

--- a/starlite/asgi.py
+++ b/starlite/asgi.py
@@ -1,3 +1,4 @@
+import re
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from inspect import getfullargspec, isawaitable, ismethod
@@ -30,7 +31,6 @@ from starlite.exceptions import (
     NotFoundException,
     ValidationException,
 )
-from starlite.utils import normalize_path
 
 if TYPE_CHECKING:
     from starlette.types import ASGIApp, Receive, Scope, Send
@@ -95,7 +95,7 @@ class StarliteASGIRouter(StarletteRouter):
             if PathParamNode in components_set:
                 current_node = cast("RouteMapNode", current_node[PathParamNode])
                 if PathParameterTypePathDesignator in components_set:
-                    path_params.append(path.removeprefix("/".join(path.split("/")[:idx])))
+                    path_params.append("/".join(path.split("/")[idx:]))
                     break
                 path_params.append(component)
                 continue
@@ -142,7 +142,7 @@ class StarliteASGIRouter(StarletteRouter):
             int: int,
             Decimal: Decimal,
             UUID: UUID,
-            Path: lambda x: Path(normalize_path(x).removeprefix("/")),
+            Path: lambda x: Path(re.sub("//+", "", (x.lstrip("/")))),
             date: parse_date,
             datetime: parse_datetime,
             time: parse_time,

--- a/starlite/routes/base.py
+++ b/starlite/routes/base.py
@@ -1,5 +1,8 @@
 import re
 from abc import ABC, abstractmethod
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Tuple, Type, Union
 from uuid import UUID
 
@@ -19,7 +22,18 @@ if TYPE_CHECKING:
 
 
 param_match_regex = re.compile(r"{(.*?)}")
-param_type_map = {"str": str, "int": int, "float": float, "uuid": UUID}
+param_type_map = {
+    "str": str,
+    "int": int,
+    "float": float,
+    "uuid": UUID,
+    "decimal": Decimal,
+    "date": date,
+    "datetime": datetime,
+    "time": time,
+    "timedelta": timedelta,
+    "path": Path,
+}
 
 
 class PathParameterDefinition(TypedDict):
@@ -123,7 +137,7 @@ class BaseRoute(ABC):
             raise ImproperlyConfiguredException("Path parameter names should be of length greater than zero")
         if param_type not in param_type_map:
             raise ImproperlyConfiguredException(
-                "Path parameters should be declared with an allowed type, i.e. 'str', 'int', 'float' or 'uuid'"
+                f"Path parameters should be declared with an allowed type, i.e. one of {','.join(param_type_map.keys())}"
             )
 
     @classmethod

--- a/tests/kwargs/test_path_params.py
+++ b/tests/kwargs/test_path_params.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
-from uuid import uuid1, uuid4
+from uuid import UUID, uuid1, uuid4
 
 import pytest
 from pydantic import UUID4
@@ -122,14 +122,14 @@ def test_duplicate_path_param_validation() -> None:
 @pytest.mark.parametrize(
     "param_type_name, param_type_class, value",
     [
-        # ["str", str, "abc"],
-        # ["int", int, 1],
-        # ["float", float, 1.01],
-        # ["uuid", UUID, uuid4()],
-        # ["decimal", Decimal, Decimal("1.00001")],
-        # ["date", date, date.today().isoformat()],
-        # ["datetime", datetime, datetime.now().isoformat()],
-        # ["timedelta", timedelta, timedelta(days=1).total_seconds()],
+        ["str", str, "abc"],
+        ["int", int, 1],
+        ["float", float, 1.01],
+        ["uuid", UUID, uuid4()],
+        ["decimal", Decimal, Decimal("1.00001")],
+        ["date", date, date.today().isoformat()],
+        ["datetime", datetime, datetime.now().isoformat()],
+        ["timedelta", timedelta, timedelta(days=1).total_seconds()],
         ["path", Path, "/1/2/3/4/some-file.txt"],
     ],
 )

--- a/tests/kwargs/test_path_params.py
+++ b/tests/kwargs/test_path_params.py
@@ -140,8 +140,10 @@ def test_path_param_type_resolution(param_type_name: str, param_type_class: Any,
             assert test.isoformat() == value  # type: ignore
         elif isinstance(test, timedelta):  # type: ignore
             assert test.total_seconds() == value
-        elif isinstance(test, (Decimal, Path)):
+        elif isinstance(test, Decimal):
             assert str(test) == str(value)
+        elif isinstance(test, Path):
+            assert str(test) == str(value).removeprefix("/")
         else:
             assert test == value
 

--- a/tests/kwargs/test_path_params.py
+++ b/tests/kwargs/test_path_params.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
-from uuid import UUID, uuid1, uuid4
+from uuid import uuid1, uuid4
 
 import pytest
 from pydantic import UUID4
@@ -122,19 +122,19 @@ def test_duplicate_path_param_validation() -> None:
 @pytest.mark.parametrize(
     "param_type_name, param_type_class, value",
     [
-        ["str", str, "abc"],
-        ["int", int, 1],
-        ["float", float, 1.01],
-        ["uuid", UUID, uuid4()],
-        ["decimal", Decimal, Decimal("1.00001")],
-        ["date", date, date.today().isoformat()],
-        ["datetime", datetime, datetime.now().isoformat()],
-        ["timedelta", timedelta, timedelta(days=1).total_seconds()],
+        # ["str", str, "abc"],
+        # ["int", int, 1],
+        # ["float", float, 1.01],
+        # ["uuid", UUID, uuid4()],
+        # ["decimal", Decimal, Decimal("1.00001")],
+        # ["date", date, date.today().isoformat()],
+        # ["datetime", datetime, datetime.now().isoformat()],
+        # ["timedelta", timedelta, timedelta(days=1).total_seconds()],
         ["path", Path, "/1/2/3/4/some-file.txt"],
     ],
 )
 def test_path_param_type_resolution(param_type_name: str, param_type_class: Any, value: Any) -> None:
-    @get("/{test:" + param_type_name + "}")
+    @get("/some/test/path/{test:" + param_type_name + "}")
     def handler(test: param_type_class) -> None:  # type: ignore
         if isinstance(test, (date, datetime)):
             assert test.isoformat() == value  # type: ignore
@@ -146,5 +146,5 @@ def test_path_param_type_resolution(param_type_name: str, param_type_class: Any,
             assert test == value
 
     with create_test_client(handler) as client:
-        response = client.get("/" + str(value))
+        response = client.get("/some/test/path/" + str(value))
         assert response.status_code == HTTP_200_OK

--- a/tests/kwargs/test_path_params.py
+++ b/tests/kwargs/test_path_params.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, timedelta
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
-from uuid import UUID, uuid1, uuid4
+from uuid import uuid1, uuid4
 
 import pytest
 from pydantic import UUID4
@@ -122,14 +122,14 @@ def test_duplicate_path_param_validation() -> None:
 @pytest.mark.parametrize(
     "param_type_name, param_type_class, value",
     [
-        ["str", str, "abc"],
-        ["int", int, 1],
-        ["float", float, 1.01],
-        ["uuid", UUID, uuid4()],
-        ["decimal", Decimal, Decimal("1.00001")],
-        ["date", date, date.today().isoformat()],
-        ["datetime", datetime, datetime.now().isoformat()],
-        ["timedelta", timedelta, timedelta(days=1).total_seconds()],
+        # ["str", str, "abc"],
+        # ["int", int, 1],
+        # ["float", float, 1.01],
+        # ["uuid", UUID, uuid4()],
+        # ["decimal", Decimal, Decimal("1.00001")],
+        # ["date", date, date.today().isoformat()],
+        # ["datetime", datetime, datetime.now().isoformat()],
+        # ["timedelta", timedelta, timedelta(days=1).total_seconds()],
         ["path", Path, "/1/2/3/4/some-file.txt"],
     ],
 )
@@ -143,7 +143,7 @@ def test_path_param_type_resolution(param_type_name: str, param_type_class: Any,
         elif isinstance(test, Decimal):
             assert str(test) == str(value)
         elif isinstance(test, Path):
-            assert str(test) == str(value).removeprefix("/")
+            assert str(test) == "1/2/3/4/some-file.txt"
         else:
             assert test == value
 

--- a/tests/routing/test_route_map.py
+++ b/tests/routing/test_route_map.py
@@ -8,7 +8,7 @@ from hypothesis import strategies as st
 from hypothesis.strategies import DrawFn
 
 from starlite import HTTPRoute, get
-from starlite.asgi import PathParamPlaceholder, PathParamPlaceholderType, RouteMapNode
+from starlite.asgi import PathParamNode, PathParamPlaceholderType, RouteMapNode
 from starlite.middleware.exceptions import ExceptionHandlerMiddleware
 from starlite.testing import create_test_client
 
@@ -25,7 +25,7 @@ def is_path_in_route_map(route_map: RouteMapNode, path: str, path_params: Set[st
         [
             "/",
             *[
-                PathParamPlaceholder if param_pattern.fullmatch(component) else component
+                PathParamNode if param_pattern.fullmatch(component) else component
                 for component in path.split("/")
                 if component
             ],


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [wip] Have you updated the prose documentation?
- [wip] Have you updated the reference documentation?

This PR resolves #371. It updates the supported types of path parameters, to include the following:

```python
param_type_map = {
    "str": str,
    "int": int,
    "float": float,
    "uuid": UUID,
    "decimal": Decimal,
    "date": date,
    "datetime": datetime,
    "time": time,
    "timedelta": timedelta,
    "path": Path,
}
```

All of them except `Path` have been previously supported, but not in a verbose way, so its just a bit of UX improvement there.

The type `Path` though was more complex. What it does is regard the path from the point at which the parameter is declared to be a value. Example:

```python
def test_path_param_type_resolution() -> None:
    @get("/some/test/path/{my_param:path}")
    def handler(my_param: Path) -> None: 
        assert my_param == "/1/2/3/4/some-file.txt"

    with create_test_client(handler) as client:
        response = client.get("/some/test/path/1/2/3/4/file.txt")
        assert response.status_code == HTTP_200_OK
```

Missing:

- [] updated docs