### PR TITLE
Removes `needs: validate` dependency from `test_minimal_app`.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,6 @@ jobs:
   test_minimal_app:
     # tests the hello-world example against a minimal install
     name: Test Minimal Application with Base Dependencies
-    needs: validate
     runs-on: ubuntu-latest
     env:
       python_version: "3.10"


### PR DESCRIPTION
Action was failing due to there being no independent job in the workflow.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
