### PR TITLE
Fix link colors in the docs

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -197,7 +197,7 @@ body {
   --md-accent-bg-color: #171c28;
   --md-accent-bg-color--light: hsl(222, 27%, 20%);
   --md-accent-fg-color: var(--md-primary-fg-color--light);
-  --md-accent-fg-color--transparent: var(--md-primary-fg-color--light);
+  --md-accent-fg-color--transparent: #ffd58033;
 
   /* Misc */
   --md-footer-fg-color: var(--md-accent-fg-color);
@@ -271,9 +271,15 @@ body {
     0 .25rem .66rem hsla(0, 0%, 0%, 0.2),
     0 0              .06125rem  hsla(0, 0%, 0%, 0.35); */
 }
+
 [data-md-color-scheme="mirage-light"] .md-typeset a:focus,
-.md-typeset a:hover {
+[data-md-color-scheme="mirage-light"] .md-typeset a:hover {
   color: var(--md-primary-fg-color);
+}
+
+[data-md-color-scheme="mirage"] .md-typeset a:focus,
+[data-md-color-scheme="mirage"] .md-typeset a:hover {
+  color: var(--md-primary-fg-color--light);
 }
 
 [data-md-color-scheme="mirage-light"] .md-header {


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

At the moment it is very hard to use search and quoted links with light theme.

See attached video

<details><summary>light theme before</summary>

https://user-images.githubusercontent.com/153191/197404906-0d879023-b43e-40ba-8946-31256c03301f.mp4
</details>

I suggest to revert changes to background-color of links in onhover state.

<details><summary>light theme after</summary>

https://user-images.githubusercontent.com/153191/197405187-b2b2c48e-eab4-4184-81aa-388427101a57.mp4
</details>

Also I've added onhover link color change in the dark theme so it is consistent with light theme which had onhover effect.

We can pick better colors later but right now lets fix what actually makes it hard to work with the docs