### PR TITLE
Add support for using custom `Request` and `WebSocket` classes.

### DIFF
--- a/docs/reference/config/0-app-config.md
+++ b/docs/reference/config/0-app-config.md
@@ -27,6 +27,7 @@
             - openapi_config
             - parameters
             - plugins
+            - request_class
             - response_class
             - response_cookies
             - response_headers
@@ -35,3 +36,4 @@
             - static_files_config
             - tags
             - template_config
+            - websocket_class

--- a/docs/reference/connection/0-asgi-connection.md
+++ b/docs/reference/connection/0-asgi-connection.md
@@ -13,6 +13,7 @@
             - app
             - auth
             - base_url
+            - cache
             - clear_session
             - client
             - cookies
@@ -20,7 +21,10 @@
             - logger
             - path_params
             - query_params
+            - receive
             - route_handler
+            - scope
+            - send
             - session
             - set_session
             - state

--- a/docs/reference/connection/1-request.md
+++ b/docs/reference/connection/1-request.md
@@ -8,6 +8,7 @@
             - auth
             - base_url
             - body
+            - cache
             - clear_session
             - client
             - content_type
@@ -19,7 +20,10 @@
             - method
             - path_params
             - query_params
+            - receive
             - route_handler
+            - scope
+            - send
             - send_push_promise
             - session
             - set_session

--- a/docs/reference/connection/2-websocket.md
+++ b/docs/reference/connection/2-websocket.md
@@ -8,6 +8,7 @@
             - app
             - auth
             - base_url
+            - cache
             - clear_session
             - client
             - close
@@ -16,11 +17,14 @@
             - logger
             - path_params
             - query_params
+            - receive
             - receive_bytes
             - receive_data
             - receive_json
             - receive_text
             - route_handler
+            - scope
+            - send
             - send_bytes
             - send_data
             - send_json

--- a/starlite/config/app.py
+++ b/starlite/config/app.py
@@ -1,8 +1,9 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Type
 
 from pydantic import BaseConfig, BaseModel
 from pydantic_openapi_schema.v3_1_0 import SecurityRequirement
 
