### PR TITLE
Add poetry scripts for common commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,14 @@ picologging = ["picologging"]
 structlog = ["structlog"]
 redis = ["redis"]
 
+[tool.poetry.scripts]
+test = "scripts:test"
+all_checks = "scripts:all_checks"
+lint = "scripts:lint"
+type_check = "scripts:type_check"
+fmt = "scripts:fmt"
+docs = "scripts:docs"
+
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -4,14 +4,31 @@ from typing import List, Optional, Union
 
 
 def _run_command(command: List[str], exit_after_run: Optional[bool] = True) -> int:
-    completed_process = subprocess.run(command)
+    """Run a CLI command.
+
+    Args:
+        command: the CLI command to run
+        exit_after_run: exit after the command finished running
+
+    Returns:
+        The command's return code
+    """
+    completed_process = subprocess.run(command, check=False)
     if exit_after_run:
-        exit(completed_process.returncode)
+        sys.exit(completed_process.returncode)
 
     return completed_process.returncode
 
 
 def _pre_commit(hook_ids: Optional[Union[str, List[str]]] = None) -> None:
+    """Run one or more pre-commit hooks.
+
+    Args:
+        hook_ids: one or more hooks to run. It's an optional parameter, `None` means run all hooks
+
+    Returns:
+        None
+    """
     files = ["--files", *sys.argv[1:]] if len(sys.argv) > 1 else ["--all-files"]
 
     if not hook_ids:
@@ -26,28 +43,76 @@ def _pre_commit(hook_ids: Optional[Union[str, List[str]]] = None) -> None:
         cur_return_code = _run_command(["pre-commit", "run", "--color=always", hook_id, *files], exit_after_run=False)
         overall_return_code = overall_return_code or cur_return_code
 
-    exit(overall_return_code)
+    sys.exit(overall_return_code)
 
 
 def test() -> None:
+    """Run tests.
+
+    Args:
+        argv: a directory or file to run on
+
+    Returns:
+        None
+    """
+
     _run_command(["pytest", *sys.argv[1:]])
 
 
 def all_checks() -> None:
+    """Run all pre-commit checks.
+
+    Args:
+        argv: a directory or files to run on
+
+    Returns:
+        None
+    """
+
     _pre_commit()
 
 
 def lint() -> None:
+    """Run pylint from pre-commit.
+
+    Args:
+        argv: a directory or files to run on
+
+    Returns:
+        None
+    """
+
     _pre_commit("pylint")
 
 
 def fmt() -> None:
-    _pre_commit(["black", "isort", "prettier", "blacken-docs"])
+    """Run black, isort, prettier, blacken-docs and docformatter from pre-
+    commit.
+
+    Args:
+        argv: a directory or files to run on
+
+    Returns:
+        None
+    """
+
+    _pre_commit(["black", "isort", "prettier", "blacken-docs", "docformatter"])
 
 
 def type_check() -> None:
+    """Run mypy from pre-commit.
+
+    Args:
+        argv: a directory or files to run on
+
+    Returns:
+        None
+    """
+
     _pre_commit("mypy")
 
 
 def docs() -> None:
+    """Build docs."""
+
     _run_command(["mkdocs", "build"])

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,53 @@
+import subprocess
+import sys
+from typing import List, Optional, Union
+
+
+def _run_command(command: List[str], exit_after_run: Optional[bool] = True) -> int:
+    completed_process = subprocess.run(command)
+    if exit_after_run:
+        exit(completed_process.returncode)
+
+    return completed_process.returncode
+
+
+def _pre_commit(hook_ids: Optional[Union[str, List[str]]] = None) -> None:
+    files = ["--files", *sys.argv[1:]] if len(sys.argv) > 1 else ["--all-files"]
+
+    if not hook_ids:
+        _run_command(["pre-commit", "run", "--color=always", *files])
+        return
+
+    if isinstance(hook_ids, str):
+        hook_ids = [hook_ids]
+
+    overall_return_code = 0
+    for hook_id in hook_ids:
+        cur_return_code = _run_command(["pre-commit", "run", "--color=always", hook_id, *files], exit_after_run=False)
+        overall_return_code = overall_return_code or cur_return_code
+
+    exit(overall_return_code)
+
+
+def test() -> None:
+    _run_command(["pytest", *sys.argv[1:]])
+
+
+def all_checks() -> None:
+    _pre_commit()
+
+
+def lint() -> None:
+    _pre_commit("pylint")
+
+
+def fmt() -> None:
+    _pre_commit(["black", "isort", "prettier", "blacken-docs"])
+
+
+def type_check() -> None:
+    _pre_commit("mypy")
+
+
+def docs() -> None:
+    _run_command(["mkdocs", "build"])


### PR DESCRIPTION
This PR adds [poetry scripts](https://python-poetry.org/docs/pyproject/#scripts) with some common commands that I always forget and need to look up 😄 
Please let me know if you're open to this idea, otherwise I can close the PR.

It currently adds the following scripts (we can always add more or change as we go):
- `poetry run docs` - build docs
- `poetry run test` - runs tests
  - Can accept specific directories/file and will run only them, for example: `poetry run test tests/caching`
- `poetry run lint` - runs pylint from pre-commit
  - Can accept specific directories/files and will run only them, for example: `poetry run lint starlite/cache/**`
- `poetry run fmt` - runs black, isort, prettier, blacken-docs from pre-commit
  - Can accept specific directories/files and will run only them, for example: `poetry run fmt starlite/cache/**`
- `poetry run type_check` - runs mypy from pre-commit
  - Can accept specific directories/files and will run only them, for example: `poetry run type_check starlite/cache/**`
- `poetry run all_checks` - runs all pre-commit checks
  - Can accept specific directories/files and will run only them, for example: `poetry run all_checks starlite/cache/**`


# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
