### PR TITLE
Add `__test__ = False` to TestClient

### DIFF
--- a/starlite/testing/test_client/client.py
+++ b/starlite/testing/test_client/client.py
@@ -55,6 +55,7 @@ T = TypeVar("T", bound=ASGIApp)
 
 
 class TestClient(Client, Generic[T]):
+    __test__ = False
     blocking_portal: "BlockingPortal"
     lifespan_handler: LifeSpanHandler
     exit_stack: "ExitStack"


### PR DESCRIPTION
Pytest will try to collect `TestClient` in some circumstances. This can be prevented by adding a `__test__ = False` to the TestClient

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
