### PR TITLE
Replace background tasks

### DIFF
--- a/docs/reference/utils/0-predicate-utils.md
+++ b/docs/reference/utils/0-predicate-utils.md
@@ -4,8 +4,6 @@
 
 ::: starlite.utils.predicates.T
 
-::: starlite.utils.predicates.is_async_callable
-
 ::: starlite.utils.predicates.is_class_and_subclass
 
 ::: starlite.utils.predicates.is_dataclass_class_or_instance_typeguard

--- a/docs/reference/utils/1-sync-utils.md
+++ b/docs/reference/utils/1-sync-utils.md
@@ -4,6 +4,8 @@
 
 ::: starlite.utils.sync.T
 
+::: starlite.utils.is_async_callable
+
 ::: starlite.utils.AsyncCallable
     options:
         members:

--- a/docs/usage/5-responses/11-background-tasks.md
+++ b/docs/usage/5-responses/11-background-tasks.md
@@ -1,10 +1,10 @@
 # Background Tasks
 
 All Starlite responses and response containers (e.g. `File`, `Template` etc.) allow passing in a `background_task`
-kwarg. This kwarg accepts either an instance of [BackgroundTask][starlite.datastructure.background_tasks.BackgroundTask]
+kwarg. This kwarg accepts either an instance of [BackgroundTask][starlite.datastructures.background_tasks.BackgroundTask]
 or
-an instance of [BackgroundTasks][starlite.datastructure.background_tasks.BackgroundTasks], which wraps an iterable
-of [BackgroundTask][starlite.datastructure.background_tasks.BackgroundTask] instances.
+an instance of [BackgroundTasks][starlite.datastructures.background_tasks.BackgroundTasks], which wraps an iterable
+of [BackgroundTask][starlite.datastructures.background_tasks.BackgroundTask] instances.
 
 A background task is a sync or async callable (function, method or class that implements the `__call__` dunder method)
 that will be called after the response finishes sending the data.
