### PR TITLE
Adds `TestClient.update_session_cookies()`

### DIFF
--- a/docs/reference/testing/0-test-client.md
+++ b/docs/reference/testing/0-test-client.md
@@ -6,6 +6,7 @@
             - __init__
             - __enter__
             - create_session_cookies
+            - update_session_cookies
 
 ::: starlite.testing.create_test_client
     options:

--- a/docs/usage/14-testing.md
+++ b/docs/usage/14-testing.md
@@ -75,10 +75,10 @@ def test_health_check(test_client: TestClient):
 
 If you are using **Session Middleware** for session persistence across requests then your route handlers may expect
 preloaded session when you are mocking request to the route handler. To mock request with session cookies, you can use
-`TestClient.create_session_cookies` to mock session. The session middleware will then load session from the session
+`TestClient.update_session_cookies` to mock session. The session middleware will then load session from the session
 cookies that you provide.
 
-`TestClient.create_session_cookies` accepts the following arguments:
+`TestClient.update_session_cookies` accepts the following arguments:
 
 - session_data: You can pass dictionary to this argument to preload the session.
 
@@ -105,9 +105,9 @@ class TestClass:
 
     def test_something(self, session_config: SessionCookieConfig) -> None:
         with TestClient(app=app, session_config=session_config) as client:
-            cookies = client.create_session_cookies(session_data={"user": "test_user"})
-            # Pass raw cookies to the request.
-            client.get(url="/my_route", cookies=cookies)
+            # update session cookies on the client
+            client.update_session_cookies(session_data={"user": "test_user"})
+            client.get(url="/my_route")
 ```
 
 !!! important

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -196,12 +196,13 @@ def test_test_client(enable_session: bool, session_data: Dict[str, str]) -> None
     @get(path="/test")
     def test_handler(state: State, request: Request) -> None:
         assert state.value == 1
-        assert request.session == session_data
+        assert request.session == {**session_data, "more": "data"}
 
     session_config = SessionCookieConfig(secret=SecretBytes(os.urandom(16)))
     app = Starlite(route_handlers=[test_handler], on_startup=[start_up_handler], middleware=[session_config.middleware])
 
     with TestClient(app=app, session_config=session_config if enable_session else None) as client:
         client.cookies = client.create_session_cookies(session_data=session_data)
+        client.update_session_cookies({"more": "data"})
         client.get("/test")
         assert app.state.value == 1


### PR DESCRIPTION
Due to httpx deprecation of passing cookies to `Client.request` it makes sense to have a method that updates the cookies instead of retuning them.

Closes #557

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
