### PR TITLE
Fix signature model for dependency with skip_validaiton and default.

### DIFF
--- a/starlite/signature.py
+++ b/starlite/signature.py
@@ -348,8 +348,10 @@ class SignatureModelFactory:
                 self.collect_dependency_names(parameter)
                 self.set_field_default(parameter)
                 if self.should_skip_parameter_validation(parameter):
-                    # pydantic has issues with none-pydantic classes that receive generics
-                    self.field_definitions[parameter.name] = (Any, ...)
+                    if is_dependency_field(parameter.default):
+                        self.field_definitions[parameter.name] = (Any, parameter.default.default)
+                    else:
+                        self.field_definitions[parameter.name] = (Any, ...)
                     continue
                 if ModelFactory.is_constrained_field(parameter.default):
                     self.field_definitions[parameter.name] = (parameter.default, ...)

--- a/starlite/utils/dependency.py
+++ b/starlite/utils/dependency.py
@@ -1,11 +1,14 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic.fields import FieldInfo
 
 from starlite.constants import EXTRA_KEY_IS_DEPENDENCY, EXTRA_KEY_SKIP_VALIDATION
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeGuard
 
-def is_dependency_field(val: Any) -> bool:
+
+def is_dependency_field(val: Any) -> "TypeGuard[FieldInfo]":
     """Determine if a value is a `FieldInfo` instance created via the
     `Dependency()` function.
 
@@ -29,4 +32,4 @@ def should_skip_dependency_validation(val: Any) -> bool:
         `True` if `val` is `FieldInfo` created by [`Dependency()`][starlite.params.Dependency] function and
         `skip_validation=True` is set.
     """
-    return is_dependency_field(val) and val.extra.get(EXTRA_KEY_SKIP_VALIDATION)
+    return is_dependency_field(val) and bool(val.extra.get(EXTRA_KEY_SKIP_VALIDATION))

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -94,3 +94,14 @@ def test_dependency_skip_validation() -> None:
         skipped_resp = client.get("/skipped")
         assert skipped_resp.status_code == HTTP_200_OK
         assert skipped_resp.json() == {"value": "str"}
+
+
+def test_dependency_skip_validation_with_default_value() -> None:
+    @get("/skipped")
+    def skipped(value: int = Dependency(default=1, skip_validation=True)) -> Dict[str, int]:
+        return {"value": value}
+
+    with create_test_client(route_handlers=[skipped]) as client:
+        skipped_resp = client.get("/skipped")
+        assert skipped_resp.status_code == HTTP_200_OK
+        assert skipped_resp.json() == {"value": 1}


### PR DESCRIPTION
Where a parameter is marked as a dependency with `Dependency` function and also provided a default value, the handler was receiving `Ellipsis` as the value for the parameter.

This change ensures that the signature model respects the default value provided for the parameter.

Closes #592

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
