### PR TITLE
Clear Session Should Assign Empty Dict

### DIFF
--- a/starlite/connection/base.py
+++ b/starlite/connection/base.py
@@ -283,7 +283,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
         Returns:
             None.
         """
-        self.scope["session"] = Empty
+        self.scope["session"] = {}
 
     def url_for(self, name: str, **path_parameters: Dict[str, Any]) -> Optional[str]:
         """

--- a/starlite/middleware/session.py
+++ b/starlite/middleware/session.py
@@ -22,7 +22,6 @@ from starlite.connection import ASGIConnection
 from starlite.datastructures.cookie import Cookie
 from starlite.exceptions import MissingDependencyException
 from starlite.middleware.base import DefineMiddleware, MiddlewareProtocol
-from starlite.types import Empty
 from starlite.utils import get_serializer_from_scope
 from starlite.utils.serialization import default_serializer
 
@@ -215,8 +214,7 @@ class SessionMiddleware(MiddlewareProtocol):
             headers = MutableHeaders(scope=message)
             scope_session = scope.get("session")
 
-            should_clear_session = scope_session is Empty
-            if not should_clear_session:
+            if scope_session:
                 data = self.dump_data(scope_session, scope=scope)
                 cookie_params = self.config.dict(exclude_none=True, exclude={"secret", "key"})
                 for i, datum in enumerate(data, start=0):


### PR DESCRIPTION
If in case a user wants to add new keys to session after clearing it, its default value should be an empty dictionary.