### PR TITLE
Fix admonition for dark theme in docs

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -143,7 +143,7 @@ body {
   /* Typeset `table` color shades */
   --md-typeset-table-color: hsla(0, 0%, 0%, 0.12);
 
-  /* Admonition color shades *
+  /* Admonition color shades */
   --md-admonition-fg-color:          var(--md-default-fg-color);
   --md-admonition-bg-color:          var(--md-default-bg-color);
 


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

I am using dark theme for docs and seeing admonition blocks (notes/hints) is simply painful for my eyes :-)

Before
![image](https://user-images.githubusercontent.com/153191/197314791-34b4ec8f-d26c-49c5-8fa3-8137318a648f.png)

After
![image](https://user-images.githubusercontent.com/153191/197314773-5a9e12b3-5a5e-4479-9866-5575e14dedf7.png)
