### PR TITLE
Cleanup logging config and fix default handlers

### DIFF
--- a/tests/logging_config/test_logging.py
+++ b/tests/logging_config/test_logging.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
 from starlite import Starlite
+from starlite.config.logging import default_handlers
 from starlite.logging import LoggingConfig
 from starlite.testing import TestClient, create_test_client
 
@@ -12,7 +13,7 @@ if TYPE_CHECKING:
 
 @patch("logging.config.dictConfig")
 def test_logging_debug(dict_config_mock: Mock) -> None:
-    config = LoggingConfig()
+    config = LoggingConfig(handlers=default_handlers)
     config.configure()
     assert dict_config_mock.mock_calls[0][1][0]["loggers"]["starlite"]["level"] == "INFO"
     dict_config_mock.reset_mock()
@@ -20,7 +21,7 @@ def test_logging_debug(dict_config_mock: Mock) -> None:
 
 @patch("logging.config.dictConfig")
 def test_logging_startup(dict_config_mock: Mock) -> None:
-    logger = LoggingConfig(loggers={"app": {"level": "INFO", "handlers": ["console"]}})
+    logger = LoggingConfig(handlers=default_handlers, loggers={"app": {"level": "INFO", "handlers": ["console"]}})
     with create_test_client([], on_startup=[logger.configure]):
         assert dict_config_mock.called
 
@@ -38,9 +39,9 @@ def test_queue_logger(caplog: "LogCaptureFixture") -> None:
 
 
 def test_logger_startup(caplog: "LogCaptureFixture") -> None:
-    with TestClient(app=Starlite(route_handlers=[], on_startup=[LoggingConfig().configure])) as client, caplog.at_level(
-        logging.INFO
-    ):
+    with TestClient(
+        app=Starlite(route_handlers=[], on_startup=[LoggingConfig(handlers=default_handlers).configure])
+    ) as client, caplog.at_level(logging.INFO):
         client.options("/")
         logger = logging.getLogger()
         handlers = logger.handlers

--- a/tests/logging_config/test_picologging.py
+++ b/tests/logging_config/test_picologging.py
@@ -1,35 +1,51 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict
 from unittest.mock import Mock, patch
 
 import picologging
+import pytest
 
 from starlite import Starlite
+from starlite.config.logging import default_handlers, default_picologging_handlers
 from starlite.logging import LoggingConfig
+from starlite.logging.picologging import QueueListenerHandler
 from starlite.testing import TestClient, create_test_client
 
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
 
 
-@patch("logging.config.dictConfig")
-def test_logging_debug(dict_config_mock: Mock) -> None:
-    log_config = LoggingConfig(
-        handlers={
-            "console": {
-                "class": "picologging.StreamHandler",
-                "level": "DEBUG",
-                "formatter": "standard",
-            },
-            "queue_listener": {
-                "class": "starlite.logging.picologging.QueueListenerHandler",
-                "handlers": ["cfg://handlers.console"],
-            },
-        }
-    )
-    log_config.configure()
-    assert dict_config_mock.mock_calls[0][1][0]["loggers"]["starlite"]["level"] == "INFO"
-    dict_config_mock.reset_mock()
+@pytest.mark.parametrize(
+    "dict_config_class, handlers, expected_called",
+    [
+        ["logging.config.dictConfig", default_handlers, True],
+        ["logging.config.dictConfig", default_picologging_handlers, False],
+        ["picologging.config.dictConfig", default_handlers, False],
+        ["picologging.config.dictConfig", default_picologging_handlers, True],
+    ],
+)
+def test_correct_dict_config_called(
+    dict_config_class: str, handlers: Dict[str, Dict[str, Any]], expected_called: bool
+) -> None:
+    with patch(dict_config_class) as dict_config_mock:
+        log_config = LoggingConfig(handlers=handlers)
+        log_config.configure()
+        if expected_called:
+            assert dict_config_mock.called
+        else:
+            assert not dict_config_mock.called
+
+
+@pytest.mark.parametrize("picologging_exists", [True, False])
+def test_correct_default_handlers_set(picologging_exists: bool) -> None:
+    with patch("starlite.config.logging.find_spec") as find_spec_mock:
+        find_spec_mock.return_value = picologging_exists
+        log_config = LoggingConfig()
+
+        if picologging_exists:
+            assert log_config.handlers == default_picologging_handlers
+        else:
+            assert log_config.handlers == default_handlers
 
 
 @patch("picologging.config.dictConfig")
