### PR TITLE
Add url_for_static_asset to app and templates

### DIFF
--- a/docs/reference/1-app.md
+++ b/docs/reference/1-app.md
@@ -5,10 +5,11 @@
         members:
             - __init__
             - __call__
-            - register
             - get_handler_index_by_name
+            - register
             - route_handler_method_view
             - route_reverse
+            - url_for_static_asset
 
 ::: starlite.app.HandlerIndex
     options:

--- a/docs/reference/config/6-static-files-config.md
+++ b/docs/reference/config/6-static-files-config.md
@@ -6,3 +6,4 @@
             - path
             - directories
             - html_mode
+            - name

--- a/docs/reference/connection/0-asgi-connection.md
+++ b/docs/reference/connection/0-asgi-connection.md
@@ -30,4 +30,5 @@
             - state
             - url
             - url_for
+            - url_for_static_asset
             - user

--- a/docs/usage/0-the-starlite-app/3-static-files.md
+++ b/docs/usage/0-the-starlite-app/3-static-files.md
@@ -1,12 +1,12 @@
 # Static Files
 
 Static files are served by the app from predefined locations. To configure static file serving, either pass an
-instance of `starlite.config.StaticFilesConfig` or a list thereof to the Starlite constructor using
-the `static_files_config` kwarg.
+instance of [`starlite.config.StaticFilesConfig`][starlite.config.static_files.StaticFilesConfig] or a list
+thereof to the Starlite constructor using the `static_files_config` kwarg.
 
-For example, lets say our Starlite app is going to serve **regular files** from the "my_app/static" folder and **html
-documents** from the "my_app/html" folder, and we would like to serve the **static files** on the "/files" path,
-and the **html files** on the "/html" path:
+For example, lets say our Starlite app is going to serve **regular files** from the `my_app/static` folder and **html
+documents** from the `my_app/html` folder, and we would like to serve the **static files** on the `/files` path,
+and the **html files** on the `/html` path:
 
 ```python
 from starlite import Starlite, StaticFilesConfig
@@ -27,3 +27,23 @@ be sent over, otherwise a **404 response** will be sent.
 If `html_mode` is enabled and no specific file is requested, the application will fall back to serving `index.html`. If
 no file is found the application will look for a `404.html` file in order to render a response, otherwise a 404
 `NotFoundException` will be returned.
+
+You can provide `name` parameter to `StaticFilesConfig` to identify given config and generate links to files in folders
+belonging to that config. `name` should be a unique string across all static configs and
+[route handlers](2-route-handlers/4-route-handler-indexing.md)
+
+```python
+from starlite import Starlite, StaticFilesConfig
+
+app = Starlite(
+    route_handlers=[...],
+    static_files_config=[
+        StaticFilesConfig(
+            directories=["static"], path="/some_folder/static/path", name="static"
+        ),
+    ],
+)
+
+url_path = app.url_for_static_asset("static", "file.pdf")
+# /some_folder/static/path/file.pdf
+```

--- a/docs/usage/16-templating/0-template-engines.md
+++ b/docs/usage/16-templating/0-template-engines.md
@@ -1,7 +1,7 @@
 # Template Engines
 
-Starlite has built-in support for both [jinja2](https://jinja.palletsprojects.com/en/3.0.x/)
-and [mako](https://www.makotemplates.org/) as template engines, and it also offers a simple way to add additional
+Starlite has built-in support for both [Jinja2](https://jinja.palletsprojects.com/en/3.0.x/)
+and [Mako](https://www.makotemplates.org/) as template engines, and it also offers a simple way to add additional
 template engines.
 
 ## Registering a Template Engine
@@ -30,8 +30,8 @@ app = Starlite(
 )
 ```
 
-The kwarg `directory` passed to `TemplateConfig` is either a directory or list of directories to use for loading
-templates.
+The kwarg `directory` passed to [`TemplateConfig`][starlite.config.template.TemplateConfig] is either a directory or
+list of directories to use for loading templates.
 
 ## Template Responses
 

--- a/docs/usage/16-templating/2-template-functions.md
+++ b/docs/usage/16-templating/2-template-functions.md
@@ -15,6 +15,11 @@ This function returns the request's unique `csrf_token`. You can use this if you
 non-HTML based templates, or insert it into HTML templates not using a hidden input field but by some other means,
 for example inside a special `<meta>` tag.
 
