### PR TITLE
Makes SQLAlchemyConfig.connection_string optional.

### DIFF
--- a/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_config.py
+++ b/tests/plugins/sql_alchemy_plugin/test_sql_alchemy_config.py
@@ -1,6 +1,8 @@
 from typing import Any, Optional
 
 import pytest
+from pydantic import ValidationError
+from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 from starlette.status import HTTP_200_OK
@@ -99,3 +101,18 @@ def test_logging_config(engine_logger: Optional[str], pool_logger: Optional[str]
 
 def test_default_serializer_returns_string() -> None:
     assert serializer({"hello": "world"}) == '{"hello":"world"}'
+
+
+def test_config_connection_string_or_engine_instance_validation() -> None:
+    with pytest.raises(ValidationError):
+        SQLAlchemyConfig(connection_string=None, engine_instance=None)
+
+    connection_string = "sqlite:///"
+    engine = create_engine(connection_string)
+
+    with pytest.raises(ValidationError):
+        SQLAlchemyConfig(connection_string=connection_string, engine_instance=engine)
+
+    # these should be OK
+    SQLAlchemyConfig(engine_instance=engine)
+    SQLAlchemyConfig(connection_string=connection_string)

--- a/tests/plugins/sql_alchemy_plugin/test_sqlalchemy_plugin.py
+++ b/tests/plugins/sql_alchemy_plugin/test_sqlalchemy_plugin.py
@@ -1,0 +1,67 @@
+from typing import Any
+
+import pytest
+from sqlalchemy import Column, Integer
+from sqlalchemy.orm import Mapper, as_declarative, declarative_base
+
+from starlite.exceptions import ImproperlyConfiguredException
+from starlite.plugins.sql_alchemy import SQLAlchemyPlugin
+
+DeclBase = declarative_base()
+
+
+@as_declarative()
+class AsDeclBase:
+    ...
+
+
+class FromAsDeclarative(AsDeclBase):
+    __tablename__ = "whatever"
+    id = Column(Integer, primary_key=True)
+
+
+class FromDeclBase(DeclBase):  # type:ignore[misc,valid-type]
+    __tablename__ = "whatever"
+    id = Column(Integer, primary_key=True)
+
+
+class Plain:
+    ...
+
+
+@pytest.mark.parametrize(
+    "item,result",
+    [
+        (FromAsDeclarative, True),
+        (FromAsDeclarative(), True),
+        (FromDeclBase, True),
+        (FromDeclBase(), True),
+        (Plain, False),
+        (Plain(), False),
+        (None, False),
+        ("str", False),
+    ],
+)
+def test_is_plugin_supported_type(item: Any, result: bool) -> None:
+    assert SQLAlchemyPlugin.is_plugin_supported_type(item) is result
+
+
+@pytest.mark.parametrize(
+    "item,should_raise",
+    [
+        (FromAsDeclarative, False),
+        (FromAsDeclarative(), True),
+        (FromDeclBase, False),
+        (FromDeclBase(), True),
+        (Plain, True),
+        (Plain(), True),
+        (None, True),
+        ("str", True),
+    ],
+)
+def test_parse_model(item: Any, should_raise: bool) -> None:
+    if should_raise:
+        with pytest.raises(ImproperlyConfiguredException):
+            SQLAlchemyPlugin.parse_model(item)
+    else:
+        assert isinstance(SQLAlchemyPlugin.parse_model(item), Mapper)

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -202,6 +202,6 @@ def test_test_client(enable_session: bool, session_data: Dict[str, str]) -> None
     app = Starlite(route_handlers=[test_handler], on_startup=[start_up_handler], middleware=[session_config.middleware])
 
     with TestClient(app=app, session_config=session_config if enable_session else None) as client:
-        cookies = client.create_session_cookies(session_data=session_data)
-        client.get("/test", cookies=cookies)
+        client.cookies = client.create_session_cookies(session_data=session_data)
+        client.get("/test")
         assert app.state.value == 1


### PR DESCRIPTION
One of either `connection_string` or `engine_instance` must be set.

Adds some tests for #549.

Closes #555

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
