### PR TITLE
QueueListenerHandler log to stderr by default.

### DIFF
--- a/starlite/config/logging.py
+++ b/starlite/config/logging.py
@@ -132,7 +132,7 @@ class LoggingConfig(BaseLoggingConfig, BaseModel):
     }
     """A dict in which each key is a logger name and each value is a dict describing how to configure the corresponding Logger instance."""
     root: Dict[str, Union[Dict[str, Any], List[Any], str]] = {
-        "handlers": ["queue_listener", "console"],
+        "handlers": ["queue_listener"],
         "level": "INFO",
     }
     """This will be the configuration for the root logger. Processing of the configuration will be as for any logger,

--- a/starlite/logging/picologging.py
+++ b/starlite/logging/picologging.py
@@ -1,5 +1,4 @@
 import atexit
-from io import StringIO
 from logging import StreamHandler
 from queue import Queue
 from typing import Any, List, Optional
@@ -28,7 +27,7 @@ class QueueListenerHandler(QueueHandler):  # type: ignore[misc]
         if handlers:
             handlers = resolve_handlers(handlers)
         else:
-            handlers = [StreamHandler(StringIO())]
+            handlers = [StreamHandler()]
         self.listener = QueueListener(self.queue, *handlers)
         self.listener.start()
 

--- a/starlite/logging/standard.py
+++ b/starlite/logging/standard.py
@@ -1,5 +1,4 @@
 import atexit
-from io import StringIO
 from logging import StreamHandler
 from logging.handlers import QueueHandler, QueueListener
 from queue import Queue
@@ -20,7 +19,7 @@ class QueueListenerHandler(QueueHandler):
         if handlers:
             handlers = resolve_handlers(handlers)
         else:
-            handlers = [StreamHandler(StringIO())]
+            handlers = [StreamHandler()]
         self.listener = QueueListener(self.queue, *handlers)
         self.listener.start()
 


### PR DESCRIPTION
Removes logging to `StringIO` and removes `console` handler as handler to `root` logger.

Closes #593

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
