### PR TITLE
Updates SQLAlchemy plugin type detection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     </tr>
   </tbody>
   <tfoot>
-    
+
   </tfoot>
 </table>
 


### PR DESCRIPTION
Makes detection of declarative model types and instances compatible with 1.x and 2.0.

Closes #548

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
