### PR TITLE
Enhancement: Remove Firebird and Sybase for SQL Alchemy 2.0 support

### DIFF
--- a/starlite/plugins/sql_alchemy.py
+++ b/starlite/plugins/sql_alchemy.py
@@ -17,15 +17,7 @@ from starlite.plugins.base import PluginProtocol
 try:
     from sqlalchemy import inspect
     from sqlalchemy import types as sqlalchemy_type
-    from sqlalchemy.dialects import (
-        firebird,
-        mssql,
-        mysql,
-        oracle,
-        postgresql,
-        sqlite,
-        sybase,
-    )
+    from sqlalchemy.dialects import mssql, mysql, oracle, postgresql, sqlite
     from sqlalchemy.orm import DeclarativeMeta, Mapper
     from sqlalchemy.sql.type_api import TypeEngine
 except ImportError as e:
@@ -134,9 +126,6 @@ class SQLAlchemyPlugin(PluginProtocol[DeclarativeMeta]):
             sqlalchemy_type.UnicodeText: self.handle_string_type,
             sqlalchemy_type.VARBINARY: self.handle_string_type,
             sqlalchemy_type.VARCHAR: self.handle_string_type,
-            # firebird
-            firebird.CHAR: self.handle_string_type,
-            firebird.VARCHAR: self.handle_string_type,
             # mssql
             mssql.BIT: lambda x: bool,
             mssql.DATETIME2: lambda x: datetime,
@@ -224,15 +213,6 @@ class SQLAlchemyPlugin(PluginProtocol[DeclarativeMeta]):
             sqlite.DATETIME: lambda x: datetime,
             sqlite.JSON: lambda x: Json,
             sqlite.TIME: lambda x: time,
-            # sybase
-            sybase.BIT: lambda x: bool,
-            sybase.IMAGE: self.handle_string_type,
-            sybase.MONEY: lambda x: Decimal,
-            sybase.SMALLMONEY: lambda x: Decimal,
-            sybase.TINYINT: lambda x: int,
-            sybase.UNICHAR: self.handle_string_type,
-            sybase.UNITEXT: self.handle_string_type,
-            sybase.UNIVARCHAR: self.handle_string_type,
         }
 
     def get_pydantic_type(self, column_type: Any) -> Any:

--- a/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_table_types.py
+++ b/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_table_types.py
@@ -47,15 +47,7 @@ from sqlalchemy import (
     Unicode,
     UnicodeText,
 )
-from sqlalchemy.dialects import (
-    firebird,
-    mssql,
-    mysql,
-    oracle,
-    postgresql,
-    sqlite,
-    sybase,
-)
+from sqlalchemy.dialects import mssql, mysql, oracle, postgresql, sqlite
 from sqlalchemy.orm import registry
 from sqlalchemy.sql.functions import now
 
@@ -116,9 +108,6 @@ class DeclarativeModel(SQLAlchemyBase):
     UnicodeText_column = Column(UnicodeText)
     VARBINARY_column = Column(VARBINARY)
     VARCHAR_column = Column(VARCHAR)
-    # firebird
-    firebird_CHAR_column = Column(firebird.CHAR)
-    firebird_VARCHAR_column = Column(firebird.VARCHAR)
     # mssql
     mssql_BIT_column = Column(mssql.BIT)
     mssql_DATETIME2_column = Column(mssql.DATETIME2)
@@ -206,15 +195,6 @@ class DeclarativeModel(SQLAlchemyBase):
     sqlite_DATETIME_column = Column(sqlite.DATETIME)
     sqlite_JSON_column = Column(sqlite.JSON)
     sqlite_TIME_column = Column(sqlite.TIME)
-    # sybase
-    sybase_BIT_column = Column(sybase.BIT)
-    sybase_IMAGE_column = Column(sybase.IMAGE)
-    sybase_MONEY_column = Column(sybase.MONEY)
-    sybase_SMALLMONEY_column = Column(sybase.SMALLMONEY)
-    sybase_TINYINT_column = Column(sybase.TINYINT)
-    sybase_UNICHAR_column = Column(sybase.UNICHAR)
-    sybase_UNITEXT_column = Column(sybase.UNITEXT)
-    sybase_UNIVARCHAR_column = Column(sybase.UNIVARCHAR)
 
 
 imperative_model = Table(


### PR DESCRIPTION
The Sybase and Firebird have been removed from the default SQL alchemy dialects in the 2.0 branch causing the plugin to fail when loading.

Given that the amount of usage for Sybase and Firebase is very small (and probably zero overlap with Starlite users), this PR removes this from Starlite.
