### PR TITLE
Issue #482 set media type on response container

### DIFF
--- a/starlite/datastructures.py
+++ b/starlite/datastructures.py
@@ -36,6 +36,7 @@ from starlette.responses import StreamingResponse
 from starlite_multipart.datastructures import UploadFile as MultipartUploadFile
 from typing_extensions import Literal, ParamSpec
 
+from starlite.enums import MediaType
 from starlite.openapi.enums import OpenAPIType
 
 P = ParamSpec("P")
@@ -44,7 +45,6 @@ if TYPE_CHECKING:
     from pydantic.fields import ModelField
 
     from starlite.app import Starlite
-    from starlite.enums import MediaType
     from starlite.response import TemplateResponse
 
 
@@ -156,6 +156,8 @@ class ResponseContainer(GenericModel, ABC, Generic[R]):
     """A string/string dictionary of response headers. Header keys are insensitive. Defaults to None."""
     cookies: List[Cookie] = []
     """A list of Cookie instances to be set under the response 'Set-Cookie' header. Defaults to None."""
+    media_type: Optional[Union[MediaType, str]] = None
+    """If defined, overrides the media type configured in the route decorator"""
 
     @abstractmethod
     def to_response(

--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -138,7 +138,9 @@ def _create_response_container_handler(
     async def handler(data: ResponseContainer, app: "Starlite", **kwargs: Any) -> StarletteResponse:
         normalized_headers = {**_normalize_headers(headers), **data.headers}
         normalized_cookies = _normalize_cookies(data.cookies, cookies)
-        response = data.to_response(app=app, headers=normalized_headers, status_code=status_code, media_type=media_type)
+        response = data.to_response(
+            app=app, headers=normalized_headers, status_code=status_code, media_type=data.media_type or media_type
+        )
         for cookie in normalized_cookies:
             response.set_cookie(**cookie)
         return await after_request(response) if after_request else response  # type: ignore
@@ -498,7 +500,6 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
             response_class = self.resolve_response_class()
             headers = self.resolve_response_headers()
             cookies = self.resolve_response_cookies()
-
             if is_class_and_subclass(self.signature.return_annotation, ResponseContainer):  # type: ignore[misc]
                 handler = _create_response_container_handler(
                     after_request=after_request,

--- a/tests/response/test_serialization.py
+++ b/tests/response/test_serialization.py
@@ -15,7 +15,7 @@ secret = SecretStr("secret_text")
 pure_path = PurePath("/path/to/file")
 
 
-class TestEnum(enum.Enum):
+class _TestEnum(enum.Enum):
     A = "alpha"
     B = "beta"
 
@@ -30,13 +30,15 @@ class TestEnum(enum.Enum):
         [PydanticDataClassPerson(**person.dict()), PydanticDataClassPerson, MediaType.JSON],
         ["abcdefg", str, MediaType.TEXT],
         ["<div/>", str, MediaType.HTML],
-        [{"enum": TestEnum.A}, Dict[str, TestEnum], MediaType.JSON],
+        [{"enum": _TestEnum.A}, Dict[str, _TestEnum], MediaType.JSON],
         [{"secret": secret}, Dict[str, SecretStr], MediaType.JSON],
         [{"pure_path": pure_path}, Dict[str, PurePath], MediaType.JSON],
     ],
 )
 def test_response_serialization(content: Any, response_type: Any, media_type: MediaType) -> None:
-    response = Response[response_type](content, media_type=media_type, status_code=HTTP_200_OK)  # type: ignore[valid-type]
+    response = Response[response_type](  # type: ignore[valid-type]
+        content, media_type=media_type, status_code=HTTP_200_OK
+    )
     if media_type == MediaType.JSON:
         value = loads(response.body)
         if isinstance(value, dict) and "enum" in value:


### PR DESCRIPTION
Support setting `media_type` on `ResponseContainer`.

A specific use-case is returning files where the media type is unknown at time of route handler definition.

Closes #482 

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
