### PR TITLE
Pin starlette to `>=0.21` and httpx to `>=0.22`.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -615,7 +615,7 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydantic-factories"
-version = "1.6.2"
+version = "1.7.0"
 description = "Mock data generation for pydantic based models"
 category = "main"
 optional = false
@@ -1038,7 +1038,7 @@ testing = ["httpx"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "9fd9045648d30d4378530b4d505435fc53e958340bd26e1763a4c270b325a6b5"
+content-hash = "ff2469d3ff30e9cf5acdcdf8bbc2006684ad94b10f37c4a15b15d416511fdcc0"
 
 [metadata.files]
 aiosqlite = [
@@ -1644,8 +1644,8 @@ pydantic = [
     {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 pydantic-factories = [
-    {file = "pydantic-factories-1.6.2.tar.gz", hash = "sha256:f63f8b94928ca65f71871400e3a46b5fd0f64667cfeb9a7dca0e8706079fde52"},
-    {file = "pydantic_factories-1.6.2-py3-none-any.whl", hash = "sha256:c7d5ef83eadb0f1a02090b2b381599b71d6830296a9d631f31bf95d0cbfc00d7"},
+    {file = "pydantic-factories-1.7.0.tar.gz", hash = "sha256:f837093f317902bb8cd6804ca52675fc4e56f136c6b30ff64c15625d1b399e9e"},
+    {file = "pydantic_factories-1.7.0-py3-none-any.whl", hash = "sha256:1aecb46039c0d27f97f59c2b44e5ac176c9b54e4eb872aaf3a1b451792859bf7"},
 ]
 pydantic-openapi-schema = [
     {file = "pydantic-openapi-schema-1.3.0.tar.gz", hash = "sha256:2aed6913080f1dae94234e00d0905504c6aab65ab6afe246ed7aa98da989f69e"},
@@ -1687,6 +1687,13 @@ PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,14 +36,14 @@ packages = [
 python = ">=3.7,<4.0"
 brotli = { version = "*", optional = true }
 cryptography = { version = "*", optional = true }
-httpx = { version = "*", optional = true }
+httpx = { version = ">=0.22", optional = true }
 orjson = "*"
 picologging = { version = "*", optional = true }
 pydantic = "*"
 pydantic-factories = "*"
 pydantic-openapi-schema = "*"
 pyyaml = "*"
-starlette = "*"
+starlette = ">=0.21"
 starlite-multipart = "*"
 typing-extensions = "*"
 
@@ -51,7 +51,7 @@ typing-extensions = "*"
 brotli = "*"
 cryptography = "*"
 freezegun = "*"
-httpx = "*"
+httpx = ">=0.22"
 hypothesis = "*"
 jinja2 = "*"
 mako = "*"


### PR DESCRIPTION
Starlette 0.21 requires httpx 0.22+, and we depend on both.

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