+## The `url_for_static_asset` Callable
+
+URLs for static files can be created using the `url_for_static_asset` function. It's signature and behaviour are identical to
+[app.url_for_static_asset][starlite.app.Starlite.url_for_static_asset].
+
 ## Registering Template Callables
 
 The Starlite [TemplateEngineProtocol][starlite.template.base.TemplateEngineProtocol] specifies the method

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Type, Union, c
 from starlette.middleware import Middleware as StarletteMiddleware
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware.trustedhost import TrustedHostMiddleware
+from starlette.staticfiles import StaticFiles
 from typing_extensions import TypedDict
 
 from starlite.asgi import (
@@ -380,7 +381,7 @@ class Starlite(Router):
             self.static_files_config if isinstance(self.static_files_config, list) else [self.static_files_config]
         ):
             self._static_paths.add(static_config.path)
-            self.register(asgi(path=static_config.path)(static_config.to_static_files_app()))
+            self.register(asgi(path=static_config.path, name=static_config.name)(static_config.to_static_files_app()))
 
         self.asgi_router = StarliteASGIRouter(on_shutdown=self.on_shutdown, on_startup=self.on_startup, app=self)
         self.asgi_handler = self._create_asgi_handler()
@@ -477,8 +478,8 @@ class Starlite(Router):
         return HandlerIndex(handler=handler, paths=paths, identifier=identifier)
 
     def route_reverse(self, name: str, **path_parameters: Any) -> str:
