### PR TITLE
Feature: Implements `on_app_init` hook

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,5 +1,41 @@
 # config
 
+::: starlite.config.app.AppConfig
+    options:
+        members:
+            - after_exception
+            - after_request
+            - after_response
+            - after_shutdown
+            - after_startup
+            - allowed_hosts
+            - before_request
+            - before_send
+            - before_shutdown
+            - before_startup
+            - cache_config
+            - compression_config
+            - cors_config
+            - csrf_config
+            - debug
+            - dependencies
+            - exception_handlers
+            - guards
+            - middleware
+            - on_shutdown
+            - on_startup
+            - openapi_config
+            - parameters
+            - plugins
+            - response_class
+            - response_cookies
+            - response_headers
+            - route_handlers
+            - security
+            - static_files_config
+            - tags
+            - template_config
+
 ::: starlite.config.cache.CacheConfig
     options:
         members:

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -32,6 +32,8 @@
 
 ::: starlite.types.Middleware
 
+::: starlite.types.OnAppInitHandler
+
 ::: starlite.types.ParametersMap
 
 ::: starlite.types.ReservedKwargs

--- a/docs/usage/0-the-starlite-app/6-application-init-hook.md
+++ b/docs/usage/0-the-starlite-app/6-application-init-hook.md
@@ -1,0 +1,18 @@
+# Application Init Hook
+
+Starlite includes a hook for intercepting the arguments passed to the [Starlite][starlite.app.Starlite] constructor,
+before they are used to instantiate the application.
+
+Handlers can be passed to the `on_app_init` parameter on construction of the application, and in turn, each will receive
+an instance of [AppConfig][starlite.config.app.AppConfig] and must return an instance of same.
+
+This hook is useful for applying common configuration between applications, and for use by developers who may wish to
+develop third-party application configuration systems.
+
+!!! Note
+    `on_app_init` handlers cannot be `async def` functions, as they are called within `Starlite.__init__()`, outside of
+    an async context.
+
+```py title="After Exception Hook"
+--8<-- "examples/application_hooks/on_app_init.py"
+```

--- a/examples/application_hooks/on_app_init.py
+++ b/examples/application_hooks/on_app_init.py
@@ -13,11 +13,11 @@ async def close_db_connection() -> None:
 def receive_app_config(app_config: "AppConfig") -> "AppConfig":
     """Receives parameters from the application.
 
-    In reality, this would be a personal library of boilerplate that is
-    carried from one application to another, or a third-party developed
+    In reality, this would be a library of boilerplate that is carried
+    from one application to another, or a third-party developed
     application configuration tool.
     """
-    app_config.on_shutdown = (app_config.on_shutdown or []) + [close_db_connection]
+    app_config.on_shutdown.append(close_db_connection)
     return app_config
 
 

--- a/examples/application_hooks/on_app_init.py
+++ b/examples/application_hooks/on_app_init.py
@@ -1,0 +1,24 @@
+from typing import TYPE_CHECKING
+
+from starlite import Starlite
+
+if TYPE_CHECKING:
+    from starlite.config import AppConfig
+
+
+async def close_db_connection() -> None:
+    """Closes the database connection on application shutdown."""
+
+
+def receive_app_config(app_config: "AppConfig") -> "AppConfig":
+    """Receives parameters from the application.
+
+    In reality, this would be a personal library of boilerplate that is
+    carried from one application to another, or a third-party developed
+    application configuration tool.
+    """
+    app_config.on_shutdown = (app_config.on_shutdown or []) + [close_db_connection]
+    return app_config
+
+
+app = Starlite([], on_app_init=[receive_app_config])

--- a/examples/tests/application_hooks/test_on_app_init.py
+++ b/examples/tests/application_hooks/test_on_app_init.py
@@ -1,0 +1,5 @@
+from examples.application_hooks.on_app_init import app, close_db_connection
+
+
+def test_on_app_init() -> None:
+    assert close_db_connection in app.on_shutdown

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
           - usage/0-the-starlite-app/3-static-files.md
           - usage/0-the-starlite-app/4-logging.md
           - usage/0-the-starlite-app/5-application-hooks.md
+          - usage/0-the-starlite-app/6-application-init-hook.md
       - Routing:
           - usage/1-routing/0-routing.md
           - usage/1-routing/1-registering-routes.md

--- a/poetry.lock
+++ b/poetry.lock
@@ -23,8 +23,8 @@ sniffio = ">=1.1"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-doc = ["packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["contextlib2", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=4)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (<0.15)", "uvloop (>=0.15)"]
+doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
 trio = ["trio (>=0.16)"]
 
 [[package]]
@@ -47,10 +47,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
-docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "black"
@@ -76,7 +76,7 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
-name = "Brotli"
+name = "brotli"
 version = "1.0.9"
 description = "Python bindings for the Brotli compression library"
 category = "main"
@@ -168,14 +168,14 @@ cffi = ">=1.12"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
-docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
+docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
+test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
-name = "Deprecated"
+name = "deprecated"
 version = "1.2.13"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
 category = "dev"
@@ -186,7 +186,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 wrapt = ">=1.10,<2"
 
 [package.extras]
-dev = ["PyTest", "PyTest (<5)", "PyTest-Cov", "PyTest-Cov (<2.6)", "bump2version (<1)", "configparser (<5)", "importlib-metadata (<3)", "importlib-resources (<4)", "sphinx (<2)", "sphinxcontrib-websupport (<2)", "tox", "zipp (<2)"]
+dev = ["tox", "bump2version (<1)", "sphinx (<2)", "importlib-metadata (<3)", "importlib-resources (<4)", "configparser (<5)", "sphinxcontrib-websupport (<2)", "zipp (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
 
 [[package]]
 name = "distlib"
@@ -205,8 +205,8 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [package.extras]
-curio = ["curio (>=1.2,<2.0)", "sniffio (>=1.1,<2.0)"]
 dnssec = ["cryptography (>=2.6,<37.0)"]
+curio = ["curio (>=1.2,<2.0)", "sniffio (>=1.1,<2.0)"]
 doh = ["h2 (>=4.1.0)", "httpx (>=0.21.1)", "requests (>=2.23.0,<3.0.0)", "requests-toolbelt (>=0.9.1,<0.10.0)"]
 idna = ["idna (>=2.1,<4.0)"]
 trio = ["trio (>=0.14,<0.20)"]
@@ -221,7 +221,7 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-test = ["black", "pytest"]
+test = ["pytest", "black"]
 
 [[package]]
 name = "email-validator"
@@ -247,8 +247,8 @@ python-versions = ">=3.7"
 test = ["pytest (>=6)"]
 
 [[package]]
-name = "Faker"
-version = "14.2.0"
+name = "faker"
+version = "14.2.1"
 description = "Faker is a Python package that generates fake data for you."
 category = "main"
 optional = false
@@ -290,7 +290,7 @@ optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.extras]
-docs = ["Sphinx"]
+docs = ["sphinx"]
 
 [[package]]
 name = "h11"
