### PR TITLE
Issue #611 - Fix randomly failing rate limit test + bugfix

### DIFF
--- a/starlite/middleware/rate_limit.py
+++ b/starlite/middleware/rate_limit.py
@@ -182,7 +182,7 @@ class RateLimitMiddleware:
             None
         """
         cache_object.history = [int(time()), *cache_object.history]
-        await self.cache.set(key, dumps(cache_object))
+        await self.cache.set(key, dumps(cache_object), expiration=DURATION_VALUES[self.unit])
 
     async def should_check_request(self, request: "Request[Any, Any]") -> bool:
         """

--- a/tests/middleware/test_rate_limit.py
+++ b/tests/middleware/test_rate_limit.py
@@ -2,6 +2,7 @@ from time import time
 from typing import Any
 
 import pytest
+from freezegun import freeze_time
 from orjson import dumps, loads
 from starlette.status import HTTP_200_OK, HTTP_429_TOO_MANY_REQUESTS
 
@@ -24,7 +25,9 @@ async def test_rate_limiting(unit: DurationUnit) -> None:
     config = RateLimitConfig(rate_limit=(unit, 1))
     cache_key = "RateLimitMiddleware::testclient"
 
-    with create_test_client(route_handlers=[handler], middleware=[config.middleware]) as client:
+    with freeze_time() as frozen_time, create_test_client(
+        route_handlers=[handler], middleware=[config.middleware]
+    ) as client:
         cache = client.app.cache
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
@@ -37,6 +40,8 @@ async def test_rate_limiting(unit: DurationUnit) -> None:
         assert response.headers.get(config.rate_limit_remaining_header_key) == "0"
         assert response.headers.get(config.rate_limit_reset_header_key) == str(int(time()) - cache_object.reset)
 
+        frozen_time.tick(DURATION_VALUES[unit] - 1)
+
         response = client.get("/")
         assert response.status_code == HTTP_429_TOO_MANY_REQUESTS
         assert response.headers.get(config.rate_limit_policy_header_key) == f"1; w={DURATION_VALUES[unit]}"
@@ -44,8 +49,8 @@ async def test_rate_limiting(unit: DurationUnit) -> None:
         assert response.headers.get(config.rate_limit_remaining_header_key) == "0"
         assert response.headers.get(config.rate_limit_reset_header_key) == str(int(time()) - cache_object.reset)
 
-        cache_object.history = [cache_object.history[0] - DURATION_VALUES[unit]]
-        await cache.set(cache_key, dumps(cache_object))
+        frozen_time.tick(1)
+
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
 

--- a/tests/middleware/test_rate_limit.py
+++ b/tests/middleware/test_rate_limit.py
@@ -40,7 +40,7 @@ async def test_rate_limiting(unit: DurationUnit) -> None:
         assert response.headers.get(config.rate_limit_remaining_header_key) == "0"
         assert response.headers.get(config.rate_limit_reset_header_key) == str(int(time()) - cache_object.reset)
 
-        frozen_time.tick(DURATION_VALUES[unit] - 1)
+        frozen_time.tick(DURATION_VALUES[unit] - 1)  # type: ignore[arg-type]
 
         response = client.get("/")
         assert response.status_code == HTTP_429_TOO_MANY_REQUESTS
@@ -49,7 +49,7 @@ async def test_rate_limiting(unit: DurationUnit) -> None:
         assert response.headers.get(config.rate_limit_remaining_header_key) == "0"
         assert response.headers.get(config.rate_limit_reset_header_key) == str(int(time()) - cache_object.reset)
 
-        frozen_time.tick(1)
+        frozen_time.tick(1)  # type: ignore[arg-type]
 
         response = client.get("/")
         assert response.status_code == HTTP_200_OK


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

The test was randomly failing because it was time sensitive. Adding `freeze_time` should solve it.

Also - in the rate limit middleware cache expiration was not set so any unit of more than 60 seconds would not work correctly.
