### PR TITLE
OpenAPI (redoc/swagger/spotlight elements) usage in environments that cant access CDN's

### DIFF
--- a/docs/reference/openapi/0-openapi-controller.md
+++ b/docs/reference/openapi/0-openapi-controller.md
@@ -8,6 +8,8 @@
             - path
             - redoc
             - redoc_version
+            - redoc_google_fonts
+            - redoc_js_url
             - render_404_page
             - render_methods_map
             - render_redoc
@@ -19,6 +21,11 @@
             - should_serve_endpoint
             - stoplight_elements
             - stoplight_elements_version
+            - stoplight_elements_css_url
+            - stoplight_elements_js_url
             - style
             - swagger_ui
             - swagger_ui_version
+            - swagger_css_url
+            - swagger_js_ui_bundle
+            - swagger_js_standalone_preset_js

--- a/docs/usage/12-openapi/3-openapi-controller.md
+++ b/docs/usage/12-openapi/3-openapi-controller.md
@@ -40,15 +40,9 @@ app = Starlite(
 See the [API Reference][starlite.openapi.controller.OpenAPIController] for full details on the `OpenAPIController` class
 and the kwargs it accepts.
 
+## CDN and offline file support
 
-## OpenAPI usage in offline environments.
-
-When subclassing [OpenAPIController][starlite.openapi.controller.OpenAPIController] 
-it is possible to set several variables for setting urls to css, js files
-needed for rendering the OpenAPI pages (swagger/redoc/spotlight elements)
-
-you can also set dont use google fonts (used in redoc)
-
+You can change the default download paths for JS and CSS bundles as well as google fonts by subclassing [OpenAPIController][starlite.openapi.controller.OpenAPIController]  and setting any of the following class variables:
 
 ```python
 from starlite import Starlite, OpenAPIController, OpenAPIConfig
@@ -60,9 +54,14 @@ class MyOpenAPIController(OpenAPIController):
     redoc_js_url = "https://offline_location/redoc.standalone.js"
     swagger_css_url = "https://offline_location/swagger-ui-css"
     swagger_ui_bundle_js_url = "https://offline_location/swagger-ui-bundle.js"
-    swagger_ui_standalone_preset_js_url = "https://offline_location/swagger-ui-standalone-preset.js"
+    swagger_ui_standalone_preset_js_url = (
+        "https://offline_location/swagger-ui-standalone-preset.js"
+    )
     stoplight_elements_css_url = "https://offline_location/spotlight-styles.mins.css"
-    stoplight_elements_js_url = "https://offline_location/spotlight-web-components.min.js"
+    stoplight_elements_js_url = (
+        "https://offline_location/spotlight-web-components.min.js"
+    )
+
 
 app = Starlite(
     route_handlers=[...],

--- a/docs/usage/12-openapi/3-openapi-controller.md
+++ b/docs/usage/12-openapi/3-openapi-controller.md
@@ -39,3 +39,35 @@ app = Starlite(
 
 See the [API Reference][starlite.openapi.controller.OpenAPIController] for full details on the `OpenAPIController` class
 and the kwargs it accepts.
+
+
+## OpenAPI usage in offline environments.
+
+When subclassing [OpenAPIController][starlite.openapi.controller.OpenAPIController] 
+it is possible to set several variables for setting urls to css, js files
+needed for rendering the OpenAPI pages (swagger/redoc/spotlight elements)
+
+you can also set dont use google fonts (used in redoc)
+
+
+```python
+from starlite import Starlite, OpenAPIController, OpenAPIConfig
+
+
+class MyOpenAPIController(OpenAPIController):
+    path = "/api-docs"
+    redoc_google_fonts = False
+    redoc_js_url = "https://offline_location/redoc.standalone.js"
+    swagger_css_url = "https://offline_location/swagger-ui-css"
+    swagger_ui_bundle_js_url = "https://offline_location/swagger-ui-bundle.js"
+    swagger_ui_standalone_preset_js_url = "https://offline_location/swagger-ui-standalone-preset.js"
+    stoplight_elements_css_url = "https://offline_location/spotlight-styles.mins.css"
+    stoplight_elements_js_url = "https://offline_location/spotlight-web-components.min.js"
+
+app = Starlite(
+    route_handlers=[...],
+    openapi_config=OpenAPIConfig(
+        title="My API", version="1.0.0", openapi_controller=MyOpenAPIController
+    ),
+)
+```

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -46,37 +46,43 @@ class OpenAPIController(Controller):
     """
     redoc_google_fonts: bool = True
     """
-    use google cdn fonts in the rendering of redoc
-    """
-    swagger_css_url: str = \
-        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui.css"
-    """
-    specify swagger_css_url for use in offline environments 
-    """
-    swagger_js_ui_bundle: str = \
-        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui-bundle.js"
-    """
-    specify swagger_js_ui_bundle for use in offline environments
-    """
-    swagger_js_standalone_preset_js: str = \
-        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui-standalone-preset.js"
-    """
-    specify swagger_js_standalone_preset_js for use in offline environments
+    Google CDN Fonts in Redoc, use False for use in isolated environment
     """
     redoc_js_url: str = \
         f"https://cdn.jsdelivr.net/npm/redoc@{redoc_version}/bundles/redoc.standalone.js"
     """
-    specify redoc_js_url for use in offline environments 
+    Specify redoc_js_url for use in offline use in isolated environment.
+    Default reverts to as used in redoc_version
     """
-    stoplight_css_url: str = \
+    swagger_css_url: str = \
+        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui.css"
+    """
+    Specify swagger_css_url for use in offline use in isolated environment.
+    Default reverts to as used in swagger_ui_version
+    """
+    swagger_ui_bundle_js_url: str = \
+        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui-bundle.js"
+    """
+    Specify swagger_ui_bundle_js_url for use in offline use in isolated environment.
+    Default reverts to as used in swagger_ui_version
+    """
+    swagger_ui_standalone_preset_js_url: str = \
+        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui-standalone-preset.js"
+    """
+    Specify swagger_js_standalone_preset_js for use in isolated environment.
+    Default reverts to as used in swagger_ui_version
+    """
+    stoplight_elements_css_url: str = \
         f"https://unpkg.com/@stoplight/elements@{stoplight_elements_version}/styles.min.css"
     """
-    specify stoplight_css_url for use in offline environments 
+    Specify stoplight_css_url for use in isolated environment .
+    Default reverts to as used in stoplight_elements_version
     """
-    stoplight_js_url: str = \
+    stoplight_elements_js_url: str = \
         f"https://unpkg.com/@stoplight/elements@{stoplight_elements_version}/web-components.min.js"
     """
-    specify stoplight_js_url for use in offline environments 
+    Specify stoplight_js_url for use in isolated environment.
+    Default reverts to as used in stoplight_elements_version
     """
 
     # internal
@@ -326,8 +332,8 @@ class OpenAPIController(Controller):
             <meta charset="utf-8"/>
             <meta name="viewport" content="width=device-width, initial-scale=1">
             <link href="{self.swagger_css_url}" rel="stylesheet">
-            <script src="{self.swagger_js_ui_bundle}" crossorigin></script>
-            <script src="{self.swagger_js_standalone_preset_js}" crossorigin></script>
+            <script src="{self.swagger_ui_bundle_js_url}" crossorigin></script>
+            <script src="{self.swagger_ui_standalone_preset_js_url}" crossorigin></script>
             <style>{self.style}</style>
           </head>
         """
@@ -377,8 +383,8 @@ class OpenAPIController(Controller):
             {self.favicon}
             <meta charset="utf-8"/>
             <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-            <link rel="stylesheet" href="{self.stoplight_css_url}">
-            <script src="{self.stoplight_js_url}" crossorigin></script>
+            <link rel="stylesheet" href="{self.stoplight_elements_css_url}">
+            <script src="{self.stoplight_elements_js_url}" crossorigin></script>
             <style>{self.style}</style>
           </head>
         """

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -44,6 +44,41 @@ class OpenAPIController(Controller):
     """
     URL to download a favicon from.
     """
+    with_google_fonts: bool = True
+    """
+    use google cdn fonts in the rendering of redoc
+    """
+    swagger_css_url: str = \
+        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{self.swagger_ui_version}/swagger-ui.css"
+    """
+    specify swagger_css_url for use in offline environments 
+    """
+    swagger_js_ui_bundle: str = \
+        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{self.swagger_ui_version}/swagger-ui-bundle.js"
+    """
+    specify swagger_js_ui_bundle for use in offline environments
+    """
+    swagger_js_standalone_preset_js: str = \
+        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{self.swagger_ui_version}/swagger-ui-standalone-preset.js"
+    """
+    specify swagger_js_standalone_preset_js for use in offline environments
+    """
+    redoc_js_url: str = \
+        f"https://cdn.jsdelivr.net/npm/redoc@{redoc_version}/bundles/redoc.standalone.js"
+    """
+    specify redoc_js_url for use in offline environments 
+    """
+    stoplight_css_url: str = \
+        f"https://unpkg.com/@stoplight/elements@{stoplight_elements_version}/styles.min.css"
+    """
+    specify stoplight_css_url for use in offline environments 
+    """
+    stoplight_js_url: str = \
+        f"https://unpkg.com/@stoplight/elements@{stoplight_elements_version}/web-components.min.js"
+    """
+    specify stoplight_js_url for use in offline environments 
+    """
+
     # internal
     _dumped_schema: str = ""
     # until swagger-ui supports v3.1.* of OpenAPI officially, we need to modify the schema for it and keep it
@@ -290,9 +325,9 @@ class OpenAPIController(Controller):
             {self.favicon}
             <meta charset="utf-8"/>
             <meta name="viewport" content="width=device-width, initial-scale=1">
-            <link href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@{self.swagger_ui_version}/swagger-ui.css" rel="stylesheet">
-            <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@{self.swagger_ui_version}/swagger-ui-bundle.js" crossorigin></script>
-            <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@{self.swagger_ui_version}/swagger-ui-standalone-preset.js" crossorigin></script>
+            <link href="{self.swagger_css_url}" rel="stylesheet">
+            <script src="{self.swagger_js_ui_bundle}" crossorigin></script>
+            <script src="{self.swagger_js_standalone_preset_js}" crossorigin></script>
             <style>{self.style}</style>
           </head>
         """
@@ -342,8 +377,8 @@ class OpenAPIController(Controller):
             {self.favicon}
             <meta charset="utf-8"/>
             <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-            <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements@{self.stoplight_elements_version}/styles.min.css">
-            <script src="https://unpkg.com/@stoplight/elements@{self.stoplight_elements_version}/web-components.min.js" crossorigin></script>
+            <link rel="stylesheet" href="{self.stoplight_css_url}">
+            <script src="{self.stoplight_js_url}" crossorigin></script>
             <style>{self.style}</style>
           </head>
         """
@@ -388,8 +423,13 @@ class OpenAPIController(Controller):
             {self.favicon}
             <meta charset="utf-8"/>
             <meta name="viewport" content="width=device-width, initial-scale=1">
+            """
+        if self.with_google_fonts:
+            head += """
             <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
-            <script src="https://cdn.jsdelivr.net/npm/redoc@{self.redoc_version}/bundles/redoc.standalone.js" crossorigin></script>
+            """
+        head += f"""
+            <script src="{self.redoc_js_url}" crossorigin></script>
             <style>
                 {self.style}
             </style>

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -46,45 +46,39 @@ class OpenAPIController(Controller):
     """
     redoc_google_fonts: bool = True
     """
-    Google CDN Fonts in Redoc, use False for use in isolated environment
+    Download google fonts via CDN. Should be set to `False` when not using a CDN.
     """
     redoc_js_url: str = f"https://cdn.jsdelivr.net/npm/redoc@{redoc_version}/bundles/redoc.standalone.js"
     """
-    Specify redoc_js_url for use in isolated environment
-    Default reverts to as used in redoc_version
+    Download url for the Redoc JS bundle.
     """
     swagger_css_url: str = f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui.css"
     """
-    Specify swagger_css_url for use in isolated environment
-    Default reverts to as used in swagger_ui_version
+    Download url for the Swagger UI CSS bundle.
     """
     swagger_ui_bundle_js_url: str = (
         f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui-bundle.js"
     )
     """
-    Specify swagger_ui_bundle_js_url for use in isolated environment
-    Default reverts to as used in swagger_ui_version
+    Download url for the Swagger UI JS bundle.
     """
     swagger_ui_standalone_preset_js_url: str = (
         f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui-standalone-preset.js"
     )
     """
-    Specify swagger_js_standalone_preset_js for use in isolated environment
-    Default reverts to as used in swagger_ui_version
+    Download url for the Swagger Standalone Preset JS bundle.
     """
     stoplight_elements_css_url: str = (
         f"https://unpkg.com/@stoplight/elements@{stoplight_elements_version}/styles.min.css"
     )
     """
-    Specify stoplight_css_url for use in isolated environment.
-    Default reverts to as used in stoplight_elements_version
+    Download url for the Stoplight Elements CSS bundle.
     """
     stoplight_elements_js_url: str = (
         f"https://unpkg.com/@stoplight/elements@{stoplight_elements_version}/web-components.min.js"
     )
     """
-    Specify stoplight_js_url for use in isolated environment.
-    Default reverts to as used in stoplight_elements_version
+    Download url for the Stoplight Elements JS bundle.
     """
 
     # internal

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -44,22 +44,22 @@ class OpenAPIController(Controller):
     """
     URL to download a favicon from.
     """
-    with_google_fonts: bool = True
+    redoc_google_fonts: bool = True
     """
     use google cdn fonts in the rendering of redoc
     """
     swagger_css_url: str = \
-        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{self.swagger_ui_version}/swagger-ui.css"
+        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui.css"
     """
     specify swagger_css_url for use in offline environments 
     """
     swagger_js_ui_bundle: str = \
-        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{self.swagger_ui_version}/swagger-ui-bundle.js"
+        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui-bundle.js"
     """
     specify swagger_js_ui_bundle for use in offline environments
     """
     swagger_js_standalone_preset_js: str = \
-        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{self.swagger_ui_version}/swagger-ui-standalone-preset.js"
+        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui-standalone-preset.js"
     """
     specify swagger_js_standalone_preset_js for use in offline environments
     """
@@ -424,7 +424,7 @@ class OpenAPIController(Controller):
             <meta charset="utf-8"/>
             <meta name="viewport" content="width=device-width, initial-scale=1">
             """
-        if self.with_google_fonts:
+        if self.redoc_google_fonts:
             head += """
             <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
             """

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -50,33 +50,33 @@ class OpenAPIController(Controller):
     """
     redoc_js_url: str = f"https://cdn.jsdelivr.net/npm/redoc@{redoc_version}/bundles/redoc.standalone.js"
     """
-    Specify redoc_js_url for use in offline use in isolated environment.
+    Specify redoc_js_url for use in isolated environment
     Default reverts to as used in redoc_version
     """
     swagger_css_url: str = f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui.css"
     """
-    Specify swagger_css_url for use in offline use in isolated environment.
+    Specify swagger_css_url for use in isolated environment
     Default reverts to as used in swagger_ui_version
     """
     swagger_ui_bundle_js_url: str = (
         f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui-bundle.js"
     )
     """
-    Specify swagger_ui_bundle_js_url for use in offline use in isolated environment.
+    Specify swagger_ui_bundle_js_url for use in isolated environment
     Default reverts to as used in swagger_ui_version
     """
     swagger_ui_standalone_preset_js_url: str = (
         f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui-standalone-preset.js"
     )
     """
-    Specify swagger_js_standalone_preset_js for use in isolated environment.
+    Specify swagger_js_standalone_preset_js for use in isolated environment
     Default reverts to as used in swagger_ui_version
     """
     stoplight_elements_css_url: str = (
         f"https://unpkg.com/@stoplight/elements@{stoplight_elements_version}/styles.min.css"
     )
     """
-    Specify stoplight_css_url for use in isolated environment .
+    Specify stoplight_css_url for use in isolated environment.
     Default reverts to as used in stoplight_elements_version
     """
     stoplight_elements_js_url: str = (

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -48,38 +48,40 @@ class OpenAPIController(Controller):
     """
     Google CDN Fonts in Redoc, use False for use in isolated environment
     """
-    redoc_js_url: str = \
-        f"https://cdn.jsdelivr.net/npm/redoc@{redoc_version}/bundles/redoc.standalone.js"
+    redoc_js_url: str = f"https://cdn.jsdelivr.net/npm/redoc@{redoc_version}/bundles/redoc.standalone.js"
     """
     Specify redoc_js_url for use in offline use in isolated environment.
     Default reverts to as used in redoc_version
     """
-    swagger_css_url: str = \
-        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui.css"
+    swagger_css_url: str = f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui.css"
     """
     Specify swagger_css_url for use in offline use in isolated environment.
     Default reverts to as used in swagger_ui_version
     """
-    swagger_ui_bundle_js_url: str = \
+    swagger_ui_bundle_js_url: str = (
         f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui-bundle.js"
+    )
     """
     Specify swagger_ui_bundle_js_url for use in offline use in isolated environment.
     Default reverts to as used in swagger_ui_version
     """
-    swagger_ui_standalone_preset_js_url: str = \
+    swagger_ui_standalone_preset_js_url: str = (
         f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{swagger_ui_version}/swagger-ui-standalone-preset.js"
+    )
     """
     Specify swagger_js_standalone_preset_js for use in isolated environment.
     Default reverts to as used in swagger_ui_version
     """
-    stoplight_elements_css_url: str = \
+    stoplight_elements_css_url: str = (
         f"https://unpkg.com/@stoplight/elements@{stoplight_elements_version}/styles.min.css"
+    )
     """
     Specify stoplight_css_url for use in isolated environment .
     Default reverts to as used in stoplight_elements_version
     """
-    stoplight_elements_js_url: str = \
+    stoplight_elements_js_url: str = (
         f"https://unpkg.com/@stoplight/elements@{stoplight_elements_version}/web-components.min.js"
+    )
     """
     Specify stoplight_js_url for use in isolated environment.
     Default reverts to as used in stoplight_elements_version

--- a/tests/openapi/test_controller.py
+++ b/tests/openapi/test_controller.py
@@ -3,16 +3,15 @@ from starlette.status import HTTP_200_OK, HTTP_404_NOT_FOUND
 from starlite import OpenAPIConfig
 from starlite.app import DEFAULT_OPENAPI_CONFIG
 from starlite.enums import MediaType
+from starlite.openapi.controller import OpenAPIController as _OpenAPIController
 from starlite.testing import create_test_client
 from tests.openapi.utils import PersonController, PetController
-from starlite.openapi.controller import OpenAPIController as _OpenAPIController
 
 
 class OpenAPIController(_OpenAPIController):
-    """
-    test class for usage in a couple "offline" tests
-    and for without google fonts test
-    """
+    """test class for usage in a couple "offline" tests and for without google
+    fonts test."""
+
     redoc_google_fonts = False
     redoc_js_url = "https://offline_location/redoc.standalone.js"
     swagger_css_url = "https://offline_location/swagger-ui-css"
@@ -21,9 +20,9 @@ class OpenAPIController(_OpenAPIController):
     stoplight_elements_css_url = "https://offline_location/spotlight-styles.mins.css"
     stoplight_elements_js_url = "https://offline_location/spotlight-web-components.min.js"
 
+
 def test_without_google_fonts() -> None:
-    config = OpenAPIConfig(
-        title="Starlite API", version="1.0.0", openapi_controller=OpenAPIController)
+    config = OpenAPIConfig(title="Starlite API", version="1.0.0", openapi_controller=OpenAPIController)
     with create_test_client([PersonController, PetController], openapi_config=config) as client:
         response = client.get("/schema/redoc")
         assert "fonts.googleapis.com" not in response.text
@@ -42,16 +41,16 @@ def test_openapi_swagger_offline() -> None:
     with create_test_client([PersonController, PetController], openapi_config=config) as client:
         response = client.get("/schema/swagger")
         assert OpenAPIController.swagger_css_url in response.text
-        assert OpenAPIController.swagger_js_ui_bundle in response.text
-        assert OpenAPIController.swagger_js_standalone_preset_js in response.text
+        assert OpenAPIController.swagger_ui_bundle_js_url in response.text
+        assert OpenAPIController.swagger_ui_standalone_preset_js_url in response.text
 
 
 def test_openapi_stoplight_elements_offline() -> None:
     config = OpenAPIConfig(title="Starlite API", version="1.0.0", openapi_controller=OpenAPIController)
     with create_test_client([PersonController, PetController], openapi_config=config) as client:
         response = client.get("/schema/elements")
-        assert OpenAPIController.stoplight_css_url in response.text
-        assert OpenAPIController.stoplight_js_url in response.text
+        assert OpenAPIController.stoplight_elements_css_url in response.text
+        assert OpenAPIController.stoplight_elements_js_url in response.text
 
 
 def test_openapi_root() -> None:

--- a/tests/openapi/test_controller.py
+++ b/tests/openapi/test_controller.py
@@ -1,9 +1,57 @@
 from starlette.status import HTTP_200_OK, HTTP_404_NOT_FOUND
 
+from starlite import OpenAPIConfig
 from starlite.app import DEFAULT_OPENAPI_CONFIG
 from starlite.enums import MediaType
 from starlite.testing import create_test_client
 from tests.openapi.utils import PersonController, PetController
+from starlite.openapi.controller import OpenAPIController as _OpenAPIController
+
+
+class OpenAPIController(_OpenAPIController):
+    """
+    test class for usage in a couple "offline" tests
+    and for without google fonts test
+    """
+    redoc_google_fonts = False
+    redoc_js_url = "https://offline_location/redoc.standalone.js"
+    swagger_css_url = "https://offline_location/swagger-ui-css"
+    swagger_js_ui_bundle = "https://offline_location/swagger-ui-bundle.js"
+    swagger_js_standalone_preset_js = "https://offline_location/swagger-ui-standalone-preset.js"
+    stoplight_css_url = "https://offline_location/spotlight-styles.mins.css"
+    stoplight_js_url = "https://offline_location/spotlight-web-components.min.js"
+
+def test_without_google_fonts() -> None:
+    config = OpenAPIConfig(
+        title="Starlite API", version="1.0.0", openapi_controller=OpenAPIController)
+    with create_test_client([PersonController, PetController], openapi_config=config) as client:
+        response = client.get("/schema/redoc")
+        assert "fonts.googleapis.com" not in response.text
+
+
+def test_openapi_redoc_offline() -> None:
+    config = OpenAPIConfig(title="Starlite API", version="1.0.0", openapi_controller=OpenAPIController)
+    with create_test_client([PersonController, PetController], openapi_config=config) as client:
+        response = client.get("/schema/redoc")
+        assert OpenAPIController.redoc_js_url in response.text
+        assert "fonts.googleapis.com" not in response.text
+
+
+def test_openapi_swagger_offline() -> None:
+    config = OpenAPIConfig(title="Starlite API", version="1.0.0", openapi_controller=OpenAPIController)
+    with create_test_client([PersonController, PetController], openapi_config=config) as client:
+        response = client.get("/schema/swagger")
+        assert OpenAPIController.swagger_css_url in response.text
+        assert OpenAPIController.swagger_js_ui_bundle in response.text
+        assert OpenAPIController.swagger_js_standalone_preset_js in response.text
+
+
+def test_openapi_stoplight_elements_offline() -> None:
+    config = OpenAPIConfig(title="Starlite API", version="1.0.0", openapi_controller=OpenAPIController)
+    with create_test_client([PersonController, PetController], openapi_config=config) as client:
+        response = client.get("/schema/elements")
+        assert OpenAPIController.stoplight_css_url in response.text
+        assert OpenAPIController.stoplight_js_url in response.text
 
 
 def test_openapi_root() -> None:

--- a/tests/openapi/test_controller.py
+++ b/tests/openapi/test_controller.py
@@ -64,7 +64,9 @@ def test_default_stoplight_elements_cdn_urls() -> None:
             client.app.openapi_config.openapi_controller.stoplight_elements_css_url
             in default_stoplight_elements_bundles
         )
-        assert client.app.openapi_config.openapi_controller.stoplight_elements_js_url
+        assert (
+            client.app.openapi_config.openapi_controller.stoplight_elements_js_url in default_stoplight_elements_bundles
+        )
         assert all(cdn_url in response.text for cdn_url in default_stoplight_elements_bundles)
 
 

--- a/tests/openapi/test_controller.py
+++ b/tests/openapi/test_controller.py
@@ -16,10 +16,10 @@ class OpenAPIController(_OpenAPIController):
     redoc_google_fonts = False
     redoc_js_url = "https://offline_location/redoc.standalone.js"
     swagger_css_url = "https://offline_location/swagger-ui-css"
-    swagger_js_ui_bundle = "https://offline_location/swagger-ui-bundle.js"
-    swagger_js_standalone_preset_js = "https://offline_location/swagger-ui-standalone-preset.js"
-    stoplight_css_url = "https://offline_location/spotlight-styles.mins.css"
-    stoplight_js_url = "https://offline_location/spotlight-web-components.min.js"
+    swagger_ui_bundle_js_url = "https://offline_location/swagger-ui-bundle.js"
+    swagger_ui_standalone_preset_js_url = "https://offline_location/swagger-ui-standalone-preset.js"
+    stoplight_elements_css_url = "https://offline_location/spotlight-styles.mins.css"
+    stoplight_elements_js_url = "https://offline_location/spotlight-web-components.min.js"
 
 def test_without_google_fonts() -> None:
     config = OpenAPIConfig(

--- a/tests/openapi/test_controller.py
+++ b/tests/openapi/test_controller.py
@@ -21,10 +21,67 @@ class OpenAPIController(_OpenAPIController):
     stoplight_elements_js_url = "https://offline_location/spotlight-web-components.min.js"
 
 
-def test_without_google_fonts() -> None:
+def test_default_redoc_cdn_urls() -> None:
+    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+        response = client.get("/schema/redoc")
+        default_redoc_version = "next"
+        default_redoc_js_bundle = (
+            f"https://cdn.jsdelivr.net/npm/redoc@{default_redoc_version}/bundles/redoc.standalone.js"
+        )
+        assert client.app.openapi_config is not None
+        assert client.app.openapi_config.openapi_controller.redoc_js_url == default_redoc_js_bundle
+        assert default_redoc_js_bundle in response.text
+
+
+def test_default_swagger_ui_cdn_urls() -> None:
+    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+        response = client.get("/schema/swagger")
+        default_swagger_ui_version = "4.14.0"
+        default_swagger_bundles = [
+            f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{default_swagger_ui_version}/swagger-ui.css",
+            f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{default_swagger_ui_version}/swagger-ui-bundle.js",
+            f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{default_swagger_ui_version}/swagger-ui-standalone-preset.js",
+        ]
+        assert client.app.openapi_config is not None
+        assert client.app.openapi_config.openapi_controller.swagger_css_url in default_swagger_bundles
+        assert client.app.openapi_config.openapi_controller.swagger_ui_bundle_js_url in default_swagger_bundles
+        assert (
+            client.app.openapi_config.openapi_controller.swagger_ui_standalone_preset_js_url in default_swagger_bundles
+        )
+        assert all(cdn_url in response.text for cdn_url in default_swagger_bundles)
+
+
+def test_default_stoplight_elements_cdn_urls() -> None:
+    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+        response = client.get("/schema/elements")
+        default_stoplight_elements_version = "7.6.5"
+        default_stoplight_elements_bundles = [
+            f"https://unpkg.com/@stoplight/elements@{default_stoplight_elements_version}/styles.min.css",
+            f"https://unpkg.com/@stoplight/elements@{default_stoplight_elements_version}/web-components.min.js",
+        ]
+        assert client.app.openapi_config is not None
+        assert (
+            client.app.openapi_config.openapi_controller.stoplight_elements_css_url
+            in default_stoplight_elements_bundles
+        )
+        assert client.app.openapi_config.openapi_controller.stoplight_elements_js_url
+        assert all(cdn_url in response.text for cdn_url in default_stoplight_elements_bundles)
+
+
+def test_redoc_with_google_fonts() -> None:
+    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+        response = client.get("/schema/redoc")
+        google_font_cdn = "https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700"
+        assert client.app.openapi_config is not None
+        assert client.app.openapi_config.openapi_controller.redoc_google_fonts is True
+        assert google_font_cdn in response.text
+
+
+def test_redoc_without_google_fonts() -> None:
     config = OpenAPIConfig(title="Starlite API", version="1.0.0", openapi_controller=OpenAPIController)
     with create_test_client([PersonController, PetController], openapi_config=config) as client:
         response = client.get("/schema/redoc")
+        assert config.openapi_controller.redoc_google_fonts is False
         assert "fonts.googleapis.com" not in response.text
 
 


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

i was working on migrating a project from fastapi to starlite and was missing this function
it is inspired on how FastAPI handles the offline usage for the OpenAPI pages.

specifally inspired of the following from FastAPI.

functions:
get_swagger_ui_html
get_redoc_html

google_font:
https://github.com/tiangolo/fastapi/pull/481


*full transparency. im a self learned "programmer" so if something is incorrect bear with me*