@@ -317,8 +317,8 @@ exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 sortedcontainers = ">=2.1.0,<3.0.0"
 
 [package.extras]
-all = ["backports.zoneinfo (>=0.2.1)", "black (>=19.10b0)", "click (>=7.0)", "django (>=3.2)", "dpcontracts (>=0.4)", "importlib-metadata (>=3.6)", "lark-parser (>=0.6.5)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=1.0)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2022.2)"]
-cli = ["black (>=19.10b0)", "click (>=7.0)", "rich (>=9.0.0)"]
+all = ["black (>=19.10b0)", "click (>=7.0)", "django (>=3.2)", "dpcontracts (>=0.4)", "lark-parser (>=0.6.5)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=1.0)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "importlib-metadata (>=3.6)", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2022.2)"]
+cli = ["click (>=7.0)", "black (>=19.10b0)", "rich (>=9.0.0)"]
 codemods = ["libcst (>=0.3.16)"]
 dateutil = ["python-dateutil (>=1.4)"]
 django = ["django (>=3.2)"]
@@ -364,9 +364,9 @@ typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "inflection"
@@ -393,7 +393,7 @@ optional = false
 python-versions = ">=3.6.2,<4.0"
 
 [[package]]
-name = "Jinja2"
+name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
 category = "dev"
@@ -407,8 +407,8 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
-name = "Mako"
-version = "1.2.2"
+name = "mako"
+version = "1.2.3"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 category = "dev"
 optional = false
@@ -419,12 +419,12 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 MarkupSafe = ">=0.9.2"
 
 [package.extras]
-babel = ["Babel"]
+babel = ["babel"]
 lingua = ["lingua"]
 testing = ["pytest"]
 
 [[package]]
-name = "MarkupSafe"
+name = "markupsafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "dev"
@@ -446,9 +446,6 @@ description = "Node.js virtual environment builder"
 category = "dev"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
-
-[package.dependencies]
-setuptools = "*"
 
 [[package]]
 name = "orjson"
@@ -495,7 +492,7 @@ targ = ">=0.3.7"
 typing-extensions = ">=3.10.0.0"
 
 [package.extras]
-all = ["aiosqlite (>=0.16.0)", "asyncpg (>=0.21.0)", "ipython", "orjson (>=3.5.1)", "uvloop (>=0.12.0)"]
+all = ["orjson (>=3.5.1)", "ipython", "asyncpg (>=0.21.0)", "aiosqlite (>=0.16.0)", "uvloop (>=0.12.0)"]
 orjson = ["orjson (>=3.5.1)"]
 playground = ["ipython"]
 postgres = ["asyncpg (>=0.21.0)"]
@@ -511,7 +508,7 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-dev = ["black", "pytest", "pytest-cov", "rich"]
+dev = ["rich", "pytest", "pytest-cov", "black"]
 
 [[package]]
 name = "platformdirs"
@@ -522,8 +519,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
-test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
+test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
 
 [[package]]
 name = "pluggy"
@@ -537,8 +534,8 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-dev = ["pre-commit", "tox"]
-testing = ["pytest", "pytest-benchmark"]
+testing = ["pytest-benchmark", "pytest"]
+dev = ["tox", "pre-commit"]
 
 [[package]]
 name = "pre-commit"
@@ -624,7 +621,7 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pypika-tortoise"
@@ -668,7 +665,7 @@ pytest = ">=6.1.0"
 typing-extensions = {version = ">=3.7.2", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
 name = "pytest-cov"
@@ -683,7 +680,7 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+testing = ["virtualenv", "pytest-xdist", "six", "process-tests", "hunter", "fields"]
 
 [[package]]
 name = "python-dateutil"
@@ -705,7 +702,7 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "PyYAML"
+name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "main"
@@ -750,19 +747,6 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
-name = "setuptools"
-version = "65.3.0"
-description = "Easily download, build, install, upgrade, and uninstall Python packages"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -787,7 +771,7 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "SQLAlchemy"
+name = "sqlalchemy"
 version = "1.4.41"
 description = "Database Abstraction Library"
 category = "dev"
@@ -799,25 +783,25 @@ greenlet = {version = "!=0.4.17", markers = "python_version >= \"3\" and (platfo
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-aiomysql = ["aiomysql", "greenlet (!=0.4.17)"]
-aiosqlite = ["aiosqlite", "greenlet (!=0.4.17)", "typing_extensions (!=3.10.0.1)"]
+aiomysql = ["greenlet (!=0.4.17)", "aiomysql"]
+aiosqlite = ["typing_extensions (!=3.10.0.1)", "greenlet (!=0.4.17)", "aiosqlite"]
 asyncio = ["greenlet (!=0.4.17)"]
-asyncmy = ["asyncmy (>=0.2.3,!=0.2.4)", "greenlet (!=0.4.17)"]
+asyncmy = ["greenlet (!=0.4.17)", "asyncmy (>=0.2.3,!=0.2.4)"]
 mariadb_connector = ["mariadb (>=1.0.1,!=1.1.2)"]
 mssql = ["pyodbc"]
 mssql_pymssql = ["pymssql"]
 mssql_pyodbc = ["pyodbc"]
-mypy = ["mypy (>=0.910)", "sqlalchemy2-stubs"]
-mysql = ["mysqlclient (>=1.4.0)", "mysqlclient (>=1.4.0,<2)"]
+mypy = ["sqlalchemy2-stubs", "mypy (>=0.910)"]
+mysql = ["mysqlclient (>=1.4.0,<2)", "mysqlclient (>=1.4.0)"]
 mysql_connector = ["mysql-connector-python"]
-oracle = ["cx_oracle (>=7)", "cx_oracle (>=7,<8)"]
+oracle = ["cx_oracle (>=7,<8)", "cx_oracle (>=7)"]
 postgresql = ["psycopg2 (>=2.7)"]
-postgresql_asyncpg = ["asyncpg", "greenlet (!=0.4.17)"]
+postgresql_asyncpg = ["greenlet (!=0.4.17)", "asyncpg"]
 postgresql_pg8000 = ["pg8000 (>=1.16.6,!=1.29.0)"]
 postgresql_psycopg2binary = ["psycopg2-binary"]
 postgresql_psycopg2cffi = ["psycopg2cffi"]
-pymysql = ["pymysql", "pymysql (<1)"]
-sqlcipher = ["sqlcipher3_binary"]
+pymysql = ["pymysql (<1)", "pymysql"]
+sqlcipher = ["sqlcipher3-binary"]
 
 [[package]]
 name = "starlette"
@@ -889,12 +873,12 @@ pypika-tortoise = ">=0.1.6,<0.2.0"
 pytz = "*"
 
 [package.extras]
-accel = ["ciso8601", "orjson", "uvloop"]
 aiomysql = ["aiomysql"]
 asyncmy = ["asyncmy (>=0.2.5,<0.3.0)"]
 asyncodbc = ["asyncodbc (>=0.1.1,<0.2.0)"]
 asyncpg = ["asyncpg"]
-psycopg = ["psycopg[binary,pool]"]
+accel = ["ciso8601", "orjson", "uvloop"]
+psycopg = ["psycopg"]
 
 [[package]]
 name = "tox"
@@ -917,7 +901,7 @@ virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,
 
 [package.extras]
 docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
-testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)"]
+testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "psutil (>=5.6.1)", "pathlib2 (>=2.3.3)"]
 
 [[package]]
 name = "typed-ast"
