### PR TITLE
Fix `NoReturn` as allowed return typing for `delete` decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ While supporting function based route handlers, Starlite also supports and promo
 controllers:
 
 ```python title="my_app/controllers/user.py"
-from typing import List, Optional, NoReturn
+from typing import List, Optional
 
 from pydantic import UUID4
 from starlite import Controller, Partial, get, post, put, patch, delete
@@ -164,7 +164,7 @@ class UserController(Controller):
         ...
 
     @delete(path="/{user_id:uuid}")
-    async def delete_user(self, user_id: UUID4) -> NoReturn:
+    async def delete_user(self, user_id: UUID4) -> None:
         ...
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,7 +100,7 @@ class User:
 **Define a Controller** for your data model:
 
 ```python title="my_app/controllers/user.py"
-from typing import List, NoReturn
+from typing import List
 
 from pydantic import UUID4
 from starlite import Controller, Partial, get, post, put, patch, delete
@@ -132,7 +132,7 @@ class UserController(Controller):
         ...
 
     @delete(path="/{user_id:uuid}")
-    async def delete_user(self, user_id: UUID4) -> NoReturn:
+    async def delete_user(self, user_id: UUID4) -> None:
         ...
 ```
 

--- a/docs/usage/1-routing/3-controllers.md
+++ b/docs/usage/1-routing/3-controllers.md
@@ -9,7 +9,6 @@ from pydantic import BaseModel, UUID4
 from starlite.controller import Controller
 from starlite.handlers import get, post, patch, delete
 from starlite.types import Partial
-from typing import NoReturn
 
 
 class UserOrder(BaseModel):
@@ -35,7 +34,7 @@ class UserOrderController(Controller):
         ...
 
     @delete(path="/{order_id:uuid}")
-    async def delete_user_order(self, order_id: UUID4) -> NoReturn:
+    async def delete_user_order(self, order_id: UUID4) -> None:
         ...
 ```
 

--- a/docs/usage/5-responses/2-status-codes.md
+++ b/docs/usage/5-responses/2-status-codes.md
@@ -26,8 +26,7 @@ If `status_code` is not set by the user, the following defaults are used:
 
 !!! important
     For status codes < 100 or 204, 304 statuses, no response body is allowed. If you specify a return annotation other
-    than `typing.NoReturn` or `None` in those cases, an
-    [`ImproperlyConfiguredException`][starlite.exceptions.ImproperlyConfiguredException] will be raised.
+    than `None`, an [`ImproperlyConfiguredException`][starlite.exceptions.ImproperlyConfiguredException] will be raised.
 
 !!! note
     When using the `route` decorator with multiple http methods, the default status code is `200`.

--- a/poetry.lock
+++ b/poetry.lock
@@ -253,7 +253,7 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "Faker"
-version = "15.1.0"
+version = "15.1.1"
 description = "Faker is a Python package that generates fake data for you."
 category = "main"
 optional = false
