### PR TITLE
Fix #628

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[1.29.1]
+
+- fix `SessionMiddleware` handling non-session cookies with `session` anywhere in their name
+
 [1.29.0]
 
 - Adds native support for `TypedDict` as data type.


### PR DESCRIPTION
Fixes #628 by only attempting to read data from cookies if their name matches the pattern used by the middleware for cookie names (`<key>` or `<key>-<n>` if multiple cookies are being used).

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

