### PR TITLE
Fix lower-casing of header values. (#693)

### DIFF
--- a/starlite/response/base.py
+++ b/starlite/response/base.py
@@ -255,7 +255,7 @@ class Response(Generic[T]):
             content_type = self.media_type
 
         encoded_headers = [
-            *((k.lower().encode("latin-1"), str(v).lower().encode("latin-1")) for k, v in self.headers.items()),
+            *((k.lower().encode("latin-1"), str(v).encode("latin-1")) for k, v in self.headers.items()),
             *((b"set-cookie", cookie.to_header(header="").encode("latin-1")) for cookie in self.cookies),
             (b"content-type", content_type.encode("latin-1")),
         ]

--- a/tests/response/test_base_response.py
+++ b/tests/response/test_base_response.py
@@ -31,6 +31,18 @@ def test_response_headers() -> None:
         assert response.headers["content-type"] == "text/plain; charset=utf-8"
 
 
+def test_response_headers_do_not_lowercase_values() -> None:
+    # reproduces: https://github.com/starlite-api/starlite/issues/693
+
+    @get("/")
+    def handler() -> Response:
+        return Response(content="hello world", media_type=MediaType.TEXT, headers={"foo": "BaR"})
+
+    with create_test_client(handler) as client:
+        response = client.get("/")
+        assert response.headers["foo"] == "BaR"
+
+
 def test_set_cookie() -> None:
     @get("/")
     def handler() -> Response:

--- a/tests/response/test_file_response.py
+++ b/tests/response/test_file_response.py
@@ -79,7 +79,7 @@ def test_file_response_with_chinese_filename(tmpdir: Path) -> None:
     app = FileResponse(path=path, filename=filename)
     client = TestClient(app)
     response = client.get("/")
-    expected_disposition = "attachment; filename*=utf-8''%e4%bd%a0%e5%a5%bd.txt"
+    expected_disposition = "attachment; filename*=utf-8''%E4%BD%A0%E5%A5%BD.txt"
     assert response.status_code == HTTP_200_OK
     assert response.content == content
     assert response.headers["content-disposition"] == expected_disposition


### PR DESCRIPTION
A bug was introduced as part of #626, that would lower case header values

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
