### PR TITLE
Use a context-manager to handle SQLA sessions in session-backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ target/
 # files
 **/*.so
 **/*.sqlite
-**/*.sqlite-jounal
+**/*.sqlite*
 *.iml
 .DS_Store
 .coverage

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ target/
 # files
 **/*.so
 **/*.sqlite
+**/*.sqlite-jounal
 *.iml
 .DS_Store
 .coverage


### PR DESCRIPTION
Previously some SQLAlchemy sessions in `AsyncSQLAlchemySessionBackend` weren't properly closed due to not being used as a context manager / explicitly closed. This was flaky because closing via garbage collection only works sometimes in an async context and with certain database drivers.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
