### PR TITLE
Small typo fix

### DIFF
--- a/docs/usage/8-authentication/1-abstract-authentication-middleware.md
+++ b/docs/usage/8-authentication/1-abstract-authentication-middleware.md
@@ -162,7 +162,7 @@ from starlite.middleware.base import DefineMiddleware
 from my_app.security.authentication_middleware import JWTAuthenticationMiddleware
 # you can optionally exclude certain paths from authentication.
 # the following excludes all routes mounted at or under `/schema*`
-auth_mw = DefineMiddleware(JWTAuthenticationMiddleware, excluded="schema")
+auth_mw = DefineMiddleware(JWTAuthenticationMiddleware, exclude="schema")
 
 app = Starlite(request_handlers=[...], middleware=[auth_mw])
 ```
@@ -215,7 +215,7 @@ from my_app.security.authentication_middleware import JWTAuthenticationMiddlewar
 # the following excludes all routes mounted at or under `/schema*`
 # additionally,
 # you can modify the default exclude key of "exclude_from_auth", by overriding the `exclude_from_auth_key` parameter on the Authentication Middleware
-auth_mw = DefineMiddleware(JWTAuthenticationMiddleware, excluded="schema")
+auth_mw = DefineMiddleware(JWTAuthenticationMiddleware, exclude="schema")
 
 
 @get(path="/", exclude_from_auth=True)


### PR DESCRIPTION
In [the docs](https://starlite-api.github.io/starlite/usage/8-authentication/1-abstract-authentication-middleware/#starlite.middleware.session.SessionCookieConfig.secure), there is a typo for the keyword arguments passed into `AbstractAuthenticationMiddleware`. This PR corrects the typo.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
