### PR TITLE
Add log_config and rich_logging attribs to app

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ disable = [
     "too-many-lines",
     "too-many-locals",
     "too-many-return-statements",
+    "too-many-statements",
     "ungrouped-imports",
 ]
 enable = "useless-suppression"

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -299,23 +299,14 @@ class Starlite(Router):
                 self.register(asgi(path=config.path)(config.to_static_files_app()))
 
         if rich_logging:
-            try:
-                from rich import console as rich_console
-            except ImportError as exc:
-                rich_console = None
-                raise ImproperlyConfiguredException(
-                    "rich logging set to True but rich module not found!  Install it with pip install rich."
-                ) from exc
-            if rich_console:
-                log_config = {}
-                log_config["rich_logging"] = True
+            log_config = {"rich_logging": True}
 
-        self.log_config = LoggingConfig(**log_config) if log_config is not None else LoggingConfig()
+        log_config_defined: LoggingConfig = LoggingConfig(**log_config) if log_config is not None else LoggingConfig()
 
         if self.on_startup:
-            self.on_startup.extend([self.log_config.configure])
+            self.on_startup.extend([log_config_defined.configure])
         else:
-            self.on_startup = [self.log_config.configure]
+            self.on_startup = [log_config_defined.configure]
 
         self.asgi_router = StarliteASGIRouter(on_shutdown=self.on_shutdown, on_startup=self.on_startup, app=self)
         self.asgi_handler = self._create_asgi_handler()

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -250,7 +250,7 @@ class Starlite(Router):
         self.cors_config = cors_config
         self.csrf_config = csrf_config
         self.debug = debug
-        self.log_config = LoggingConfig(**log_config) if log_config is not None else LoggingConfig()
+        self.log_config = log_config
         self.on_shutdown = on_shutdown or []
         self.on_startup = on_startup or []
         self.openapi_config = openapi_config
@@ -300,15 +300,17 @@ class Starlite(Router):
 
         if rich_logging:
             try:
-                import rich  # pylint: disable=import-outside-toplevel
-
-                rich.reconfigure()  # make sure pycln doesn't remove this import attempt
-
-                self.state.rich_logging = self.rich_logging
+                from rich import console as rich_console
             except ImportError as exc:
+                rich_console = None
                 raise ImproperlyConfiguredException(
                     "rich logging set to True but rich module not found!  Install it with pip install rich."
                 ) from exc
+            if rich_console:
+                log_config = {}
+                log_config["rich_logging"] = True
+
+        self.log_config = LoggingConfig(**log_config) if log_config is not None else LoggingConfig()
 
         if self.on_startup:
             self.on_startup.extend([self.log_config.configure])

--- a/starlite/config/logging.py
+++ b/starlite/config/logging.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, Iterable, List, Optional
 from pydantic import BaseModel
 from typing_extensions import Literal
 
-if TYPE_CHECKING:
-    from starlite.datastructures import State
 
 try:
     from picologging import config as picologging_config
@@ -51,6 +49,8 @@ class LoggingConfig(BaseModel):
     root: Dict[str, Union[Dict[str, Any], List[Any], str]] = {"handlers": ["queue_listener"], "level": "INFO"}
     """This will be the configuration for the root logger. Processing of the configuration will be as for any logger,
     except that the propagate setting will not be applicable."""
+    rich_logging: bool = False
+    """Whether rich console logging is to be used over the default"""
 
     def _enable_rich_logging(self, log_config_dict: Dict[str, Any]) -> Dict[str, Any]:
         """Overwrite the default console log configuration with rich log
@@ -78,7 +78,7 @@ class LoggingConfig(BaseModel):
 
         return log_config_dict
 
-    def configure(self, state: "State") -> None:
+    def configure(self) -> None:
         """Configured logger with the given configuration.
 
         If the logger class contains the word `picologging`, we try to
