### PR TITLE
Proper clean up in Tortoise ORM plugin example

### DIFF
--- a/docs/usage/10-plugins/2-tortoise-orm-plugin.md
+++ b/docs/usage/10-plugins/2-tortoise-orm-plugin.md
@@ -6,6 +6,7 @@ To use the `starlite.plugins.tortoise_orm.TortoiseORMPlugin` import it and pass 
 from typing import cast
 
 from tortoise import Model, Tortoise, fields
+from tortoise.connection import connections
 
 from starlite import Starlite, get, post
 from starlite.plugins.tortoise_orm import TortoiseORMPlugin
@@ -67,6 +68,10 @@ async def init_tortoise() -> None:
     await Tortoise.generate_schemas()
 
 
+async def shutdown_tortoise() -> None:
+    await connections.close_all()
+
+
 @get("/tournaments")
 async def get_tournaments() -> list[Tournament]:
     tournaments = await Tournament.all()
@@ -90,6 +95,7 @@ async def create_tournament(data: Tournament) -> Tournament:
 app = Starlite(
     route_handlers=[get_tournament, get_tournaments, create_tournament],
     on_startup=[init_tortoise],
+    on_shutdown=[shutdown_tortoise],
     plugins=[TortoiseORMPlugin()],
 )
 ```


### PR DESCRIPTION
At the moment example on Tortoise ORM plugin doesn't work properly as it doesn't close db connections on app shutdown.

Tortoise ORM states that it is [very important to do clean up](https://tortoise.github.io/setup.html?h=close_connections#the-importance-of-cleaning-up) or otherwise there will be problems with program termination. Indeed, when you try to run the example under uvicorn it will hang on Ctrl-C (see screenshot) forcing user to kill the program.

![image](https://user-images.githubusercontent.com/153191/192901599-c86959e8-2576-440e-a7bb-91e79d448f6b.png)

You can check yourself with the following piece (I simply added `uvicorn.run` to the example code) with python test.py

<details>
  <summary>test.py</summary>

  ```
  import uvicorn

from typing import cast

from tortoise import Model, Tortoise, fields
from tortoise.connection import connections

from starlite import Starlite, get, post
from starlite.plugins.tortoise_orm import TortoiseORMPlugin


class Tournament(Model):
    id = fields.IntField(pk=True)
    name = fields.TextField()
    created_at = fields.DatetimeField(auto_now_add=True)
    optional = fields.TextField(null=True)
    events: fields.ReverseRelation["Event"]

    class Meta:
        ordering = ["name"]


class Event(Model):
    id = fields.IntField(pk=True)
    name = fields.TextField()
    created_at = fields.DatetimeField(auto_now_add=True)
    tournament: fields.ForeignKeyNullableRelation[Tournament] = fields.ForeignKeyField(
        "models.Tournament", related_name="events", null=True
    )
    participants: fields.ManyToManyRelation["Team"] = fields.ManyToManyField(
        "models.Team", related_name="events", through="event_team"
    )
    address: fields.OneToOneNullableRelation["Address"]

    class Meta:
        ordering = ["name"]


class Address(Model):
    city = fields.CharField(max_length=64)
    street = fields.CharField(max_length=128)
    created_at = fields.DatetimeField(auto_now_add=True)

    event: fields.OneToOneRelation[Event] = fields.OneToOneField(
        "models.Event", related_name="address", pk=True
    )

    class Meta:
        ordering = ["city"]


class Team(Model):
    id = fields.IntField(pk=True)
    name = fields.TextField()
    created_at = fields.DatetimeField(auto_now_add=True)

    events: fields.ManyToManyRelation[Event]

    class Meta:
        ordering = ["name"]


async def init_tortoise() -> None:
    await Tortoise.init(db_url="sqlite://:memory:", modules={"models": [__name__]})
    await Tortoise.generate_schemas()


async def shutdown_tortoise() -> None:
    await connections.close_all()


@get("/tournaments")
async def get_tournaments() -> list[Tournament]:
    tournaments = await Tournament.all()
    return cast("list[Tournament]", tournaments)


@get("/tournaments/{tournament_id:int}")
async def get_tournament(tournament_id: int) -> Tournament:
    tournament = await Tournament.filter(id=tournament_id).first()
    return cast("Tournament", tournament)


@post("/tournaments")
async def create_tournament(data: Tournament) -> Tournament:
    assert isinstance(data, Tournament)
    await data.save()
    await data.refresh_from_db()
    return data


app = Starlite(
    route_handlers=[get_tournament, get_tournaments, create_tournament],
    on_startup=[init_tortoise],
    plugins=[TortoiseORMPlugin()],
)

if __name__ == "__main__":
    uvicorn.run(app, host="0.0.0.0", port=8000)

  ```
</details>

<details>
  <summary>Dependencies</summary>

  ```
  aiosqlite==0.17.0
  starlite[picologging]==1.20.0
  tortoise-orm==0.19.2
  uvicorn[standard]==0.18.3
  ```
</details>
  
Also while linked Tortoise ORM docs offers to use `Tortoise.close_connections` it seems that this method has been deprecated in `0.19.0` and `connections.close_all` should be used instead.

https://tortoise.github.io/setup.html#tortoise.Tortoise.close_connections

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