@@ -956,8 +940,8 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -1019,8 +1003,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
-testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [extras]
 brotli = ["brotli"]
@@ -1076,7 +1060,7 @@ black = [
     {file = "black-22.8.0-py3-none-any.whl", hash = "sha256:d2c21d439b2baf7aa80d6dd4e3659259be64c6f49dfd0f32091063db0e006db4"},
     {file = "black-22.8.0.tar.gz", hash = "sha256:792f7eb540ba9a17e8656538701d3eb1afcb134e3b45b71f20b25c77a8db7e6e"},
 ]
-Brotli = [
+brotli = [
     {file = "Brotli-1.0.9-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:268fe94547ba25b58ebc724680609c8ee3e5a843202e9a381f6f9c5e8bdb5c70"},
     {file = "Brotli-1.0.9-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:c2415d9d082152460f2bd4e382a1e85aed233abc92db5a3880da2257dc7daf7b"},
     {file = "Brotli-1.0.9-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5913a1177fc36e30fcf6dc868ce23b0453952c78c04c266d3149b3d39e1410d6"},
@@ -1306,7 +1290,7 @@ cryptography = [
     {file = "cryptography-38.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:52e7bee800ec869b4031093875279f1ff2ed12c1e2f74923e8f49c916afd1d3b"},
     {file = "cryptography-38.0.1.tar.gz", hash = "sha256:1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7"},
 ]
-Deprecated = [
+deprecated = [
     {file = "Deprecated-1.2.13-py2.py3-none-any.whl", hash = "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"},
     {file = "Deprecated-1.2.13.tar.gz", hash = "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d"},
 ]
@@ -1329,9 +1313,9 @@ exceptiongroup = [
     {file = "exceptiongroup-1.0.0rc9-py3-none-any.whl", hash = "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337"},
     {file = "exceptiongroup-1.0.0rc9.tar.gz", hash = "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"},
 ]
-Faker = [
-    {file = "Faker-14.2.0-py3-none-any.whl", hash = "sha256:e02c55a5b0586caaf913cc6c254b3de178e08b031c5922e590fd033ebbdbfd02"},
-    {file = "Faker-14.2.0.tar.gz", hash = "sha256:6db56e2c43a2b74250d1c332ef25fef7dc07dcb6c5fab5329dd7b4467b8ed7b9"},
+faker = [
+    {file = "Faker-14.2.1-py3-none-any.whl", hash = "sha256:2e28aaea60456857d4ce95dd12aed767769537ad23d13d51a545cd40a654e9d9"},
+    {file = "Faker-14.2.1.tar.gz", hash = "sha256:daad7badb4fd916bd047b28c8459ef4689e4fe6acf61f6dfebee8cc602e4d009"},
 ]
 filelock = [
     {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
@@ -1429,15 +1413,15 @@ iso8601 = [
     {file = "iso8601-1.0.2-py3-none-any.whl", hash = "sha256:d7bc01b1c2a43b259570bb307f057abc578786ea734ba2b87b836c5efc5bd443"},
     {file = "iso8601-1.0.2.tar.gz", hash = "sha256:27f503220e6845d9db954fb212b95b0362d8b7e6c1b2326a87061c3de93594b1"},
 ]
-Jinja2 = [
+jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
     {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
 ]
-Mako = [
-    {file = "Mako-1.2.2-py3-none-any.whl", hash = "sha256:8efcb8004681b5f71d09c983ad5a9e6f5c40601a6ec469148753292abc0da534"},
-    {file = "Mako-1.2.2.tar.gz", hash = "sha256:3724869b363ba630a272a5f89f68c070352137b8fd1757650017b7e06fda163f"},
+mako = [
+    {file = "Mako-1.2.3-py3-none-any.whl", hash = "sha256:c413a086e38cd885088d5e165305ee8eed04e8b3f8f62df343480da0a385735f"},
+    {file = "Mako-1.2.3.tar.gz", hash = "sha256:7fde96466fcfeedb0eed94f187f20b23d85e4cb41444be0e542e2c8c65c396cd"},
 ]
-MarkupSafe = [
+markupsafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
     {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
@@ -1669,7 +1653,7 @@ pytz = [
     {file = "pytz-2022.2.1-py2.py3-none-any.whl", hash = "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197"},
     {file = "pytz-2022.2.1.tar.gz", hash = "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"},
 ]
-PyYAML = [
+pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
@@ -1712,10 +1696,6 @@ requests = [
     {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
-setuptools = [
-    {file = "setuptools-65.3.0-py3-none-any.whl", hash = "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82"},
-    {file = "setuptools-65.3.0.tar.gz", hash = "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"},
-]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -1728,7 +1708,7 @@ sortedcontainers = [
     {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
     {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
-SQLAlchemy = [
+sqlalchemy = [
     {file = "SQLAlchemy-1.4.41-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:13e397a9371ecd25573a7b90bd037db604331cf403f5318038c46ee44908c44d"},
     {file = "SQLAlchemy-1.4.41-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:2d6495f84c4fd11584f34e62f9feec81bf373787b3942270487074e35cbe5330"},
     {file = "SQLAlchemy-1.4.41-cp27-cp27m-win32.whl", hash = "sha256:e570cfc40a29d6ad46c9aeaddbdcee687880940a3a327f2c668dd0e4ef0a441d"},

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -257,7 +257,6 @@ class Starlite(Router):
 
         # creates app config object from parameters
         config = AppConfig(
-            route_handlers=route_handlers,
             after_exception=after_exception or [],
             after_request=after_request,
             after_response=after_response,
@@ -285,6 +284,7 @@ class Starlite(Router):
             response_class=response_class,
             response_cookies=response_cookies or [],
             response_headers=response_headers or {},
+            route_handlers=route_handlers,
             security=security or [],
             static_files_config=static_files_config or [],
             tags=tags or [],
@@ -333,7 +333,7 @@ class Starlite(Router):
         for plugin in self.plugins:
             plugin.on_app_init(app=self)
 
-        for route_handler in route_handlers:
+        for route_handler in config.route_handlers:
             self.register(route_handler)
 
         if self.openapi_config:

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -174,7 +174,7 @@ class Starlite(Router):
         static_files_config: Optional[Union["StaticFilesConfig", List["StaticFilesConfig"]]] = None,
         tags: Optional[List[str]] = None,
         template_config: Optional["TemplateConfig"] = None,
-    ):
+    ) -> None:
         """The Starlite application.
 
         `Starlite` is the root level of the app - it has the base path of "/" and all root level

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -324,7 +324,7 @@ class Starlite(Router):
             response_class=config.response_class,
             response_cookies=config.response_cookies,
             response_headers=config.response_headers,
-            route_handlers=config.route_handlers,
+            route_handlers=[],
             security=config.security,
             tags=config.tags,
         )

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -324,6 +324,7 @@ class Starlite(Router):
             response_class=config.response_class,
             response_cookies=config.response_cookies,
             response_headers=config.response_headers,
+            # route handlers are registered below
             route_handlers=[],
             security=config.security,
             tags=config.tags,

--- a/starlite/config/__init__.py
+++ b/starlite/config/__init__.py
@@ -1,3 +1,4 @@
+from .app import AppConfig
 from .cache import CacheConfig
 from .compression import CompressionConfig
 from .cors import CORSConfig
@@ -8,6 +9,7 @@ from .static_files import StaticFilesConfig
 from .template import TemplateConfig
 
 __all__ = [
+    "AppConfig",
     "CacheConfig",
     "CORSConfig",
     "CSRFConfig",

--- a/starlite/config/app.py
+++ b/starlite/config/app.py
@@ -1,0 +1,71 @@
+from typing import Dict, List, Optional, Union
+
+from pydantic import BaseConfig, BaseModel
+from pydantic_openapi_schema.v3_1_0 import SecurityRequirement
+
+from starlite.plugins.base import PluginProtocol
+from starlite.provide import Provide
+from starlite.types import (
+    AfterExceptionHookHandler,
+    AfterRequestHookHandler,
+    AfterResponseHookHandler,
+    BeforeMessageSendHookHandler,
+    BeforeRequestHookHandler,
+    ControllerRouterHandler,
+    ExceptionHandlersMap,
+    Guard,
+    LifeSpanHandler,
+    LifeSpanHookHandler,
+    Middleware,
+    ParametersMap,
+    ResponseCookies,
+    ResponseHeadersMap,
+    ResponseType,
+    SingleOrList,
+)
+
+from .cache import CacheConfig
+from .compression import CompressionConfig
+from .cors import CORSConfig
+from .csrf import CSRFConfig
+from .openapi import OpenAPIConfig
+from .static_files import StaticFilesConfig
+from .template import TemplateConfig
+
+
+class AppConfig(BaseModel):
+    class Config(BaseConfig):
+        arbitrary_types_allowed = True
+
+    route_handlers: List[ControllerRouterHandler]
+    after_exception: Optional[SingleOrList[AfterExceptionHookHandler]]
+    after_request: Optional[AfterRequestHookHandler]
+    after_response: Optional[AfterResponseHookHandler]
+    after_shutdown: Optional[SingleOrList[LifeSpanHookHandler]]
+    after_startup: Optional[SingleOrList[LifeSpanHookHandler]]
+    allowed_hosts: Optional[List[str]]
+    before_request: Optional[BeforeRequestHookHandler]
+    before_send: Optional[SingleOrList[BeforeMessageSendHookHandler]]
+    before_shutdown: Optional[SingleOrList[LifeSpanHookHandler]]
+    before_startup: Optional[SingleOrList[LifeSpanHookHandler]]
+    cache_config: CacheConfig
+    compression_config: Optional[CompressionConfig]
+    cors_config: Optional[CORSConfig]
+    csrf_config: Optional[CSRFConfig]
+    debug: bool
+    dependencies: Optional[Dict[str, Provide]]
+    exception_handlers: Optional[ExceptionHandlersMap]
+    guards: Optional[List[Guard]]
+    middleware: Optional[List[Middleware]]
+    on_shutdown: Optional[List[LifeSpanHandler]]
+    on_startup: Optional[List[LifeSpanHandler]]
+    openapi_config: Optional[OpenAPIConfig]
+    parameters: Optional[ParametersMap]
+    plugins: Optional[List[PluginProtocol]]
+    response_class: Optional[ResponseType]
+    response_cookies: Optional[ResponseCookies]
+    response_headers: Optional[ResponseHeadersMap]
+    security: Optional[List[SecurityRequirement]]
+    static_files_config: Optional[Union[StaticFilesConfig, List[StaticFilesConfig]]]
+    tags: Optional[List[str]]
+    template_config: Optional[TemplateConfig]

--- a/starlite/config/app.py
+++ b/starlite/config/app.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from pydantic import BaseConfig, BaseModel
 from pydantic_openapi_schema.v3_1_0 import SecurityRequirement
@@ -45,7 +45,7 @@ class AppConfig(BaseModel):
     class Config(BaseConfig):
         arbitrary_types_allowed = True
 
-    after_exception: Optional[SingleOrList[AfterExceptionHookHandler]]
+    after_exception: SingleOrList[AfterExceptionHookHandler]
     """
     An application level [exception hook handler][starlite.types.AfterExceptionHookHandler] or list thereof. This hook
     is called after an exception occurs. In difference to exception handlers, it is not meant to return a response -
@@ -62,17 +62,17 @@ class AppConfig(BaseModel):
     A sync or async function called after the response has been awaited. It receives the
     [Request][starlite.connection.Request] object and should not return any values.
     """
-    after_shutdown: Optional[SingleOrList[LifeSpanHookHandler]]
+    after_shutdown: SingleOrList[LifeSpanHookHandler]
     """
     An application level [life-span hook handler][starlite.types.LifeSpanHookHandler] or list thereof. This hook is
     called during the ASGI shutdown, after all callables in the 'on_shutdown' list have been called.
     """
-    after_startup: Optional[SingleOrList[LifeSpanHookHandler]]
+    after_startup: SingleOrList[LifeSpanHookHandler]
     """
     An application level [life-span hook handler][starlite.types.LifeSpanHookHandler] or list thereof. This hook is
     called during the ASGI startup, after all callables in the 'on_startup' list have been called.
     """
-    allowed_hosts: Optional[List[str]]
+    allowed_hosts: List[str]
     """
     A list of allowed hosts - enables the builtin allowed hosts middleware.
     """
@@ -82,17 +82,17 @@ class AppConfig(BaseModel):
     [Request][starlite.connection.Request] instance and any non-`None` return value is used for the response, bypassing
     the route handler.
     """
-    before_send: Optional[SingleOrList[BeforeMessageSendHookHandler]]
+    before_send: SingleOrList[BeforeMessageSendHookHandler]
     """
     An application level [before send hook handler][starlite.types.BeforeMessageSendHookHandler] or list thereof. This
     hook is called when the ASGI send function is called.
     """
-    before_shutdown: Optional[SingleOrList[LifeSpanHookHandler]]
+    before_shutdown: SingleOrList[LifeSpanHookHandler]
     """
     An application level [life-span hook handler][starlite.types.LifeSpanHookHandler] or list thereof. This hook is
     called during the ASGI shutdown, before any callables in the 'on_shutdown' list have been called.
     """
-    before_startup: Optional[SingleOrList[LifeSpanHookHandler]]
+    before_startup: SingleOrList[LifeSpanHookHandler]
     """
     An application level [life-span hook handler][starlite.types.LifeSpanHookHandler] or list thereof. This hook is
     called during the ASGI startup, before any callables in the 'on_startup' list have been called.
@@ -117,27 +117,27 @@ class AppConfig(BaseModel):
     """
     If `True`, app errors rendered as HTML with a stack trace.
     """
-    dependencies: Optional[Dict[str, Provide]]
+    dependencies: Dict[str, Provide]
     """
     A string keyed dictionary of dependency [Provider][starlite.provide.Provide] instances.
     """
-    exception_handlers: Optional[ExceptionHandlersMap]
+    exception_handlers: ExceptionHandlersMap
     """
     A dictionary that maps handler functions to status codes and/or exception types.
     """
-    guards: Optional[List[Guard]]
+    guards: List[Guard]
     """
     A list of [Guard][starlite.types.Guard] callables.
     """
-    middleware: Optional[List[Middleware]]
+    middleware: List[Middleware]
     """
     A list of [Middleware][starlite.types.Middleware].
     """
-    on_shutdown: Optional[List[LifeSpanHandler]]
+    on_shutdown: List[LifeSpanHandler]
     """
     A list of [LifeSpanHandler][starlite.types.LifeSpanHandler] called during application shutdown.
     """
-    on_startup: Optional[List[LifeSpanHandler]]
+    on_startup: List[LifeSpanHandler]
     """
     A list of [LifeSpanHandler][starlite.types.LifeSpanHandler] called during application startup.
     """
@@ -145,11 +145,11 @@ class AppConfig(BaseModel):
     """
     Defaults to [DEFAULT_OPENAPI_CONFIG][starlite.app.DEFAULT_OPENAPI_CONFIG]
     """
-    parameters: Optional[ParametersMap]
+    parameters: ParametersMap
     """
     A mapping of [Parameter][starlite.params.Parameter] definitions available to all application paths.
     """
-    plugins: Optional[List[PluginProtocol]]
+    plugins: List[PluginProtocol]
     """
     List of [PluginProtocol][starlite.plugins.base.PluginProtocol].
     """
@@ -157,11 +157,11 @@ class AppConfig(BaseModel):
     """
     A custom subclass of [starlite.response.Response] to be used as the app's default response.
     """
-    response_cookies: Optional[ResponseCookies]
+    response_cookies: ResponseCookies
     """
     A list of [Cookie](starlite.datastructures.Cookie] instances.
     """
-    response_headers: Optional[ResponseHeadersMap]
+    response_headers: ResponseHeadersMap
     """
     A string keyed dictionary mapping [ResponseHeader][starlite.datastructures.ResponseHeader] instances.
     """
@@ -170,16 +170,16 @@ class AppConfig(BaseModel):
     A required list of route handlers, which can include instances of [Router][starlite.router.Router], subclasses of
     [Controller][starlite.controller.Controller] or any function decorated by the route handler decorators.
     """
-    security: Optional[List[SecurityRequirement]]
+    security: List[SecurityRequirement]
     """
     A list of dictionaries that will be added to the schema of all route handlers in the application. See
     [SecurityRequirement][pydantic_openapi_schema.v3_1_0.security_requirement.SecurityRequirement] for details.
     """
-    static_files_config: Optional[Union[StaticFilesConfig, List[StaticFilesConfig]]]
+    static_files_config: SingleOrList[StaticFilesConfig]
     """
     An instance or list of [StaticFilesConfig][starlite.config.StaticFilesConfig].
     """
-    tags: Optional[List[str]]
+    tags: List[str]
     """
     A list of string tags that will be appended to the schema of all route handlers under the application.
     """

--- a/starlite/config/app.py
+++ b/starlite/config/app.py
@@ -34,38 +34,156 @@ from .template import TemplateConfig
 
 
 class AppConfig(BaseModel):
+    """The parameters provided to the `Starlite` app are used to instantiate an
+    instance, and then the instance is passed to any callbacks registered to
+    `on_app_init` in the order they are provided.
+
+    The final attribute values are used to instantiate the application
+    object.
+    """
+
     class Config(BaseConfig):
         arbitrary_types_allowed = True
 
-    route_handlers: List[ControllerRouterHandler]
     after_exception: Optional[SingleOrList[AfterExceptionHookHandler]]
+    """
+    An application level [exception hook handler][starlite.types.AfterExceptionHookHandler] or list thereof. This hook
+    is called after an exception occurs. In difference to exception handlers, it is not meant to return a response -
+    only to process the exception (e.g. log it, send it to Sentry etc.).
+    """
     after_request: Optional[AfterRequestHookHandler]
+    """
+    A sync or async function executed after the route handler function returned and the response object has been
+    resolved. Receives the response object which may be either an instance of [Response][starlite.response.Response] or
+    `starlette.Response`.
+    """
     after_response: Optional[AfterResponseHookHandler]
+    """
+    A sync or async function called after the response has been awaited. It receives the
+    [Request][starlite.connection.Request] object and should not return any values.
+    """
     after_shutdown: Optional[SingleOrList[LifeSpanHookHandler]]
+    """
+    An application level [life-span hook handler][starlite.types.LifeSpanHookHandler] or list thereof. This hook is
+    called during the ASGI shutdown, after all callables in the 'on_shutdown' list have been called.
+    """
     after_startup: Optional[SingleOrList[LifeSpanHookHandler]]
+    """
+    An application level [life-span hook handler][starlite.types.LifeSpanHookHandler] or list thereof. This hook is
+    called during the ASGI startup, after all callables in the 'on_startup' list have been called.
+    """
     allowed_hosts: Optional[List[str]]
+    """
+    A list of allowed hosts - enables the builtin allowed hosts middleware.
+    """
     before_request: Optional[BeforeRequestHookHandler]
+    """
+    A sync or async function called immediately before calling the route handler. Receives the
+    [Request][starlite.connection.Request] instance and any non-`None` return value is used for the response, bypassing
+    the route handler.
+    """
     before_send: Optional[SingleOrList[BeforeMessageSendHookHandler]]
+    """
+    An application level [before send hook handler][starlite.types.BeforeMessageSendHookHandler] or list thereof. This
+    hook is called when the ASGI send function is called.
+    """
     before_shutdown: Optional[SingleOrList[LifeSpanHookHandler]]
+    """
+    An application level [life-span hook handler][starlite.types.LifeSpanHookHandler] or list thereof. This hook is
+    called during the ASGI shutdown, before any callables in the 'on_shutdown' list have been called.
+    """
     before_startup: Optional[SingleOrList[LifeSpanHookHandler]]
+    """
+    An application level [life-span hook handler][starlite.types.LifeSpanHookHandler] or list thereof. This hook is
+    called during the ASGI startup, before any callables in the 'on_startup' list have been called.
+    """
     cache_config: CacheConfig
+    """
+    Configures caching behavior of the application.
+    """
     compression_config: Optional[CompressionConfig]
+    """
+    Configures compression behaviour of the application, this enabled a builtin or user defined Compression middleware.
+    """
     cors_config: Optional[CORSConfig]
+    """
+    If set this enables the builtin CORS middleware.
+    """
     csrf_config: Optional[CSRFConfig]
+    """
+    If set this enables the builtin CSRF middleware.
+    """
     debug: bool
+    """
+    If `True`, app errors rendered as HTML with a stack trace.
+    """
     dependencies: Optional[Dict[str, Provide]]
+    """
+    A string keyed dictionary of dependency [Provider][starlite.provide.Provide] instances.
+    """
     exception_handlers: Optional[ExceptionHandlersMap]
+    """
+    A dictionary that maps handler functions to status codes and/or exception types.
+    """
     guards: Optional[List[Guard]]
+    """
+    A list of [Guard][starlite.types.Guard] callables.
+    """
     middleware: Optional[List[Middleware]]
+    """
+    A list of [Middleware][starlite.types.Middleware].
+    """
     on_shutdown: Optional[List[LifeSpanHandler]]
+    """
+    A list of [LifeSpanHandler][starlite.types.LifeSpanHandler] called during application shutdown.
+    """
     on_startup: Optional[List[LifeSpanHandler]]
+    """
+    A list of [LifeSpanHandler][starlite.types.LifeSpanHandler] called during application startup.
+    """
     openapi_config: Optional[OpenAPIConfig]
+    """
+    Defaults to [DEFAULT_OPENAPI_CONFIG][starlite.app.DEFAULT_OPENAPI_CONFIG]
+    """
     parameters: Optional[ParametersMap]
+    """
+    A mapping of [Parameter][starlite.params.Parameter] definitions available to all application paths.
+    """
     plugins: Optional[List[PluginProtocol]]
+    """
+    List of [PluginProtocol][starlite.plugins.base.PluginProtocol].
+    """
     response_class: Optional[ResponseType]
+    """
+    A custom subclass of [starlite.response.Response] to be used as the app's default response.
+    """
     response_cookies: Optional[ResponseCookies]
+    """
+    A list of [Cookie](starlite.datastructures.Cookie] instances.
+    """
     response_headers: Optional[ResponseHeadersMap]
+    """
+    A string keyed dictionary mapping [ResponseHeader][starlite.datastructures.ResponseHeader] instances.
+    """
+    route_handlers: List[ControllerRouterHandler]
+    """
+    A required list of route handlers, which can include instances of [Router][starlite.router.Router], subclasses of
+    [Controller][starlite.controller.Controller] or any function decorated by the route handler decorators.
+    """
     security: Optional[List[SecurityRequirement]]
+    """
+    A list of dictionaries that will be added to the schema of all route handlers in the application. See
+    [SecurityRequirement][pydantic_openapi_schema.v3_1_0.security_requirement.SecurityRequirement] for details.
+    """
     static_files_config: Optional[Union[StaticFilesConfig, List[StaticFilesConfig]]]
+    """
+    An instance or list of [StaticFilesConfig][starlite.config.StaticFilesConfig].
+    """
     tags: Optional[List[str]]
+    """
+    A list of string tags that will be appended to the schema of all route handlers under the application.
+    """
     template_config: Optional[TemplateConfig]
+    """
+    An instance of [TemplateConfig][starlite.config.TemplateConfig].
+    """

--- a/starlite/router.py
+++ b/starlite/router.py
@@ -127,7 +127,7 @@ class Router:
         self.response_cookies = response_cookies or []
         self.response_headers = response_headers or {}
         self.routes: List["BaseRoute"] = []
-        self.security = security
+        self.security = security or []
         self.tags = tags or []
 
         for route_handler in route_handlers or []:

--- a/starlite/types/__init__.py
+++ b/starlite/types/__init__.py
@@ -28,7 +28,7 @@ from .callable_types import (
     Guard,
     LifeSpanHandler,
     LifeSpanHookHandler,
-    OnAppConfigHandler,
+    OnAppInitHandler,
     Serializer,
 )
 from .composite import (
@@ -76,7 +76,7 @@ __all__ = [
     "Message",
     "Method",
     "Middleware",
-    "OnAppConfigHandler",
+    "OnAppInitHandler",
     "ParametersMap",
     "Receive",
     "ReservedKwargs",

--- a/starlite/types/__init__.py
+++ b/starlite/types/__init__.py
@@ -28,6 +28,7 @@ from .callable_types import (
     Guard,
     LifeSpanHandler,
     LifeSpanHookHandler,
+    OnAppConfigHandler,
     Serializer,
 )
 from .composite import (
@@ -75,6 +76,7 @@ __all__ = [
     "Message",
     "Method",
     "Middleware",
+    "OnAppConfigHandler",
     "ParametersMap",
     "Receive",
     "ReservedKwargs",

--- a/starlite/types/callable_types.py
+++ b/starlite/types/callable_types.py
@@ -7,11 +7,13 @@ from .internal_types import StarliteType
 if TYPE_CHECKING:
     from starlette.responses import Response as StarletteResponse  # noqa: TC004
 
+    from starlite.config import AppConfig  # noqa: TC004
     from starlite.connection import Request, WebSocket  # noqa: TC004
     from starlite.datastructures import State  # noqa: TC004
     from starlite.handlers import HTTPRouteHandler, WebsocketRouteHandler  # noqa: TC004
     from starlite.response import Response  # noqa: TC004
 else:
+    AppConfig = Any
     HTTPRouteHandler = Any
     Request = Any
     Response = Any
@@ -37,4 +39,5 @@ Guard = Union[
 ]
 LifeSpanHandler = Union[Callable[[], SyncOrAsyncUnion[Any]], Callable[[State], SyncOrAsyncUnion[Any]]]
 LifeSpanHookHandler = Callable[[StarliteType], SyncOrAsyncUnion[None]]
+OnAppConfigHandler = Callable[[AppConfig], AppConfig]
 Serializer = Callable[[Any], Any]

--- a/starlite/types/callable_types.py
+++ b/starlite/types/callable_types.py
@@ -39,5 +39,5 @@ Guard = Union[
 ]
 LifeSpanHandler = Union[Callable[[], SyncOrAsyncUnion[Any]], Callable[[State], SyncOrAsyncUnion[Any]]]
 LifeSpanHookHandler = Callable[[StarliteType], SyncOrAsyncUnion[None]]
-OnAppConfigHandler = Callable[[AppConfig], AppConfig]
+OnAppInitHandler = Callable[[AppConfig], AppConfig]
 Serializer = Callable[[Any], Any]

--- a/tests/app/test_app_config.py
+++ b/tests/app/test_app_config.py
@@ -12,37 +12,37 @@ from starlite.router import Router
 @pytest.fixture()
 def app_config_object() -> AppConfig:
     return AppConfig(
-        after_exception=None,
+        after_exception=[],
         after_request=None,
         after_response=None,
-        after_shutdown=None,
-        after_startup=None,
-        allowed_hosts=None,
+        after_shutdown=[],
+        after_startup=[],
+        allowed_hosts=[],
         before_request=None,
-        before_send=None,
-        before_shutdown=None,
-        before_startup=None,
+        before_send=[],
+        before_shutdown=[],
+        before_startup=[],
         cache_config=DEFAULT_CACHE_CONFIG,
         compression_config=None,
         cors_config=None,
         csrf_config=None,
         debug=False,
-        dependencies=None,
-        exception_handlers=None,
-        guards=None,
-        middleware=None,
-        on_shutdown=None,
-        on_startup=None,
+        dependencies={},
+        exception_handlers={},
+        guards=[],
+        middleware=[],
+        on_shutdown=[],
+        on_startup=[],
         openapi_config=None,
-        parameters=None,
-        plugins=None,
+        parameters={},
+        plugins=[],
         response_class=None,
-        response_cookies=None,
-        response_headers=None,
+        response_cookies=[],
+        response_headers={},
         route_handlers=[],
-        security=None,
-        static_files_config=None,
-        tags=None,
+        security=[],
+        static_files_config=[],
+        tags=[],
         template_config=None,
     )
 
@@ -62,21 +62,32 @@ def test_app_params_defined_on_app_config_object() -> None:
 
 def test_app_config_object_used(app_config_object: AppConfig, monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure that the properties on the `AppConfig` object are accessed within
-    the `Starlite` constructor."""
+    the `Starlite` constructor.
+
+    In the test we replace every field on the `AppConfig` type with a
+    property mock so that we can check that it has at least been
+    accessed. It doesn't actually check that we do the right thing with
+    it, but is a guard against the case of adding a parameter to the
+    `Starlite` signature and to the `AppConfig` object, and using the
+    value from the parameter downstream from construction of the
+    `AppConfig` object.
+    """
 
     # replace each field on the `AppConfig` object with a `PropertyMock`, this allows us to assert that the properties
     # have been accessed during app instantiation.
     property_mocks: List[PropertyMock] = []
     for name in AppConfig.__fields__:
         if name == "cache_config":
-            return_value = DEFAULT_CACHE_CONFIG
+            property_mock = PropertyMock(return_value=DEFAULT_CACHE_CONFIG)
         else:
-            return_value = None
-        property_mock = PropertyMock(return_value=return_value)
+            # default iterable return value allows the mock properties that need to be iterated over in
+            # `Starlite.__init__()` to not blow up, for other properties it shouldn't matter what the value is for the
+            # sake of this test.
+            property_mock = PropertyMock(return_value=[])
         property_mocks.append(property_mock)
         monkeypatch.setattr(type(app_config_object), name, property_mock, raising=False)
 
-    # Patch methods called from within `Starlite.__init__()` to prevent various errors.
+    # Things that we don't actually need to call for this test
     monkeypatch.setattr(Starlite, "register", MagicMock())
     monkeypatch.setattr(Starlite, "_create_asgi_handler", MagicMock())
     monkeypatch.setattr(Router, "__init__", MagicMock())

--- a/tests/app/test_app_config.py
+++ b/tests/app/test_app_config.py
@@ -1,0 +1,97 @@
+import inspect
+from typing import List
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+from starlite.app import DEFAULT_CACHE_CONFIG, Starlite
+from starlite.config.app import AppConfig
+from starlite.router import Router
+
+
+@pytest.fixture()
+def app_config_object() -> AppConfig:
+    return AppConfig(
+        route_handlers=[],
+        after_exception=None,
+        after_request=None,
+        after_response=None,
+        after_shutdown=None,
+        after_startup=None,
+        allowed_hosts=None,
+        before_request=None,
+        before_send=None,
+        before_shutdown=None,
+        before_startup=None,
+        cache_config=DEFAULT_CACHE_CONFIG,
+        compression_config=None,
+        cors_config=None,
+        csrf_config=None,
+        debug=False,
+        dependencies=None,
+        exception_handlers=None,
+        guards=None,
+        middleware=None,
+        on_shutdown=None,
+        on_startup=None,
+        openapi_config=None,
+        parameters=None,
+        plugins=None,
+        response_class=None,
+        response_cookies=None,
+        response_headers=None,
+        security=None,
+        static_files_config=None,
+        tags=None,
+        template_config=None,
+    )
+
+
+@pytest.fixture()
+def starlite_signature() -> inspect.Signature:
+    return inspect.signature(Starlite)
+
+
+def test_app_params_defined_on_app_config_object(starlite_signature: inspect.Signature) -> None:
+    """Ensures that all parameters to the `Starlite` constructor are present on
+    the `AppConfig` object."""
+    app_config_fields = AppConfig.__fields__
+    for name in starlite_signature.parameters:
+        if name == "on_app_config":
+            continue
+        assert name in app_config_fields
+    # ensure there are not fields defined on AppConfig that aren't in the Starlite signature
+    assert not (app_config_fields.keys() - starlite_signature.parameters.keys())
+
+
+def test_app_config_object_used(
+    starlite_signature: inspect.Signature,
+    app_config_object: AppConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ensure that the properties on the `AppConfig` object are accessed within
+    the `Starlite` constructor."""
+
+    # replace each field on the `AppConfig` object with a `PropertyMock`, this allows us to assert that the properties
+    # have been accessed during app instantiation.
+    property_mocks: List[PropertyMock] = []
+    for name in AppConfig.__fields__:
+        if name == "cache_config":
+            return_value = DEFAULT_CACHE_CONFIG
+        else:
+            return_value = None
+        property_mock = PropertyMock(return_value=return_value)
+        property_mocks.append(property_mock)
+        monkeypatch.setattr(type(app_config_object), name, property_mock, raising=False)
+
+    # Patch methods called from within `Starlite.__init__()` to prevent various errors.
+    monkeypatch.setattr(Starlite, "register", MagicMock())
+    monkeypatch.setattr(Starlite, "_create_asgi_handler", MagicMock())
+    monkeypatch.setattr(Router, "__init__", MagicMock())
+
+    # instantiates the app with an `on_app_config` that returns our patched `AppConfig` object.
+    Starlite(route_handlers=[], debug=False, on_app_config=[MagicMock(return_value=app_config_object)])
+
+    # this ensures that each of the properties of the `AppConfig` object have been accessed within `Starlite.__init__()`
+    for mock in property_mocks:
+        mock.assert_called()


### PR DESCRIPTION
# `on_app_init` callbacks

## Issue with the current `PluginProtocol.on_app_init()` system.

- The `Plugin.on_app_init()` callback occurs before route handler registration, so plugins do not 
have the opportunity to receive the handlers passed to the application before they are applied to 
the app.
- Certain application attributes have pre-processing applied to them on assignment to self. 
Therefore, if a plugin wants to manage or modify these attributes, the plugins need to perform this
step of pre-processing, or at least understand it, before they can operate on these configuraion 
attributes. E.g., `as_async_callable_list()`.
- Difficult to be confident in longevity of implementations. Simple things like order of 
configuration/attribute changes, or changes to wrapper objects in later releases may impact the way 
plugins need to work to operate on certain configuration values.
- We run the risk of a plugin that abuses internal apis in `PluginProtocol.on_app_init()` becoming popular and making a rod for our backs in terms of internal refactoring.

## Proposed solution

- We construct a pydantic model of the arguments that the application object receives, called 
`AppConfig`. We already use the `validate_arguments()` decorator, that constructs a signature 
model to validate arguments passed to the app constructor, so this would just be replacing that 
validation with an explicit model.
- The arguments to the starlite constructor are used to instantiate this `AppConfig` object.
- After the configuration object has been instantiated with the parameters passed to `Starlite`, 
any handlers registered for `on_app_config` callback receive the `AppConfig` instance and must 
return it.
- Config callbacks are passed the `AppConfig` object in the order that they are passed to 
the `Starlite` constructor and must define their own behavior and recommendations for where the 
plugin should be inserted into the callback list.
- Benefit of this is that plugins can be built around the certainty of semantic versioning guarantees of 
the `Starlite` interface.

## Proposed implementation

The implementation is totally backward compatible.

Registered `on_app_config` hook handlers must receive and return an instance of `AppConfig`.

The `AppConfig` object is first instantiated from parameters passed to `Starlite.__init__()`, and then passed to each of the registered hook handlers.

The resultant `AppConfig` instance is used to instantiate the application.

Removes the use of `pydantic.validate_arguments()` on `Starlite.__init__()` as the instantiation of the `AppConfig` object does the same thing.

There is a test to ensure that the parameters of the `Starlite` constructor are matched by properties on `AppConfig`.

There is a test that ensures all properties on the `AppConfig` object are accessed within the `Starlite` constructor.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
