### PR TITLE
Fix mypy and tests failure

### DIFF
--- a/starlite/openapi/schema.py
+++ b/starlite/openapi/schema.py
@@ -8,6 +8,7 @@ from pydantic import (
     ConstrainedBytes,
     ConstrainedDecimal,
     ConstrainedFloat,
+    ConstrainedFrozenSet,
     ConstrainedInt,
     ConstrainedList,
     ConstrainedSet,
@@ -93,7 +94,7 @@ def create_string_constrained_field_schema(field_type: Union[Type[ConstrainedStr
 
 
 def create_collection_constrained_field_schema(
-    field_type: Union[Type[ConstrainedList], Type[ConstrainedSet]],
+    field_type: Union[Type[ConstrainedList], Type[ConstrainedSet], Type[ConstrainedFrozenSet]],
     sub_fields: Optional[List[ModelField]],
     plugins: List["PluginProtocol"],
 ) -> Schema:
@@ -103,7 +104,7 @@ def create_collection_constrained_field_schema(
         schema.minItems = field_type.min_items
     if field_type.max_items:
         schema.maxItems = field_type.max_items
-    if issubclass(field_type, ConstrainedSet):
+    if issubclass(field_type, (ConstrainedSet, ConstrainedFrozenSet)):
         schema.uniqueItems = True
     if sub_fields:
         items = [create_schema(field=sub_field, generate_examples=False, plugins=plugins) for sub_field in sub_fields]
@@ -119,13 +120,14 @@ def create_collection_constrained_field_schema(
 
 def create_constrained_field_schema(
     field_type: Union[
-        Type[ConstrainedSet],
-        Type[ConstrainedList],
-        Type[ConstrainedStr],
         Type[ConstrainedBytes],
-        Type[ConstrainedFloat],
-        Type[ConstrainedInt],
         Type[ConstrainedDecimal],
+        Type[ConstrainedFloat],
+        Type[ConstrainedFrozenSet],
+        Type[ConstrainedInt],
+        Type[ConstrainedList],
+        Type[ConstrainedSet],
+        Type[ConstrainedStr],
     ],
     sub_fields: Optional[List[ModelField]],
     plugins: List["PluginProtocol"],

--- a/starlite/plugins/sql_alchemy/plugin.py
+++ b/starlite/plugins/sql_alchemy/plugin.py
@@ -140,7 +140,7 @@ class SQLAlchemyPlugin(PluginProtocol[DeclarativeMeta]):
             dimensions -= 1
         return list_type
 
-    def handle_tuple_type(self, column_type: sqlalchemy_type.TupleType) -> Any:  # type:ignore[name-defined]
+    def handle_tuple_type(self, column_type: sqlalchemy_type.TupleType) -> Any:
         """Handles the SQLAlchemy Tuple type.
 
         Args:
@@ -211,7 +211,7 @@ class SQLAlchemyPlugin(PluginProtocol[DeclarativeMeta]):
             sqlalchemy_type.TIMESTAMP: lambda x: datetime,
             sqlalchemy_type.Text: self.handle_string_type,
             sqlalchemy_type.Time: lambda x: time,
-            sqlalchemy_type.TupleType: self.handle_tuple_type,  # type:ignore[attr-defined]
+            sqlalchemy_type.TupleType: self.handle_tuple_type,  # pyright: ignore
             sqlalchemy_type.Unicode: self.handle_string_type,
             sqlalchemy_type.UnicodeText: self.handle_string_type,
             sqlalchemy_type.VARBINARY: self.handle_string_type,

--- a/tests/kwargs/test_multipart_data.py
+++ b/tests/kwargs/test_multipart_data.py
@@ -72,7 +72,7 @@ async def form_with_headers_handler(request: Request) -> Dict[str, Any]:
                 "filename": value.filename,
                 "content": content.decode(),
                 "content_type": value.content_type,
-                "headers": list(value.headers.items()),
+                "headers": [[name.lower(), value] for name, value in value.headers.items()],
             }
         else:
             output[key] = value
@@ -188,9 +188,9 @@ def test_multipart_request_multiple_files_with_headers(tmpdir: Any) -> None:
                 "content": "<file2 content>",
                 "content_type": "text/plain",
                 "headers": [
-                    ["Content-Disposition", 'form-data; name="test2"; filename="test2.txt"'],
+                    ["content-disposition", 'form-data; name="test2"; filename="test2.txt"'],
                     ["x-custom", "f2"],
-                    ["Content-Type", "text/plain"],
+                    ["content-type", "text/plain"],
                 ],
             },
         }


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

I am experimenting a lot now and failing mypy checks/tests are so irritating so I decided to fix them at least locally. If you've already fixed it in your code then close the PR.

Due to recent change signature change of `ModelFactory.is_constrained_field` (went from `bool` to `TypeGuard`) in pydantic-factories mypy was able to pickup that `is_constrained_field` actually has been returning true for `ConstrainedFrozenSet` for almost a year :-) while union in the appropriate type annotation in Starlite didn't include it.

Also, test is fixed which is now failing due to changes in starlite-multipart. I went and fixed the test itself since according to RFCS (https://www.rfc-editor.org/rfc/rfc7230#section-3.2 and https://www.rfc-editor.org/rfc/rfc7540#section-8.1.2 ) header names are case insensitive.

P.S. Actually it seems that Starlite and pydantic-factories miss handling for `ConstrainedDate` which is present in pydantic.