+from starlite.connection import Request, WebSocket
 from starlite.datastructures.provide import Provide
 from starlite.plugins.base import PluginProtocol
 from starlite.types import (
@@ -158,6 +159,10 @@ class AppConfig(BaseModel):
     """
     List of [PluginProtocol][starlite.plugins.base.PluginProtocol].
     """
+    request_class: Optional[Type[Request]]
+    """
+    An optional subclass of [Request][starlite.connection.request.Request] to use for http connections.
+    """
     response_class: Optional[ResponseType]
     """
     A custom subclass of [starlite.response.Response] to be used as the app's default response.
@@ -191,4 +196,8 @@ class AppConfig(BaseModel):
     template_config: Optional[TemplateConfig]
     """
     An instance of [TemplateConfig][starlite.config.TemplateConfig].
+    """
+    websocket_class: Optional[Type[WebSocket]]
+    """
+    An optional subclass of [WebSocket][starlite.connection.websocket.WebSocket] to use for websocket connections.
     """

--- a/starlite/connection/base.py
+++ b/starlite/connection/base.py
@@ -57,6 +57,19 @@ async def empty_send(_: "Message") -> None:  # pragma: no cover
 class ASGIConnection(Generic[Handler, User, Auth]):
     __slots__ = ("scope", "receive", "send", "_base_url", "_url", "_parsed_query", "_headers", "_cookies")
 
+    scope: "Scope"
+    """
+    The ASGI scope attached to the connection.
+    """
+    receive: "Receive"
+    """
+    The ASGI receive function.
+    """
+    send: "Send"
+    """
+    The ASGI send function.
+    """
+
     def __init__(self, scope: "Scope", receive: "Receive" = empty_receive, send: "Send" = empty_send) -> None:
         """The base ASGI connection container.
 

--- a/starlite/connection/base.py
+++ b/starlite/connection/base.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
     from starlite.app import Starlite
+    from starlite.cache import Cache
     from starlite.types.asgi_types import Message, Receive, Scope, Send
     from starlite.types.protocols import Logger
 
@@ -236,6 +237,15 @@ class ASGIConnection(Generic[Handler, User, Auth]):
             ImproperlyConfiguredException: if 'log_config' has not been passed to the Starlite constructor.
         """
         return self.app.get_logger()
+
+    @property
+    def cache(self) -> "Cache":
+        """
+
+        Returns:
+            A 'Cache' instance.
+        """
+        return self.app.cache
 
     def set_session(self, value: Union[Dict[str, Any], "BaseModel"]) -> None:
         """Helper method to set the session in scope.

--- a/starlite/connection/request.py
+++ b/starlite/connection/request.py
@@ -31,6 +31,17 @@ class Request(Generic[User, Auth], ASGIConnection["HTTPRouteHandler", User, Auth
     __slots__ = ("_json", "_form", "_body", "_content_type", "is_connected")
 
     scope: "HTTPScope"
+    """
+    The ASGI scope attached to the connection.
+    """
+    receive: "Receive"
+    """
+    The ASGI receive function.
+    """
+    send: "Send"
+    """
+    The ASGI send function.
+    """
 
     def __init__(self, scope: "Scope", receive: "Receive" = empty_receive, send: "Send" = empty_send) -> None:
         """The Starlite Request class.

--- a/starlite/connection/websocket.py
+++ b/starlite/connection/websocket.py
@@ -53,6 +53,17 @@ class WebSocket(
     __slots__ = ("connection_state",)
 
     scope: "WebSocketScope"
+    """
+    The ASGI scope attached to the connection.
+    """
+    receive: "Receive"
+    """
+    The ASGI receive function.
+    """
+    send: "Send"
+    """
+    The ASGI send function.
+    """
 
     def __init__(self, scope: "Scope", receive: "Receive" = empty_receive, send: "Send" = empty_send) -> None:
         """The Starlite WebSocket class.

--- a/starlite/middleware/csrf.py
+++ b/starlite/middleware/csrf.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from starlette.datastructures import MutableHeaders
 
-from starlite.connection import Request
 from starlite.datastructures.cookie import Cookie
 from starlite.enums import ScopeType
 from starlite.exceptions import PermissionDeniedException
@@ -13,6 +12,7 @@ from starlite.middleware.base import MiddlewareProtocol
 
 if TYPE_CHECKING:
     from starlite.config import CSRFConfig
+    from starlite.connection import Request
     from starlite.types import ASGIApp, HTTPSendMessage, Message, Receive, Scope, Send
 
 CSRF_SECRET_BYTES = 32
@@ -50,7 +50,7 @@ class CSRFMiddleware(MiddlewareProtocol):
             await self.app(scope, receive, send)
             return
 
-        request = Request[Any, Any](scope=scope)
+        request: "Request[Any, Any]" = scope["app"].request_class(scope=scope)
         csrf_cookie = request.cookies.get(self.config.cookie_name)
         existing_csrf_token = request.headers.get(self.config.header_name)
 

--- a/starlite/middleware/logging.py
+++ b/starlite/middleware/logging.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Type
 from orjson import OPT_OMIT_MICROSECONDS, OPT_SERIALIZE_NUMPY, dumps
 from pydantic import BaseModel
 
-from starlite.connection import Request
 from starlite.enums import ScopeType
 from starlite.middleware.base import DefineMiddleware, MiddlewareProtocol
 from starlite.utils import default_serializer, get_serializer_from_scope
@@ -17,6 +16,7 @@ from starlite.utils.extractors import (
 )
 
 if TYPE_CHECKING:
+    from starlite.connection import Request
     from starlite.types import ASGIApp, Logger, Message, Receive, Scope, Send
 
 try:
@@ -103,7 +103,7 @@ class LoggingMiddleware(MiddlewareProtocol):
             None
 
         """
-        extracted_data = await self.extract_request_data(request=Request[Any, Any](scope))
+        extracted_data = await self.extract_request_data(request=scope["app"].request_class(scope))
         self.log_message(values=extracted_data)
 
     def log_response(self, scope: "Scope") -> None:

--- a/starlite/middleware/rate_limit.py
+++ b/starlite/middleware/rate_limit.py
@@ -89,7 +89,7 @@ class RateLimitMiddleware:
             if not hasattr(self, "cache"):
                 self.cache = scope["app"].cache
 
-            request = Request[Any, Any](scope)
+            request: "Request[Any, Any]" = scope["app"].request_class(scope)
             if await self.should_check_request(request=request):
                 key = self.cache_key_from_request(request=request)
                 cache_object = await self.retrieve_cached_history(key)

--- a/starlite/routes/http.py
+++ b/starlite/routes/http.py
@@ -63,7 +63,7 @@ class HTTPRoute(BaseRoute):
         Returns:
             None
         """
-        request = Request[Any, Any](scope=scope, receive=receive, send=send)
+        request: "Request[Any, Any]" = scope["app"].request_class(scope=scope, receive=receive, send=send)
         route_handler, parameter_model = self.route_handler_map[scope["method"]]
 
         if route_handler.resolve_guards():

--- a/starlite/routes/websocket.py
+++ b/starlite/routes/websocket.py
@@ -2,13 +2,13 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, cast
 
 from starlette.routing import get_name
 
-from starlite.connection import WebSocket
 from starlite.controller import Controller
 from starlite.enums import ScopeType
 from starlite.routes.base import BaseRoute
 from starlite.signature import get_signature_model
 
 if TYPE_CHECKING:
+    from starlite.connection import WebSocket
     from starlite.handlers.websocket import WebsocketRouteHandler
     from starlite.kwargs import KwargsModel
     from starlite.types import (
@@ -58,7 +58,7 @@ class WebSocketRoute(BaseRoute):
         Returns:
             None
         """
-        websocket = WebSocket[Any, Any](scope=scope, receive=receive, send=send)
+        websocket: "WebSocket[Any, Any]" = scope["app"].websocket_class(scope=scope, receive=receive, send=send)
         if self.route_handler.resolve_guards():
             await self.route_handler.authorize_connection(connection=websocket)
 
@@ -70,7 +70,7 @@ class WebSocketRoute(BaseRoute):
         else:
             await fn(**kwargs)
 
-    async def _resolve_kwargs(self, websocket: WebSocket[Any, Any]) -> Dict[str, Any]:
+    async def _resolve_kwargs(self, websocket: "WebSocket[Any, Any]") -> Dict[str, Any]:
         """Resolves the required kwargs from the request data.
 
         Args:

--- a/starlite/testing/test_client.py
+++ b/starlite/testing/test_client.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union, cast
 
 from starlette.testclient import TestClient as StarletteTestClient
 
@@ -9,6 +9,7 @@ from starlite.middleware.session import SessionMiddleware
 if TYPE_CHECKING:
     from typing_extensions import Literal
 
+    from starlite import Request, WebSocket
     from starlite.config import (
         BaseLoggingConfig,
         CacheConfig,
@@ -175,11 +176,13 @@ def create_test_client(
     parameters: Optional["ParametersMap"] = None,
     plugins: Optional[List["PluginProtocol"]] = None,
     raise_server_exceptions: bool = True,
+    request_class: Optional[Type["Request"]] = None,
     response_class: Optional["ResponseType"] = None,
     root_path: str = "",
     session_config: Optional["SessionCookieConfig"] = None,
     static_files_config: Optional[Union["StaticFilesConfig", List["StaticFilesConfig"]]] = None,
     template_config: Optional["TemplateConfig"] = None,
+    websocket_class: Optional[Type["WebSocket"]] = None,
 ) -> TestClient:
     """Creates a Starlite app instance and initializes it.
 
@@ -255,6 +258,8 @@ def create_test_client(
         parameters: A mapping of [Parameter][starlite.params.Parameter] definitions available to all
             application paths.
         plugins: List of plugins.
+        request_class: An optional subclass of [Request][starlite.connection.request.Request] to use for
+            http connections.
         raise_server_exceptions: Flag for underlying Starlette test client to raise server exceptions instead of
             wrapping them in an HTTP response.
         response_class: A custom subclass of [starlite.response.Response] to be used as the app's default response.
@@ -263,6 +268,8 @@ def create_test_client(
         session_config: Configuration for Session Middleware class to create raw session cookies for request to the
             route handlers.
         template_config: An instance of [TemplateConfig][starlite.config.TemplateConfig]
+        websocket_class: An optional subclass of [WebSocket][starlite.connection.websocket.WebSocket] to use for
+            websocket connections.
 
     Returns:
         An instance of [TestClient][starlite.testing.TestClient] with a created app instance.
@@ -293,10 +300,12 @@ def create_test_client(
             openapi_config=openapi_config,
             parameters=parameters,
             plugins=plugins,
+            request_class=request_class,
             response_class=response_class,
             route_handlers=cast("Any", route_handlers if isinstance(route_handlers, list) else [route_handlers]),
             static_files_config=static_files_config,
             template_config=template_config,
+            websocket_class=websocket_class,
         ),
         backend=backend,
         backend_options=backend_options,

--- a/tests/app/test_app_config.py
+++ b/tests/app/test_app_config.py
@@ -45,6 +45,8 @@ def app_config_object() -> AppConfig:
         static_files_config=[],
         tags=[],
         template_config=None,
+        request_class=None,
+        websocket_class=None,
     )
 
 

--- a/tests/connection/request/test_request.py
+++ b/tests/connection/request/test_request.py
@@ -61,3 +61,20 @@ def test_route_handler_property() -> None:
     with create_test_client(route_handlers=[handler]) as client:
         client.get("/")
         assert value["handler"] is handler
+
+
+def test_custom_request_class() -> None:
+    value: Any = {}
+
+    class MyRequest(Request):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            self.scope["called"] = True  # type: ignore
+
+    @get("/")
+    def handler(request: MyRequest) -> None:
+        value["called"] = request.scope.get("called")
+
+    with create_test_client(route_handlers=[handler], request_class=MyRequest) as client:
+        client.get("/")
+        assert value["called"]

--- a/tests/connection/test_base_properties.py
+++ b/tests/connection/test_base_properties.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+from starlite import ASGIConnection, LoggingConfig, Starlite, get
+from starlite.testing import RequestFactory
+
+
+def test_connection_base_properties() -> None:
+    @get("/")
+    def handler() -> None:
+        return None
+
+    app = Starlite(route_handlers=[handler], logging_config=LoggingConfig())
+    user = {"name": "moishe"}
+    auth = {"key": "value"}
+    session = {"session": "abc"}
+    scope = RequestFactory(app=app).get("/", route_handler=handler, user=user, auth=auth, session=session).scope
+    connection = ASGIConnection[Any, Any, Any](scope)
+
+    assert connection.app
+    assert connection.app is app
+    assert connection.route_handler is handler
+    assert connection.state is not None
+    assert not scope.get("_url")
+    assert connection.url
+    assert scope.get("_url")
+    assert not scope.get("_base_url")
+    assert connection.base_url
+    assert scope.get("_base_url")
+    assert not scope.get("_headers")
+    assert connection.headers is not None
+    assert scope.get("_headers") is not None
+    assert not scope.get("_parsed_query")
+    assert connection.query_params is not None
+    assert scope.get("_parsed_query") is not None
+    assert not scope.get("_cookies")
+    assert connection.cookies is not None
+    assert scope.get("_cookies") is not None
+    assert connection.client
+    assert connection.user is user
+    assert connection.auth is auth
+    assert connection.session is session
+    assert connection.cache is app.cache


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

This PR adds support for using custom subclasses of `Request` and `WebSocket` in the application by passing these to the Starlite constructor. It forms a solid basis for extension further via plugins. For example, consider an `SQLAlchemyRequest` class that has properties to access the session etc.

 