@@ -50,26 +66,6 @@ def test_picologging_dictconfig_debug(dict_config_mock: Mock) -> None:
     log_config.configure()
     assert dict_config_mock.mock_calls[0][1][0]["loggers"]["starlite"]["level"] == "INFO"
     dict_config_mock.reset_mock()
-
-
-@patch("logging.config.dictConfig")
-def test_logging_startup(dict_config_mock: Mock) -> None:
-    test_logger = LoggingConfig(
-        handlers={
-            "console": {
-                "class": "picologging.StreamHandler",
-                "level": "DEBUG",
-                "formatter": "standard",
-            },
-            "queue_listener": {
-                "class": "starlite.logging.picologging.QueueListenerHandler",
-                "handlers": ["cfg://handlers.console"],
-            },
-        },
-        loggers={"app": {"level": "INFO", "handlers": ["console"]}},
-    )
-    with create_test_client([], on_startup=[test_logger.configure]):
-        assert dict_config_mock.called
 
 
 @patch("picologging.config.dictConfig")
@@ -94,66 +90,26 @@ def test_picologging_dictconfig_startup(dict_config_mock: Mock) -> None:
 
 @patch("picologging.config.dictConfig")
 def test_picologging_dictconfig_when_disabled(dict_config_mock: Mock) -> None:
-    test_logger = LoggingConfig(
-        loggers={"app": {"level": "INFO", "handlers": ["console"]}},
-    )
+    test_logger = LoggingConfig(loggers={"app": {"level": "INFO", "handlers": ["console"]}}, handlers=default_handlers)
     with create_test_client([], on_startup=[test_logger.configure]):
         assert not dict_config_mock.called
 
 
-logger = logging.getLogger()
-
-config = LoggingConfig(
-    handlers={
-        "console": {
-            "class": "picologging.StreamHandler",
-            "level": "DEBUG",
-            "formatter": "standard",
-        },
-        "queue_listener": {
-            "class": "starlite.logging.picologging.QueueListenerHandler",
-            "handlers": ["cfg://handlers.console"],
-        },
-    }
-)
-config.configure()
-picologger = picologging.getLogger()
-
-
 def test_queue_logger(caplog: "LogCaptureFixture") -> None:
-    """Test to check logging output contains the logged message."""
+    logger = logging.getLogger()
 
     with caplog.at_level(logging.INFO):
         logger.info("Testing now!")
         assert "Testing now!" in caplog.text
 
 
-def test_logger_startup(caplog: "LogCaptureFixture") -> None:
+def test_logger_startup() -> None:
     with TestClient(
         app=Starlite(
             route_handlers=[],
-            on_startup=[
-                LoggingConfig(
-                    handlers={
-                        "console": {
-                            "class": "picologging.StreamHandler",
-                            "level": "DEBUG",
-                            "formatter": "standard",
-                        },
-                        "queue_listener": {
-                            "class": "starlite.logging.picologging.QueueListenerHandler",
-                            "handlers": ["cfg://handlers.console"],
-                        },
-                    }
-                ).configure
-            ],
+            on_startup=[LoggingConfig(handlers=default_picologging_handlers).configure],
         )
-    ) as client, caplog.at_level(logging.INFO):
+    ) as client:
         client.options("/")
-        test_logger = logging.getLogger()
-        handlers = test_logger.handlers
-
-        test_picologging_logger = picologging.getLogger()
-        test_picologging_handlers = test_picologging_logger.handlers
-        assert isinstance(handlers[0].handlers[0], picologging.StreamHandler)  # type: ignore
-        assert isinstance(test_picologging_handlers[0].handlers[0], picologging.StreamHandler)
+        test_picologging_handlers = picologging.getLogger().handlers
+        assert isinstance(test_picologging_handlers[0], QueueListenerHandler)


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

This PR does some cleanup in the logging configs and improves the init of the handlers - so picologging is initialized properly on default. 