### PR TITLE
Fix docs about default name for route handlers in HandlerIndex

### DIFF
--- a/docs/usage/2-route-handlers/4-route-handler-indexing.md
+++ b/docs/usage/2-route-handlers/4-route-handler-indexing.md
@@ -1,10 +1,10 @@
 # Route Handler Indexing
 
 You can provide in all route handler decorators a `name` kwarg. The value for this kwarg **must be unique**, otherwise
-an exception will be raised. Default value for `name` is the value of
-[`__qualname__`](https://docs.python.org/3/library/stdtypes.html#definition.__qualname__) property of the route handler.
-`name` can be used to dynamically retrieve (i.e. during runtime) a mapping containing the route handler instance and
-paths, also it can be used to build a URL path for that handler:
+an exception will be raised. Default value for `name` is value returned by `handler.__str__` which should be the full
+dotted path to the handler (e.g. `app.controllers.projects.list` for `list` function residing in
+`app/controllers/projects.py` file). `name` can be used to dynamically retrieve (i.e. during runtime) a mapping containing
+the route handler instance and paths, also it can be used to build a URL path for that handler:
 
 ```python
 from starlite import Starlite, Request, Redirect, NotFoundException, get

--- a/tests/routing/test_route_indexing.py
+++ b/tests/routing/test_route_indexing.py
@@ -73,18 +73,19 @@ def test_default_indexes_handlers(decorator: Type[HTTPRouteHandler]) -> None:
     router = Router("router/", route_handlers=[handler, named_handler, MyController])
     app = Starlite(route_handlers=[router])
 
-    handler_index = app.get_handler_index_by_name(handler.name or str(handler))
+    handler_index = app.get_handler_index_by_name(str(handler))
     assert handler_index
     assert handler_index["paths"] == ["/router/handler"]
     assert handler_index["handler"] == handler
-    assert handler_index["identifier"] == handler.name or str(handler)
+    assert handler_index["identifier"] == str(handler)
 
-    handler_index = app.get_handler_index_by_name(MyController.handler.name or str(MyController.handler))
+    handler_index = app.get_handler_index_by_name(str(MyController.handler))
     assert handler_index
     assert handler_index["paths"] == ["/router/test"]
-    assert handler_index["identifier"] == MyController.handler.name or str(MyController.handler)
+    assert handler_index["identifier"] == str(MyController.handler)
 
-    handler_index = app.get_handler_index_by_name(named_handler)  # type: ignore
+    # check that default str(named_handler) does not override explicit name
+    handler_index = app.get_handler_index_by_name(str(named_handler))
     assert handler_index is None
 
 


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

This PR updates docs about default name for route handlers.

Also noticed that test for default handler name is a bit inconsistent trying to use `handler.name` first. I highly doubt that there will be some changes affecting `name` property but anyway lets keep tests straightforward 