### PR TITLE
Improve `normalize_path` function speed

### DIFF
--- a/starlite/utils/url.py
+++ b/starlite/utils/url.py
@@ -12,9 +12,8 @@ def normalize_path(path: str) -> str:
     Returns:
         Path string
     """
-    path = path.rstrip("/")
-    if not path.startswith("/"):
-        path = "/" + path
+    path = path.strip("/")
+    path = "/" + path
     path = re.sub("//+", "/", path)
     return path
 

--- a/tests/utils/test_url.py
+++ b/tests/utils/test_url.py
@@ -7,6 +7,7 @@ from starlite.utils.url import join_paths, normalize_path
     "base,fragment, expected",
     [
         ("/path/", "sub", "/path/sub"),
+        ("/path/", "/sub/", "/path/sub"),
         ("path/", "sub", "/path/sub"),
         ("path", "sub", "/path/sub"),
         ("/path/", "sub/", "/path/sub"),


### PR DESCRIPTION
Hello there ! 

This is a small contribution, I was planning on working on #406, but when browsing the code I saw an opportunity to make a small improvement on a function (`normalize_path` )  that seems to be called often. 

Here's the script I used to compared the speed, I dumped the output each time and put it in the comment.
There's a ~7.5% improvement speed.


```python

import re


def normalize_path(path: str) -> str:
    """Normalizes a given path by ensuring it starts with a slash and does not
    end with a slash.

    Args:
        path: Path string

    Returns:
        Path string
    """
    path = path.rstrip("/")
    if not path.startswith("/"):
        path = "/" + path
    path = re.sub("//+", "/", path)
    return path


def new_normalize_path(path: str) -> str:
    """Normalizes a given path by ensuring it starts with a slash and does not
    end with a slash.

    Args:
        path: Path string

    Returns:
        Path string
    """
    path = path.strip("/")
    path = "/" + path
    path = re.sub("//+", "/", path)
    return path



if __name__ == '__main__':
    func_to_test = normalize_path
    # extracted from the test in test_url.py
    test_data = [
        ("/path/", "sub", "/path/sub"),
        ("/path/", "/sub/", "/path/sub"),
        ("path/", "sub", "/path/sub"),
        ("path", "sub", "/path/sub"),
        ("/path/", "sub/", "/path/sub"),
        ("path/", "sub/", "/path/sub"),
        ("path", "sub/", "/path/sub"),
        ("/", "/root/sub", "/root/sub"),
    ]

    for i in range(10000):
        for base, fragment, expected_output in test_data:
            assert func_to_test(expected_output) == expected_output

# ~ 7.5% improvement speed

# Old implementation

# (starlite-py3.8)  tevak@tevak  ~/dev/starlite   main ±  python -m cProfile -s cumtime rstrip_perf.py
#          560125 function calls (560121 primitive calls) in 0.157 seconds
#
#    Ordered by: cumulative time
#
#    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
#         1    0.000    0.000    0.157    0.157 {built-in method builtins.exec}
#         1    0.020    0.020    0.157    0.157 rstrip_perf.py:1(<module>)
#     80000    0.041    0.000    0.137    0.000 rstrip_perf.py:4(normalize_path)
#     80000    0.024    0.000    0.080    0.000 re.py:203(sub)
#     80000    0.022    0.000    0.034    0.000 re.py:289(_compile)
#     80000    0.022    0.000    0.022    0.000 {method 'sub' of 're.Pattern' objects}
#     80015    0.012    0.000    0.012    0.000 {built-in method builtins.isinstance}
#     80000    0.011    0.000    0.011    0.000 {method 'startswith' of 'str' objects}
#     80000    0.005    0.000    0.005    0.000 {method 'rstrip' of 'str' objects}
#         1    0.000    0.000    0.000    0.000 sre_compile.py:759(compile)
#         1    0.000    0.000    0.000    0.000 sre_parse.py:937(parse)
#         1    0.000    0.000    0.000    0.000 sre_compile.py:598(_code)
#         1    0.000    0.000    0.000    0.000 sre_parse.py:435(_parse_sub)
#         1    0.000    0.000    0.000    0.000 sre_parse.py:493(_parse)
#         1    0.000    0.000    0.000    0.000 sre_compile.py:536(_compile_info)
#       2/1    0.000    0.000    0.000    0.000 sre_compile.py:71(_compile)
#       2/1    0.000    0.000    0.000    0.000 sre_parse.py:174(getwidth)
#         9    0.000    0.000    0.000    0.000 sre_parse.py:164(__getitem__)
#         1    0.000    0.000    0.000    0.000 enum.py:938(__and__)
#         3    0.000    0.000    0.000    0.000 sre_parse.py:254(get)
#         4    0.000    0.000    0.000    0.000 sre_parse.py:233(__next)
#     20/18    0.000    0.000    0.000    0.000 {built-in method builtins.len}
#         2    0.000    0.000    0.000    0.000 enum.py:313(__call__)
#         2    0.000    0.000    0.000    0.000 sre_parse.py:286(tell)
#         1    0.000    0.000    0.000    0.000 sre_parse.py:224(__init__)
#         1    0.000    0.000    0.000    0.000 sre_compile.py:423(_simple)
#         2    0.000    0.000    0.000    0.000 sre_parse.py:172(append)
#         5    0.000    0.000    0.000    0.000 {built-in method builtins.min}
#         4    0.000    0.000    0.000    0.000 sre_parse.py:160(__len__)
#         1    0.000    0.000    0.000    0.000 sre_compile.py:461(_get_literal_prefix)
#        21    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
#         1    0.000    0.000    0.000    0.000 sre_compile.py:432(_generate_overlap_table)
#         2    0.000    0.000    0.000    0.000 sre_compile.py:595(isstring)
#         2    0.000    0.000    0.000    0.000 enum.py:631(__new__)
#         1    0.000    0.000    0.000    0.000 sre_parse.py:921(fix_flags)
#         2    0.000    0.000    0.000    0.000 sre_parse.py:111(__init__)
#         1    0.000    0.000    0.000    0.000 {built-in method _sre.compile}
#         2    0.000    0.000    0.000    0.000 sre_parse.py:81(groups)
#         1    0.000    0.000    0.000    0.000 sre_parse.py:76(__init__)
#         2    0.000    0.000    0.000    0.000 sre_parse.py:249(match)
#         2    0.000    0.000    0.000    0.000 {method 'extend' of 'list' objects}
#         1    0.000    0.000    0.000    0.000 sre_parse.py:168(__setitem__)
#         1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
#         2    0.000    0.000    0.000    0.000 {built-in method builtins.ord}
#         1    0.000    0.000    0.000    0.000 sre_compile.py:453(_get_iscased)
#         1    0.000    0.000    0.000    0.000 {method 'items' of 'dict' objects}


# New implementation :

# (starlite-py3.8)  tevak@tevak  ~/dev/starlite   main ±  python -m cProfile -s cumtime rstrip_perf.py
#          480125 function calls (480121 primitive calls) in 0.145 seconds
#
#    Ordered by: cumulative time
#
#    ncalls  tottime  percall  cumtime  percall filename:lineno(function)
#         1    0.000    0.000    0.145    0.145 {built-in method builtins.exec}
#         1    0.022    0.022    0.145    0.145 rstrip_perf.py:1(<module>)
#     80000    0.033    0.000    0.122    0.000 rstrip_perf.py:21(new_normalize_path)
#     80000    0.023    0.000    0.083    0.000 re.py:203(sub)
#     80000    0.027    0.000    0.038    0.000 re.py:289(_compile)
#     80000    0.022    0.000    0.022    0.000 {method 'sub' of 're.Pattern' objects}
#     80015    0.011    0.000    0.011    0.000 {built-in method builtins.isinstance}
#     80000    0.006    0.000    0.006    0.000 {method 'strip' of 'str' objects}
#         1    0.000    0.000    0.000    0.000 sre_compile.py:759(compile)
#         1    0.000    0.000    0.000    0.000 sre_parse.py:937(parse)
#         1    0.000    0.000    0.000    0.000 sre_parse.py:435(_parse_sub)
#         1    0.000    0.000    0.000    0.000 sre_compile.py:598(_code)
#         1    0.000    0.000    0.000    0.000 sre_parse.py:493(_parse)
#         1    0.000    0.000    0.000    0.000 sre_compile.py:536(_compile_info)
#       2/1    0.000    0.000    0.000    0.000 sre_compile.py:71(_compile)
#       2/1    0.000    0.000    0.000    0.000 sre_parse.py:174(getwidth)
#         9    0.000    0.000    0.000    0.000 sre_parse.py:164(__getitem__)
#         1    0.000    0.000    0.000    0.000 enum.py:938(__and__)
#         3    0.000    0.000    0.000    0.000 sre_parse.py:254(get)
#         4    0.000    0.000    0.000    0.000 sre_parse.py:233(__next)
#     20/18    0.000    0.000    0.000    0.000 {built-in method builtins.len}
#         2    0.000    0.000    0.000    0.000 enum.py:313(__call__)
#         1    0.000    0.000    0.000    0.000 sre_parse.py:224(__init__)
#         2    0.000    0.000    0.000    0.000 sre_parse.py:286(tell)
#         2    0.000    0.000    0.000    0.000 sre_parse.py:172(append)
#         1    0.000    0.000    0.000    0.000 sre_compile.py:423(_simple)
#         1    0.000    0.000    0.000    0.000 sre_compile.py:461(_get_literal_prefix)
#        21    0.000    0.000    0.000    0.000 {method 'append' of 'list' objects}
#         5    0.000    0.000    0.000    0.000 {built-in method builtins.min}
#         1    0.000    0.000    0.000    0.000 sre_compile.py:432(_generate_overlap_table)
#         4    0.000    0.000    0.000    0.000 sre_parse.py:160(__len__)
#         2    0.000    0.000    0.000    0.000 sre_compile.py:595(isstring)
#         2    0.000    0.000    0.000    0.000 enum.py:631(__new__)
#         2    0.000    0.000    0.000    0.000 sre_parse.py:111(__init__)
#         1    0.000    0.000    0.000    0.000 sre_parse.py:921(fix_flags)
#         2    0.000    0.000    0.000    0.000 sre_parse.py:81(groups)
#         1    0.000    0.000    0.000    0.000 {built-in method _sre.compile}
#         1    0.000    0.000    0.000    0.000 sre_parse.py:76(__init__)
#         2    0.000    0.000    0.000    0.000 sre_parse.py:249(match)
#         2    0.000    0.000    0.000    0.000 {method 'extend' of 'list' objects}
#         1    0.000    0.000    0.000    0.000 sre_compile.py:453(_get_iscased)
#         2    0.000    0.000    0.000    0.000 {built-in method builtins.ord}
#         1    0.000    0.000    0.000    0.000 {method 'disable' of '_lsprof.Profiler' objects}
#         1    0.000    0.000    0.000    0.000 sre_parse.py:168(__setitem__)
#         1    0.000    0.000    0.000    0.000 {method 'items' of 'dict' objects}


```


# PR Checklist

- [ X ] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ X ] Have you got 100% test coverage on new code?
- [ X] Have you updated the prose documentation?
- [ X ] Have you updated the reference documentation?
