### PR TITLE
Fix for flaky test where rate limiter failed to fire when expected.

### DIFF
--- a/tests/middleware/test_rate_limit.py
+++ b/tests/middleware/test_rate_limit.py
@@ -100,7 +100,7 @@ def test_check_throttle_handler() -> None:
     def check_throttle_handler(request: Request[Any, Any]) -> bool:
         return request.url.path == "/path1"
 
-    config = RateLimitConfig(rate_limit=("second", 1), check_throttle_handler=check_throttle_handler)
+    config = RateLimitConfig(rate_limit=("minute", 1), check_throttle_handler=check_throttle_handler)
 
     with create_test_client(route_handlers=[handler1, handler2], middleware=[config.middleware]) as client:
         response = client.get("/path1")


### PR DESCRIPTION
Increases the limit duration so no chance of crossing the duration boundary mid-test.

Closes #500

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
