### PR TITLE
Drop await for anyio.Event.set (deprecated)

### DIFF
--- a/tests/response/test_streaming_response.py
+++ b/tests/response/test_streaming_response.py
@@ -45,7 +45,7 @@ async def test_streaming_response_stops_if_receiving_http_disconnect_with_async_
             streamed += len(message.get("body", b""))
             # Simulate disconnection after download has started
             if streamed >= 16:
-                await disconnected.set()
+                disconnected.set()
 
     async def stream_indefinitely() -> AsyncIterator[bytes]:
         while True:
@@ -75,7 +75,7 @@ async def test_streaming_response_stops_if_receiving_http_disconnect_with_sync_i
             streamed += len(message.get("body", b""))
             # Simulate disconnection after download has started
             if streamed >= 16:
-                await disconnected.set()
+                disconnected.set()
 
     response = StreamingResponse(content=cycle(["1", "2", "3"]))
 


### PR DESCRIPTION
anyio.Event.set() does not need to be awaited anymore after anyio 3. Since we only support anyio > 3, we can simply drop the await here.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
