### PR TITLE
Add missing quotes to testing docs

### DIFF
--- a/docs/usage/14-testing.md
+++ b/docs/usage/14-testing.md
@@ -86,7 +86,7 @@ It is recommended to create a fixture for `SessionCookieConfig` as it will be us
 also passed as an argument to the `TestClient` whenever you need to mock request. The `secret` should remain the same
 throughout the test session, so set fixture `scope` to `"class"`.
 
-```python title="tests/test_route_handlers.py
+```python title="tests/test_route_handlers.py"
 import os
 
 import pytest


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?


Testing docs were missing a quote and thus did not render a code block correctly.