@@ -261,7 +261,7 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 python-dateutil = ">=2.4"
-typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
+typing-extensions = {version = ">=3.10.0.1", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "filelock"
@@ -1096,7 +1096,7 @@ testing = ["httpx", "cryptography"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "cff177dff2eeac5a0c2474604e7f31e06d62a545f28b8c373fa42c2ef9c68dca"
+content-hash = "1c3bb338daf2ffebe637c93a4eaa6e79443104f995cf7c5b1b0694c296b5b9bb"
 
 [metadata.files]
 aiomcache = [
@@ -1129,14 +1129,18 @@ black = [
     {file = "black-22.10.0-1fixedarch-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6"},
     {file = "black-22.10.0-1fixedarch-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:2644b5d63633702bc2c5f3754b1b475378fbbfb481f62319388235d0cd104c2d"},
     {file = "black-22.10.0-1fixedarch-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4"},
+    {file = "black-22.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb"},
     {file = "black-22.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7"},
     {file = "black-22.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66"},
+    {file = "black-22.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae"},
     {file = "black-22.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b"},
     {file = "black-22.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d"},
     {file = "black-22.10.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e464456d24e23d11fced2bc8c47ef66d471f845c7b7a42f3bd77bf3d1789650"},
     {file = "black-22.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:9311e99228ae10023300ecac05be5a296f60d2fd10fff31cf5c1fa4ca4b1988d"},
+    {file = "black-22.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fba8a281e570adafb79f7755ac8721b6cf1bbf691186a287e990c7929c7692ff"},
     {file = "black-22.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:915ace4ff03fdfff953962fa672d44be269deb2eaf88499a0f8805221bc68c87"},
     {file = "black-22.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:444ebfb4e441254e87bad00c661fe32df9969b2bf224373a448d8aca2132b395"},
+    {file = "black-22.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0"},
     {file = "black-22.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383"},
     {file = "black-22.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de"},
     {file = "black-22.10.0-py3-none-any.whl", hash = "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458"},
@@ -1392,8 +1396,8 @@ exceptiongroup = [
     {file = "exceptiongroup-1.0.0rc9.tar.gz", hash = "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"},
 ]
 Faker = [
-    {file = "Faker-15.1.0-py3-none-any.whl", hash = "sha256:920eadd234a30b9603f50d75ee0a5f37fc064f90ef9207c6d3d2c691b786c480"},
-    {file = "Faker-15.1.0.tar.gz", hash = "sha256:bc2634053fd1fd82edd78e6b9bdcdcee19a0d9501227b6e0fc531c7b00b0e805"},
+    {file = "Faker-15.1.1-py3-none-any.whl", hash = "sha256:096c15e136adb365db24d8c3964fe26bfc68fe060c9385071a339f8c14e09c8a"},
+    {file = "Faker-15.1.1.tar.gz", hash = "sha256:a741b77f484215c3aab2604100669657189548f440fcb2ed0f8b7ee21c385629"},
 ]
 filelock = [
     {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
@@ -1806,6 +1810,13 @@ PyYAML = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ redis = {version = "*", optional = true, extras = ["hiredis"]}
 aiomcache = {version = "*", optional = true}
 
 [tool.poetry.group.dev.dependencies]
+aiomcache = "*"
 aiosqlite = "*"
 brotli = "*"
 cryptography = "*"
@@ -71,8 +72,7 @@ sqlalchemy = "*"
 structlog = "*"
 tortoise-orm = "*"
 tox = "*"
-aiomcache = "*"
-trio = "^0.22.0"
+trio = "*"
 
 [tool.poetry.extras]
 testing = ["httpx", "cryptography"]

--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -7,7 +7,6 @@ from typing import (
     Callable,
     Dict,
     List,
-    NoReturn,
     Optional,
     Type,
     Union,
@@ -574,11 +573,11 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         if return_annotation is Signature.empty:
             raise ImproperlyConfiguredException(
                 "A return value of a route handler function should be type annotated."
-                "If your function doesn't return a value or returns None, annotate it as returning 'NoReturn' or 'None' respectively."
+                "If your function doesn't return a value, annotate it as returning 'None'."
             )
         if (
             self.status_code < 200 or self.status_code in {HTTP_204_NO_CONTENT, HTTP_304_NOT_MODIFIED}
-        ) and return_annotation not in {NoReturn, None}:
+        ) and return_annotation is not None:
             raise ImproperlyConfiguredException(
                 "A status code 204, 304 or in the range below 200 does not support a response body."
                 "If the function should return a value, change the route handler status code to an appropriate value.",

--- a/starlite/response.py
+++ b/starlite/response.py
@@ -1,14 +1,4 @@
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Generic,
-    NoReturn,
-    Optional,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Dict, Generic, Optional, TypeVar, Union, cast
 
 import yaml
 from orjson import OPT_INDENT_2, OPT_OMIT_MICROSECONDS, OPT_SERIALIZE_NUMPY, dumps
@@ -83,10 +73,8 @@ class Response(StarletteResponse, Generic[T]):
             An encoded bytes string
         """
         try:
-            if (
-                content is None
-                or content is NoReturn
-                and (self.status_code < 100 or self.status_code in {HTTP_204_NO_CONTENT, HTTP_304_NOT_MODIFIED})
+            if content is None and (
+                self.status_code < 100 or self.status_code in {HTTP_204_NO_CONTENT, HTTP_304_NOT_MODIFIED}
             ):
                 return b""
             if self.media_type == MediaType.JSON:

--- a/tests/handlers/http/test_delete.py
+++ b/tests/handlers/http/test_delete.py
@@ -1,15 +1,10 @@
-from typing import Any, NoReturn
-
-import pytest
-
 from starlite import delete
 from starlite.testing import create_test_client
 
 
-@pytest.mark.parametrize("return_annotation", (None, NoReturn))
-def test_handler_return_none_and_204_status_response_empty(return_annotation: Any) -> None:
+def test_handler_return_none_and_204_status_response_empty() -> None:
     @delete(path="/")
-    async def route() -> return_annotation:  # type: ignore[valid-type]
+    async def route() -> None:
         return None
 
     with create_test_client(route_handlers=[route]) as client:


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

This PR resolves #585 