@@ -34,15 +34,15 @@ When the `greeter` handler is called, the logging task will be called with any `
 !!! note
 In the above example `"greeter"` is an arg and `message="was called"` is a kwarg. The function signature of
 `logging_task` allows for this, so this should pose no problem. Starlite uses [ParamSpec][typing.ParamSpec] to ensure
-that a [BackgroundTask][starlite.datastructure.background_tasks.BackgroundTask] is properly typed, so will get
+that a [BackgroundTask][starlite.datastructures.background_tasks.BackgroundTask] is properly typed, so will get
 type checking for any passed in args and kwargs.
 
 ## Executing Multiple BackgroundTasks
 
-You can also use the [BackgroundTasks][starlite.datastructure.background_tasks.BackgroundTasks] class instead, and pass
-to it an iterable (list, tuple etc.) of [BackgroundTask][starlite.datastructure.background_tasks.BackgroundTask]
+You can also use the [BackgroundTasks][starlite.datastructures.background_tasks.BackgroundTasks] class instead, and pass
+to it an iterable (list, tuple etc.) of [BackgroundTask][starlite.datastructures.background_tasks.BackgroundTask]
 instances. This class accepts one optional kwargs aside from the tasks - `run_in_task_group`, which is a boolean flag
-that defaults to `False`. If you set this value to `True` than the tasks will be ran concurrently, using
+that defaults to `False`. If you set this value to `True` than the tasks will run concurrently, using
 an [anyio.task_group](https://anyio.readthedocs.io/en/stable/tasks.html).
 
 !!! note

--- a/docs/usage/5-responses/11-background-tasks.md
+++ b/docs/usage/5-responses/11-background-tasks.md
@@ -1,0 +1,49 @@
+# Background Tasks
+
+All Starlite responses and response containers (e.g. `File`, `Template` etc.) allow passing in a `background_task`
+kwarg. This kwarg accepts either an instance of [BackgroundTask][starlite.datastructure.background_tasks.BackgroundTask]
+or
+an instance of [BackgroundTasks][starlite.datastructure.background_tasks.BackgroundTasks], which wraps an iterable
+of [BackgroundTask][starlite.datastructure.background_tasks.BackgroundTask] instances.
+
+A background task is a sync or async callable (function, method or class that implements the `__call__` dunder method)
+that will be called after the response finishes sending the data.
+
+Thus, in the following example the passed in background task will be executed after the response sends:
+
+```python
+import logging
+
+from starlite import BackgroundTask, get
+
+logger = logging.getLogger(__name__)
+
+
+async def logging_task(identifier: str, message: str) -> None:
+    logger.info(f"{identifier}: {message}")
+
+
+@get("/", background=BackgroundTask(logging_task, "greeter", message="was called"))
+def greeter() -> dict[str, str]:
+    return {"hello": "world"}
+```
+
+When the `greeter` handler is called, the logging task will be called with any `*args` and `**kwargs` passed into the
+`BackgroundTask`.
+
+!!! note
+In the above example `"greeter"` is an arg and `message="was called"` is a kwarg. The function signature of
+`logging_task` allows for this, so this should pose no problem. Starlite uses [ParamSpec][typing.ParamSpec] to ensure
+that a [BackgroundTask][starlite.datastructure.background_tasks.BackgroundTask] is properly typed, so will get
+type checking for any passed in args and kwargs.
+
+## Executing Multiple BackgroundTasks
+
+You can also use the [BackgroundTasks][starlite.datastructure.background_tasks.BackgroundTasks] class instead, and pass
+to it an iterable (list, tuple etc.) of [BackgroundTask][starlite.datastructure.background_tasks.BackgroundTask]
+instances. This class accepts one optional kwargs aside from the tasks - `run_in_task_group`, which is a boolean flag
+that defaults to `False`. If you set this value to `True` than the tasks will be ran concurrently, using
+an [anyio.task_group](https://anyio.readthedocs.io/en/stable/tasks.html).
+
+!!! note
+    Setting `run_in_task_group` to `True` will not preserve execution order.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,7 +77,7 @@ nav:
           - usage/4-request-data/1-the-body-function.md
           - usage/4-request-data/2-url-encoded-form-data.md
           - usage/4-request-data/3-multipart-form-data.md
-      - Returning Responses:
+      - Responses:
           - usage/5-responses/0-responses-intro.md
           - usage/5-responses/1-media-type.md
           - usage/5-responses/2-status-codes.md
@@ -89,6 +89,7 @@ nav:
           - usage/5-responses/8-streaming-responses.md
           - usage/5-responses/9-template-responses.md
           - usage/5-responses/10-custom-responses.md
+          - usage/5-responses/11-background-tasks.md
       - Dependency Injection:
           - usage/6-dependency-injection/0-dependency-injection-intro.md
           - usage/6-dependency-injection/1-dependency-kwargs.md

--- a/starlite/datastructures/background_tasks.py
+++ b/starlite/datastructures/background_tasks.py
@@ -45,8 +45,9 @@ class BackgroundTasks:
         tasks are called once a Response finishes.
         Args:
             tasks: An iterable of [BackgroundTask][starlite.datastructures.BackgroundTask] instances.
-            run_in_task_group: If true the tasks will be executed in parallel using an 'TaskGroup',
-                which can increase performance. Enable this option if the order of execution of the tasks does not matter.
+            run_in_task_group: If you set this value to `True` than the tasks will run concurrently, using
+                an [anyio.task_group](https://anyio.readthedocs.io/en/stable/tasks.html). Note: this will
+                not preserve execution order.
         """
         self.tasks = tasks
         self.run_in_task_group = run_in_task_group

--- a/starlite/datastructures/provide.py
+++ b/starlite/datastructures/provide.py
@@ -1,8 +1,7 @@
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 from starlite.types import Empty
-from starlite.utils.predicates import is_async_callable
-from starlite.utils.sync import AsyncCallable
+from starlite.utils.sync import AsyncCallable, is_async_callable
 
 if TYPE_CHECKING:
     from typing import Type

--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -56,8 +56,8 @@ from starlite.types import (
     ResponseHeadersMap,
     ResponseType,
 )
-from starlite.utils import unique
-from starlite.utils.predicates import is_async_callable, is_class_and_subclass
+from starlite.utils import is_async_callable, unique
+from starlite.utils.predicates import is_class_and_subclass
 from starlite.utils.sync import AsyncCallable
 
 if TYPE_CHECKING:

--- a/starlite/utils/__init__.py
+++ b/starlite/utils/__init__.py
@@ -14,7 +14,6 @@ from .model import (
 )
 from .path import join_paths, normalize_path
 from .predicates import (
-    is_async_callable,
     is_class_and_subclass,
     is_dataclass_class_or_instance_typeguard,
     is_dataclass_class_typeguard,
@@ -24,7 +23,12 @@ from .predicates import (
 from .scope import get_serializer_from_scope
 from .sequence import find_index, unique
 from .serialization import default_serializer
-from .sync import AsyncCallable, as_async_callable_list, async_partial
+from .sync import (
+    AsyncCallable,
+    as_async_callable_list,
+    async_partial,
+    is_async_callable,
+)
 
 __all__ = (
     "AsyncCallable",

--- a/starlite/utils/predicates.py
+++ b/starlite/utils/predicates.py
@@ -1,9 +1,7 @@
-import asyncio
-import functools
 import sys
 from dataclasses import is_dataclass
 from inspect import isclass
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Type, TypeVar, Union
 
 from typing_extensions import ParamSpec, TypeGuard, get_args, get_origin, is_typeddict
 
@@ -26,22 +24,6 @@ if TYPE_CHECKING:
 
 P = ParamSpec("P")
 T = TypeVar("T")
-
-
-def is_async_callable(value: Callable[P, T]) -> TypeGuard[Callable[P, Awaitable[T]]]:
-    """Extends `asyncio.iscoroutinefunction()` to additionally detect async
-    `partial` objects and class instances with `async def __call__()` defined.
-
-    Args:
-        value: Any
-
-    Returns:
-        Bool determining if type of `value` is an awaitable.
-    """
-    while isinstance(value, functools.partial):
-        value = value.func  # type: ignore[unreachable]
-
-    return asyncio.iscoroutinefunction(value) or (callable(value) and asyncio.iscoroutinefunction(value.__call__))  # type: ignore[operator]
 
 
 def is_class_and_subclass(value: Any, t_type: Type[T]) -> TypeGuard[Type[T]]:

--- a/tests/datastructures/test_background_task.py
+++ b/tests/datastructures/test_background_task.py
@@ -43,4 +43,4 @@ async def test_background_tasks_task_group_execution() -> None:
     with create_test_client(handler) as client:
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
-        assert values == [1, 2, 3, 4, 5, 6]
+        assert set(values) == {1, 2, 3, 4, 5, 6}

--- a/tests/datastructures/test_background_task.py
+++ b/tests/datastructures/test_background_task.py
@@ -5,7 +5,7 @@ from starlite.status_codes import HTTP_200_OK
 from starlite.testing import create_test_client
 
 
-async def test_background_tasks() -> None:
+async def test_background_tasks_regular_execution() -> None:
     values: List[int] = []
 
     def extend_values(values_to_extend: List[int]) -> None:
@@ -13,6 +13,27 @@ async def test_background_tasks() -> None:
 
     tasks = BackgroundTasks(
         [BackgroundTask(extend_values, [1, 2, 3]), BackgroundTask(extend_values, values_to_extend=[4, 5, 6])]
+    )
+
+    @get("/", background=tasks)
+    def handler() -> None:
+        return None
+
+    with create_test_client(handler) as client:
+        response = client.get("/")
+        assert response.status_code == HTTP_200_OK
+        assert values == [1, 2, 3, 4, 5, 6]
+
+
+async def test_background_tasks_task_group_execution() -> None:
+    values: List[int] = []
+
+    def extend_values(values_to_extend: List[int]) -> None:
+        values.extend(values_to_extend)
+
+    tasks = BackgroundTasks(
+        [BackgroundTask(extend_values, [1, 2, 3]), BackgroundTask(extend_values, values_to_extend=[4, 5, 6])],
+        run_in_task_group=True,
     )
 
     @get("/", background=tasks)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ from typing import Callable
 
 import pytest
 
-from starlite.utils.predicates import is_async_callable
+from starlite.utils import is_async_callable
 
 
 class AsyncTestCallable:


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

This PR replaces `BackgroundTask` and `BackgroundTasks` with our own implementation, including support for running in task group. It additionally moves the `AsyncCallable` in the datastructures package from utils, due to circular import issues. 

Relates to #634 and #612 