### PR TITLE
Tests for creation of Partial DTO's.  One test fails due to an open bug.

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,12 @@ from typing import Dict, List, Optional
 from pydantic import BaseModel, Field
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 from pydantic_factories import ModelFactory
+from sqlalchemy import Column
+from sqlalchemy.dialects.postgresql import INTEGER, JSONB, TEXT, TIMESTAMP
+from sqlalchemy.orm import declarative_base
 from typing_extensions import TypedDict
+
+Base = declarative_base()
 
 
 class Species(str, Enum):
@@ -65,3 +70,14 @@ class TypedDictPerson(TypedDict):
     optional: Optional[str]
     complex: Dict[str, List[Dict[str, str]]]
     pets: Optional[List[Pet]]
+
+
+class Car(Base):
+    __tablename__ = "db_cars"
+
+    id = Column(INTEGER, primary_key=True)
+    year = Column(INTEGER)
+    make = Column(TEXT)
+    model = Column(TEXT)
+    horsepower = Column(INTEGER)
+    color_codes = Column(JSONB)

--- a/tests/dto_factory/test_dto_factory_partials.py
+++ b/tests/dto_factory/test_dto_factory_partials.py
@@ -1,0 +1,48 @@
+from starlite import DTOFactory
+from starlite.plugins.sql_alchemy import SQLAlchemyPlugin
+from starlite.types.partial import Partial
+
+from tests import Person, Car
+from tests.plugins.sql_alchemy_plugin import Pet
+
+dto_factory = DTOFactory(plugins=[SQLAlchemyPlugin()])
+
+
+def test_partial_dto_pydantic():
+    dto_person = dto_factory("dto_person", Person)
+    dto_partial_person = Partial[Person]
+    bob = dto_partial_person(first_name="Bob")
+    assert bob.first_name == "Bob"
+
+
+def test_partial_dto_sqlalchemy_model():
+    car_one = {
+        "id": 1,
+        "year": 2022,
+        "make": "Ferrari",
+        "model": "488 Challenge Evo",
+        "horsepower": 670,
+        "color_codes": {
+            "red": "Rosso corsa",
+            "black": "Nero",
+            "yellow": "Giallo Modena",
+        },
+    }
+
+    car_two = {
+        "id": 2,
+        "year": 1969,
+        "make": "Ford",
+        "model": "GT40",
+        "horsepower": 380,
+    }
+
+    # Test for non-partial DTO
+    dto_car = dto_factory("dto_cars", Car)
+    ferrari = dto_car(**car_one)
+    assert ferrari.year == 2022
+
+    # Test for partial DTO
+    partial_dto_car = Partial[dto_car]
+    ford = partial_dto_car(**car_two)
+    assert ford.make == "Ford"


### PR DESCRIPTION
🚨 First PR Alert 🚨

Hopefully the code I'm proposing is ok.  Feedback is very welcome.  

This pull request adds tests for a bug I opened: https://github.com/starlite-api/starlite/issues/655

Changes include:

- Extending [tests/__init__.py](https://github.com/starlite-api/starlite/compare/main...ThinksFast:starlite:test_partial_dto?expand=1#diff-001e61d97d9dee27d0c5aa1f23ba6c1972cd8a2e8320bac839656b0ab935b84d) to include a SQL Alchemy model
- Added new file [tests/dto_factory/test_dto_factory_partials.py](https://github.com/starlite-api/starlite/compare/main...ThinksFast:starlite:test_partial_dto?expand=1#diff-a2273ea7335f9bbf8a33caed2ca0c8c0fe52c4377e3edfc8f37b95bcf3086d2c), which tests the creation of `Partial[DTO]` objects using Pydantic and SQLAlchemy models. 


# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