-        """Receives a route handler name, path parameter values and returns an
-        optional url path to the handler with filled path parameters.
+        """Receives a route handler name, path parameter values and returns url
+        path to the handler with filled path parameters.
 
         Examples:
             ```python
@@ -539,6 +540,42 @@ class Starlite(Router):
                 output.append(component)
 
         return join_paths(output)
+
+    def url_for_static_asset(self, name: str, file_path: str) -> str:
+        """Receives a static files handler name, an asset file path and returns
+        resolved url path to the asset.
+
+        Examples:
+            ```python
+            from starlite import Starlite, StaticFilesConfig
+
+            app = Starlite(
+                static_files_config=StaticFilesConfig(directories=["css"], path="/static/css")
+            )
+
+            path = app.url_for_static_asset("css", "main.css")
+
+            # /static/css/main.css
+            ```
+        Args:
+            name: A static handler unique name.
+            file_path: a string containing path to an asset.
+
+        Raises:
+            NoRouteMatchFoundException: If static files handler with 'name' does not exist.
+
+        Returns:
+            A url path to the asset.
+        """
+        handler_index = self.get_handler_index_by_name(name)
+        if handler_index is None:
+            raise NoRouteMatchFoundException(f"Static handler {name} can not be found")
+
+        handler_fn = cast("AnyCallable", handler_index["handler"].fn)
+        if not isinstance(handler_fn, StaticFiles):
+            raise NoRouteMatchFoundException(f"Handler with name {name} is not a static files handler")
+
+        return join_paths([handler_index["paths"][0], file_path])  # type: ignore [unreachable]
 
     @property
     def route_handler_method_view(self) -> Dict[str, List[str]]:

--- a/starlite/config/static_files.py
+++ b/starlite/config/static_files.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, List, cast
+from typing import TYPE_CHECKING, List, Optional, cast
 
 from pydantic import BaseModel, DirectoryPath, constr, validator
 from starlette.staticfiles import StaticFiles
@@ -29,6 +29,10 @@ class StaticFilesConfig(BaseModel):
     html_mode: bool = False
     """
         Flag dictating whether or not serving html. If true, the default file will be 'index.html'.
+    """
+    name: Optional[str] = None
+    """
+        An optional string identifying the static files handler.
     """
 
     @validator("path", always=True)

--- a/starlite/connection/base.py
+++ b/starlite/connection/base.py
@@ -302,3 +302,22 @@ class ASGIConnection(Generic[Handler, User, Auth]):
         url_path = starlite_instance.route_reverse(name, **path_parameters)
 
         return URLPath(url_path).make_absolute_url(self.base_url)
+
+    def url_for_static_asset(self, name: str, file_path: str) -> str:
+        """Receives a static files handler name, an asset file path and returns
+        resolved absolute url to the asset.
+
+        Args:
+            name: A static handler unique name.
+            file_path: a string containing path to an asset.
+
+        Raises:
+            NoRouteMatchFoundException: If static files handler with 'name' does not exist.
+
+        Returns:
+            A string representing absolute url to the asset.
+        """
+        starlite_instance = self.scope["app"]
+        url_path = starlite_instance.url_for_static_asset(name, file_path)
+
+        return URLPath(url_path).make_absolute_url(self.base_url)

--- a/starlite/template/base.py
+++ b/starlite/template/base.py
@@ -22,7 +22,7 @@ def url_for(context: TemplateContext, route_name: str, **path_parameters: Any) -
         **path_parameters: Actual values for path parameters in the route.
 
     Raises:
-        NoRouteMatchFoundException: If path parameters are missing in **path_parameters or have wrong type.
+        NoRouteMatchFoundException: If 'route_name' does not exist, path parameters are missing in **path_parameters or have wrong type.
 
     Returns:
         A fully formatted url path.
@@ -45,6 +45,23 @@ def csrf_token(context: TemplateContext) -> str:
         A CSRF token if the app level `csrf_config` is set, otherwise an empty string.
     """
     return context["request"].scope.get("_csrf_token", "")  # type: ignore
+
+
+def url_for_static_asset(context: TemplateContext, name: str, file_path: str) -> str:
+    """Wrapper for [url_for_static_asset][starlite.app.url_for_static_asset] to
+    be used in templates.
+
+    Args:
+        name: A static handler unique name.
+        file_path: a string containing path to an asset.
+
+    Raises:
+        NoRouteMatchFoundException: If static files handler with 'name' does not exist.
+
+    Returns:
+        A url path to the asset.
+    """
+    return context["request"].app.url_for_static_asset(name, file_path)
 
 
 class TemplateProtocol(Protocol):  # pragma: no cover

--- a/starlite/template/jinja.py
+++ b/starlite/template/jinja.py
@@ -1,7 +1,12 @@
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Union
 
 from starlite.exceptions import MissingDependencyException, TemplateNotFoundException
-from starlite.template.base import TemplateEngineProtocol, csrf_token, url_for
+from starlite.template.base import (
+    TemplateEngineProtocol,
+    csrf_token,
+    url_for,
+    url_for_static_asset,
+)
 
 try:
     from jinja2 import Environment, FileSystemLoader
@@ -27,8 +32,9 @@ class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate"]):
         super().__init__(directory=directory)
         loader = FileSystemLoader(searchpath=directory)
         self.engine = Environment(loader=loader, autoescape=True)
-        self.register_template_callable(key="url_for", template_callable=url_for)  # type: ignore
+        self.register_template_callable(key="url_for_static_asset", template_callable=url_for_static_asset)  # type: ignore
         self.register_template_callable(key="csrf_token", template_callable=csrf_token)  # type: ignore
+        self.register_template_callable(key="url_for", template_callable=url_for)  # type: ignore
 
     def get_template(self, template_name: str) -> "JinjaTemplate":
         """

--- a/starlite/template/mako.py
+++ b/starlite/template/mako.py
@@ -7,6 +7,7 @@ from starlite.template.base import (
     TemplateProtocol,
     csrf_token,
     url_for,
+    url_for_static_asset,
 )
 
 try:
@@ -33,6 +34,7 @@ class MakoTemplate(TemplateProtocol):
         for callable_key, template_callable in self.template_callables:
             kwargs_copy = {**kwargs}
             kwargs[callable_key] = partial(template_callable, kwargs_copy)
+
         return str(self.template.render(*args, **kwargs))
 
 
@@ -46,8 +48,9 @@ class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate]):
         super().__init__(directory=directory)
         self.engine = TemplateLookup(directories=directory if isinstance(directory, (list, tuple)) else [directory])
         self._template_callables: List[Tuple[str, Callable[[Dict[str, Any]], Any]]] = []
-        self.register_template_callable(key="url_for", template_callable=url_for)  # type: ignore
+        self.register_template_callable(key="url_for_static_asset", template_callable=url_for_static_asset)  # type: ignore
         self.register_template_callable(key="csrf_token", template_callable=csrf_token)  # type: ignore
+        self.register_template_callable(key="url_for", template_callable=url_for)  # type: ignore
 
     def get_template(self, template_name: str) -> MakoTemplate:
         """

--- a/tests/routing/test_asset_url_path.py
+++ b/tests/routing/test_asset_url_path.py
@@ -1,0 +1,41 @@
+from typing import TYPE_CHECKING
+
+import pytest
+
+from starlite import NoRouteMatchFoundException, Starlite, StaticFilesConfig, get
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_url_for_static_asset(tmp_path: "Path") -> None:
+    app = Starlite(
+        route_handlers=[],
+        static_files_config=StaticFilesConfig(path="/static/path", directories=[tmp_path], name="asset"),
+    )
+    url_path = app.url_for_static_asset("asset", "abc/def.css")
+    assert url_path == "/static/path/abc/def.css"
+
+
+def test_url_for_static_asset_doesnt_work_with_http_handler_name(tmp_path: "Path") -> None:
+    @get("/handler", name="handler")
+    def handler() -> None:
+        pass
+
+    app = Starlite(
+        route_handlers=[handler],
+        static_files_config=StaticFilesConfig(path="/static/path", directories=[tmp_path], name="asset"),
+    )
+
+    with pytest.raises(NoRouteMatchFoundException):
+        app.url_for_static_asset("handler", "abc/def.css")
+
+
+def test_url_for_static_asset_validates_name(tmp_path: "Path") -> None:
+    app = Starlite(
+        route_handlers=[],
+        static_files_config=StaticFilesConfig(path="/static/path", directories=[tmp_path], name="asset"),
+    )
+
+    with pytest.raises(NoRouteMatchFoundException):
+        app.url_for_static_asset("non-existing-name", "abc/def.css")

--- a/tests/routing/test_route_indexing.py
+++ b/tests/routing/test_route_indexing.py
@@ -1,4 +1,4 @@
-from typing import Any, Type
+from typing import TYPE_CHECKING, Any, Type
 
 import pytest
 
@@ -8,6 +8,7 @@ from starlite import (
     ImproperlyConfiguredException,
     Router,
     Starlite,
+    StaticFilesConfig,
     asgi,
     delete,
     get,
@@ -16,6 +17,9 @@ from starlite import (
     put,
     websocket,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.mark.parametrize("decorator", [get, post, patch, put, delete])
@@ -115,7 +119,7 @@ def test_indexes_handlers_with_multiple_paths(decorator: Type[HTTPRouteHandler])
     assert handler_index["handler"] == handler_two
 
 
-def test_indexing_validation() -> None:
+def test_indexing_validation(tmp_path: "Path") -> None:
     @get("/abc", name="same-name")
     def handler_one() -> None:
         pass
@@ -126,3 +130,9 @@ def test_indexing_validation() -> None:
 
     with pytest.raises(ImproperlyConfiguredException):
         Starlite(route_handlers=[handler_one, handler_two])
+
+    with pytest.raises(ImproperlyConfiguredException):
+        Starlite(
+            route_handlers=[handler_one],
+            static_files_config=StaticFilesConfig(path="/static", directories=[tmp_path], name="same-name"),
+        )


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

This PR adds:
* `name` kwarg to `StaticFilesConfig` which has the same behavior as `name` kwarg in route handlers;
* `app.asset_url_path` to generate url paths to files under given `StaticFiles`.
* `request.asset_url` to generate absolute urls to files.
* `asset_url_path` function for templates

Sample piece of code

```python
from starlite import Starlite, StaticFilesConfig

app = Starlite(
    route_handlers=[...],
    static_files_config=[
        StaticFilesConfig(
            directories=["static"], path="/complex/static/path", name="static"
        ),
    ],
)

url_path = app.asset_url_path("static", "file.pdf")
# /complex/static/path/file.pdf
```

First I was thinking about extending `app.route_reverse` function since its internal behavior is similar but decided to create a separate function because `route_reverse` interface would have to be extended making it harder to use in templates. Another reason is that I think generating static URLs later should be delegated to `StaticFiles` and its descendants - this way we can easily work with cloud storage like S3 to store large files and make them accessible only to selected users via API (quite cumbersome to implement with nginx).

At the moment implementation is very basic. It does limited checks and simply concatenates static path and passed file path. More complicated checks e.g. file existence can be implemented in `StaticFiles` descendants later; right now we can just establish interfaces in functions facing the user code.

I am not sure about the name. Maybe `asset_url_path` can be changed to something more short and concise? 