@@ -86,7 +86,7 @@ class LoggingConfig(BaseModel):
         """
         log_config_dict = self.dict(exclude_none=True)
 
-        if getattr(state, "rich_logging", False):
+        if self.rich_logging:
             log_config_dict = self._enable_rich_logging(log_config_dict)
 
         for logging_class in find_keys(self.handlers, "class"):

--- a/starlite/config/logging.py
+++ b/starlite/config/logging.py
@@ -1,9 +1,8 @@
 from logging import config
-from typing import TYPE_CHECKING, Any, Dict, Generator, Iterable, List, Optional, Union
+from typing import Any, Dict, Generator, Iterable, List, Optional, Union
 
 from pydantic import BaseModel
 from typing_extensions import Literal
-
 
 try:
     from picologging import config as picologging_config

--- a/starlite/config/logging.py
+++ b/starlite/config/logging.py
@@ -57,7 +57,7 @@ class LoggingConfig(BaseModel):
         configuration.
 
         Args:
-            log_config_dict (Dict[str,Any]): dict representation of LoggingConfig model
+            log_config_dict: dict representation of LoggingConfig model
         Returns:
             Dict[str,Any]: dict representation of LoggingConfig model with rich console logging in place of default console logging
         """

--- a/starlite/config/logging.py
+++ b/starlite/config/logging.py
@@ -1,4 +1,4 @@
-from logging import config, getLogger
+from logging import config
 from typing import TYPE_CHECKING, Any, Dict, Generator, Iterable, List, Optional, Union
 
 from pydantic import BaseModel
@@ -95,12 +95,6 @@ class LoggingConfig(BaseModel):
                 break
         else:  # no break
             config.dictConfig(log_config_dict)
-
-        # disable uvicorn errors from showing on the console
-        uvicorn_error = getLogger("uvicorn.error")
-        uvicorn_error.disabled = True
-        uvicorn_access = getLogger("uvicorn.access")
-        uvicorn_access.disabled = True
 
 
 def find_keys(node: Union[List, Dict], key: str) -> Generator[Iterable, None, None]:

--- a/starlite/config/logging.py
+++ b/starlite/config/logging.py
@@ -63,7 +63,7 @@ class LoggingConfig(BaseModel):
         """
         log_config_dict["formatters"]["rich"] = {"format": "%(name)s - %(message)s"}
 
-        log_config_dict["handlers"].pop("console", None)  # remove console handler if present
+        log_config_dict["handlers"].pop("console", None)
 
         log_config_dict["handlers"]["p_rich"] = {
             "class": "rich.logging.RichHandler",

--- a/starlite/config/logging.py
+++ b/starlite/config/logging.py
@@ -59,7 +59,7 @@ class LoggingConfig(BaseModel):
         Args:
             log_config_dict: dict representation of LoggingConfig model
         Returns:
-            Dict[str,Any]: dict representation of LoggingConfig model with rich console logging in place of default console logging
+            dict representation of LoggingConfig model with rich console logging in place of default console logging
         """
         log_config_dict["formatters"]["rich"] = {"format": "%(name)s - %(message)s"}
 

--- a/tests/logging_config/test_logging.py
+++ b/tests/logging_config/test_logging.py
@@ -2,18 +2,20 @@ import logging
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-from starlite import Starlite
+from starlite import Starlite, State
 from starlite.logging import LoggingConfig
 from starlite.testing import TestClient, create_test_client
 
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
 
+state = State()
+
 
 @patch("logging.config.dictConfig")
 def test_logging_debug(dict_config_mock: Mock) -> None:
     config = LoggingConfig()
-    config.configure()
+    config.configure(state)
     assert dict_config_mock.mock_calls[0][1][0]["loggers"]["starlite"]["level"] == "INFO"
     dict_config_mock.reset_mock()
 
@@ -26,7 +28,7 @@ def test_logging_startup(dict_config_mock: Mock) -> None:
 
 
 config = LoggingConfig()
-config.configure()
+config.configure(state)
 logger = logging.getLogger()
 
 

