### PR TITLE
Add support for ConstrainedDate in OpenAPI schema generation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -650,7 +650,7 @@ email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydantic-factories"
-version = "1.9.0"
+version = "1.10.0"
 description = "Mock data generation for pydantic based models"
 category = "main"
 optional = false
@@ -1767,8 +1767,8 @@ pydantic = [
     {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 pydantic-factories = [
-    {file = "pydantic-factories-1.9.0.tar.gz", hash = "sha256:9344a570764ba1110f80d62f52c9c010cec5025577988c861cf64da1c1011658"},
-    {file = "pydantic_factories-1.9.0-py3-none-any.whl", hash = "sha256:d9b9a2d250ddac9e120b603f42ba0b90ee904d73d699499bd9381f3dcc291dd5"},
+    {file = "pydantic_factories-1.10.0-py3-none-any.whl", hash = "sha256:a59c7ed67e8f9b11de8b427b447295dac21cc6fea97fc6db58a5456c2c024446"},
+    {file = "pydantic_factories-1.10.0.tar.gz", hash = "sha256:42e8342d5b56fa7b38136d9e25f14bedd05b8484f274a86b4532f3174b5dc3fd"},
 ]
 pydantic-openapi-schema = [
     {file = "pydantic-openapi-schema-1.3.0.tar.gz", hash = "sha256:2aed6913080f1dae94234e00d0905504c6aab65ab6afe246ed7aa98da989f69e"},

--- a/tests/openapi/utils.py
+++ b/tests/openapi/utils.py
@@ -1,9 +1,18 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import conbytes, condecimal, confloat, conint, conlist, conset, constr
+from pydantic import (
+    conbytes,
+    condate,
+    condecimal,
+    confloat,
+    conint,
+    conlist,
+    conset,
+    constr,
+)
 from pydantic_openapi_schema.v3_1_0.example import Example
 
 from starlite import (
@@ -158,4 +167,10 @@ constrained_collection = [
     conlist(int, min_items=1, max_items=10),
     conset(int, min_items=1),
     conset(int, min_items=1, max_items=10),
+]
+constrained_dates = [
+    condate(gt=date.today() - timedelta(days=10), lt=date.today() + timedelta(days=100)),
+    condate(ge=date.today() - timedelta(days=10), le=date.today() + timedelta(days=100)),
+    condate(gt=date.today() - timedelta(days=10), lt=date.today() + timedelta(days=100)),
+    condate(ge=date.today() - timedelta(days=10), le=date.today() + timedelta(days=100)),
 ]


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

This PR adds support for `ConstrainedDate` in OA schema generation