--- a/tests/logging_config/test_logging.py
+++ b/tests/logging_config/test_logging.py
@@ -2,20 +2,18 @@ import logging
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
-from starlite import Starlite, State
+from starlite import Starlite
 from starlite.logging import LoggingConfig
 from starlite.testing import TestClient, create_test_client
 
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
 
-state = State()
-
 
 @patch("logging.config.dictConfig")
 def test_logging_debug(dict_config_mock: Mock) -> None:
     config = LoggingConfig()
-    config.configure(state)
+    config.configure()
     assert dict_config_mock.mock_calls[0][1][0]["loggers"]["starlite"]["level"] == "INFO"
     dict_config_mock.reset_mock()
 
@@ -28,7 +26,7 @@ def test_logging_startup(dict_config_mock: Mock) -> None:
 
 
 config = LoggingConfig()
-config.configure(state)
+config.configure()
 logger = logging.getLogger()
 
 

--- a/tests/logging_config/test_picologging.py
+++ b/tests/logging_config/test_picologging.py
@@ -4,14 +4,12 @@ from unittest.mock import Mock, patch
 
 import picologging
 
-from starlite import Starlite, State
+from starlite import Starlite
 from starlite.logging import LoggingConfig
 from starlite.testing import TestClient, create_test_client
 
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
-
-state = State()
 
 
 @patch("logging.config.dictConfig")
@@ -29,7 +27,7 @@ def test_logging_debug(dict_config_mock: Mock) -> None:
             },
         }
     )
-    log_config.configure(state)
+    log_config.configure()
     assert dict_config_mock.mock_calls[0][1][0]["loggers"]["starlite"]["level"] == "INFO"
     dict_config_mock.reset_mock()
 
@@ -49,7 +47,7 @@ def test_picologging_dictconfig_debug(dict_config_mock: Mock) -> None:
             },
         }
     )
-    log_config.configure(state)
+    log_config.configure()
     assert dict_config_mock.mock_calls[0][1][0]["loggers"]["starlite"]["level"] == "INFO"
     dict_config_mock.reset_mock()
 
@@ -119,7 +117,7 @@ config = LoggingConfig(
     }
 )
 
-config.configure(state)
+config.configure()
 picologger = picologging.getLogger()
 
 

--- a/tests/logging_config/test_picologging.py
+++ b/tests/logging_config/test_picologging.py
@@ -4,12 +4,14 @@ from unittest.mock import Mock, patch
 
 import picologging
 
-from starlite import Starlite
+from starlite import Starlite, State
 from starlite.logging import LoggingConfig
 from starlite.testing import TestClient, create_test_client
 
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
+
+state = State()
 
 
 @patch("logging.config.dictConfig")
@@ -27,7 +29,7 @@ def test_logging_debug(dict_config_mock: Mock) -> None:
             },
         }
     )
-    log_config.configure()
+    log_config.configure(state)
     assert dict_config_mock.mock_calls[0][1][0]["loggers"]["starlite"]["level"] == "INFO"
     dict_config_mock.reset_mock()
 
@@ -47,7 +49,7 @@ def test_picologging_dictconfig_debug(dict_config_mock: Mock) -> None:
             },
         }
     )
-    log_config.configure()
+    log_config.configure(state)
     assert dict_config_mock.mock_calls[0][1][0]["loggers"]["starlite"]["level"] == "INFO"
     dict_config_mock.reset_mock()
 
@@ -116,7 +118,8 @@ config = LoggingConfig(
         },
     }
 )
-config.configure()
+
+config.configure(state)
 picologger = picologging.getLogger()
 
 


### PR DESCRIPTION
Adds two new instance attributes to starlite.app.Starlite class.
1. log_config - Takes in a dict of config options to pass to logging.dictConfig. Allows custom log configuration by the user.
2. rich_logging - Default False.  If True, swaps out the default console log handler with a RichHandler.  If rich isn't present when rich_logging = True, raises an ImproperlyConfiguredException

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?


I'll probably need some help writing tests and docs for this assuming there are no changes needed.