### PR TITLE
Test client cleanup

### DIFF
--- a/docs/usage/14-testing.md
+++ b/docs/usage/14-testing.md
@@ -81,7 +81,10 @@ two methods:
 - [set_session_data][starlite.testing.test_client.TestClient.get_session_data]
 
 !!! important
-    The **Session Middleware** must be enabled in Starlite app provided to the TestClient to use sessions.
+    - The **Session Middleware** must be enabled in Starlite app provided to the TestClient to use sessions.
+    - If you are using the [CookieBackend][starlite.middleware.session.cookie_backend.CookieBackend] you need
+        to install the `cryptography` package. You can do so by installing starlite with e.g. `pip install starlite[cryptography]`
+        or `poetry install starlite[cryptography]`
 
 ```py title="Setting session data"
 --8<-- "examples/testing/set_session_data.py"

--- a/poetry.lock
+++ b/poetry.lock
@@ -36,7 +36,7 @@ test = ["contextlib2", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (>=0.16,<0.22)"]
 
 [[package]]
-name = "async_generator"
+name = "async-generator"
 version = "1.10"
 description = "Async generators and context managers for Python 3.5+"
 category = "dev"
@@ -107,7 +107,7 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
-name = "Brotli"
+name = "brotli"
 version = "1.0.9"
 description = "Python bindings for the Brotli compression library"
 category = "main"
@@ -195,7 +195,7 @@ ssh = ["bcrypt (>=3.1.5)"]
 test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
 
 [[package]]
-name = "Deprecated"
+name = "deprecated"
 version = "1.2.13"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
 category = "main"
@@ -257,7 +257,7 @@ idna = ">=2.0.0"
 
 [[package]]
 name = "exceptiongroup"
-version = "1.0.0rc9"
+version = "1.0.0"
 description = "Backport of PEP 654 (exception groups)"
 category = "dev"
 optional = false
@@ -267,7 +267,7 @@ python-versions = ">=3.7"
 test = ["pytest (>=6)"]
 
 [[package]]
-name = "Faker"
+name = "faker"
 version = "15.1.1"
 description = "Faker is a Python package that generates fake data for you."
 category = "main"
@@ -280,7 +280,7 @@ typing-extensions = {version = ">=3.10.0.1", markers = "python_version < \"3.8\"
 
 [[package]]
 name = "fakeredis"
-version = "1.9.4"
+version = "1.10.0"
 description = "Fake implementation of redis API for testing purposes."
 category = "dev"
 optional = false
@@ -384,7 +384,7 @@ socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
 name = "hypothesis"
-version = "6.56.3"
+version = "6.56.4"
 description = "A library for property-based testing"
 category = "dev"
 optional = false
@@ -392,7 +392,7 @@ python-versions = ">=3.7"
 
 [package.dependencies]
 attrs = ">=19.2.0"
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+exceptiongroup = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 sortedcontainers = ">=2.1.0,<3.0.0"
 
 [package.extras]
@@ -413,7 +413,7 @@ zoneinfo = ["backports.zoneinfo (>=0.2.1)", "tzdata (>=2022.5)"]
 
 [[package]]
 name = "identify"
-version = "2.5.7"
+version = "2.5.8"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -472,7 +472,7 @@ optional = false
 python-versions = ">=3.6.2,<4.0"
 
 [[package]]
-name = "Jinja2"
+name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
 category = "dev"
@@ -486,7 +486,7 @@ MarkupSafe = ">=2.0"
 i18n = ["Babel (>=2.7)"]
 
 [[package]]
-name = "Mako"
+name = "mako"
 version = "1.2.3"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 category = "dev"
@@ -503,7 +503,7 @@ lingua = ["lingua"]
 testing = ["pytest"]
 
 [[package]]
-name = "MarkupSafe"
+name = "markupsafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
 category = "dev"
@@ -569,7 +569,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "piccolo"
-version = "0.94.0"
+version = "0.95.0"
 description = "A fast, user friendly ORM and query builder which supports asyncio."
 category = "dev"
 optional = false
@@ -594,14 +594,14 @@ uvloop = ["uvloop (>=0.12.0)"]
 
 [[package]]
 name = "picologging"
-version = "0.8.1"
+version = "0.9.0"
 description = "A fast and lightweight logging library for Python"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-dev = ["black", "pytest", "pytest-cov", "rich"]
+dev = ["black", "flaky", "hypothesis", "pre-commit", "pytest", "pytest-cov", "rich"]
 
 [[package]]
 name = "platformdirs"
@@ -795,7 +795,7 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "PyYAML"
+name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "main"
@@ -882,7 +882,7 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "SQLAlchemy"
+name = "sqlalchemy"
 version = "1.4.42"
 description = "Database Abstraction Library"
 category = "dev"
@@ -1130,12 +1130,12 @@ memcached = ["aiomcache"]
 picologging = ["picologging"]
 redis = ["redis"]
 structlog = ["structlog"]
-testing = ["httpx", "cryptography"]
+testing = ["httpx"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "eb8f1f41333ec2d9be6103c5f40f9e637d033a2cba071ae0fd9345d8f4b2a411"
+content-hash = "e50371c633555c5276d3644a6efe60086bab2479bb9c30781e916cc1df8ddd7d"
 
 [metadata.files]
 aiomcache = [
@@ -1150,7 +1150,7 @@ anyio = [
     {file = "anyio-3.6.2-py3-none-any.whl", hash = "sha256:fbbe32bd270d2a2ef3ed1c5d45041250284e31fc0a4df4a5a6071842051a51e3"},
     {file = "anyio-3.6.2.tar.gz", hash = "sha256:25ea0d673ae30af41a0c442f81cf3b38c7e79fdc7b60335a4c14e05eb0947421"},
 ]
-async_generator = [
+async-generator = [
     {file = "async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b"},
     {file = "async_generator-1.10.tar.gz", hash = "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144"},
 ]
@@ -1185,7 +1185,7 @@ black = [
     {file = "black-22.10.0-py3-none-any.whl", hash = "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458"},
     {file = "black-22.10.0.tar.gz", hash = "sha256:f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1"},
 ]
-Brotli = [
+brotli = [
     {file = "Brotli-1.0.9-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:268fe94547ba25b58ebc724680609c8ee3e5a843202e9a381f6f9c5e8bdb5c70"},
     {file = "Brotli-1.0.9-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:c2415d9d082152460f2bd4e382a1e85aed233abc92db5a3880da2257dc7daf7b"},
     {file = "Brotli-1.0.9-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5913a1177fc36e30fcf6dc868ce23b0453952c78c04c266d3149b3d39e1410d6"},
@@ -1411,7 +1411,7 @@ cryptography = [
     {file = "cryptography-38.0.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:52e7bee800ec869b4031093875279f1ff2ed12c1e2f74923e8f49c916afd1d3b"},
     {file = "cryptography-38.0.1.tar.gz", hash = "sha256:1db3d807a14931fa317f96435695d9ec386be7b84b618cc61cfa5d08b0ae33d7"},
 ]
-Deprecated = [
+deprecated = [
     {file = "Deprecated-1.2.13-py2.py3-none-any.whl", hash = "sha256:64756e3e14c8c5eea9795d93c524551432a0be75629f8f29e67ab8caf076c76d"},
     {file = "Deprecated-1.2.13.tar.gz", hash = "sha256:43ac5335da90c31c24ba028af536a91d41d53f9e6901ddb021bcc572ce44e38d"},
 ]
@@ -1431,16 +1431,16 @@ email-validator = [
     {file = "email_validator-1.3.0.tar.gz", hash = "sha256:553a66f8be2ec2dea641ae1d3f29017ab89e9d603d4a25cdaac39eefa283d769"},
 ]
 exceptiongroup = [
-    {file = "exceptiongroup-1.0.0rc9-py3-none-any.whl", hash = "sha256:2e3c3fc1538a094aab74fad52d6c33fc94de3dfee3ee01f187c0e0c72aec5337"},
-    {file = "exceptiongroup-1.0.0rc9.tar.gz", hash = "sha256:9086a4a21ef9b31c72181c77c040a074ba0889ee56a7b289ff0afb0d97655f96"},
+    {file = "exceptiongroup-1.0.0-py3-none-any.whl", hash = "sha256:2ac84b496be68464a2da60da518af3785fff8b7ec0d090a581604bc870bdee41"},
+    {file = "exceptiongroup-1.0.0.tar.gz", hash = "sha256:affbabf13fb6e98988c38d9c5650e701569fe3c1de3233cfb61c5f33774690ad"},
 ]
-Faker = [
+faker = [
     {file = "Faker-15.1.1-py3-none-any.whl", hash = "sha256:096c15e136adb365db24d8c3964fe26bfc68fe060c9385071a339f8c14e09c8a"},
     {file = "Faker-15.1.1.tar.gz", hash = "sha256:a741b77f484215c3aab2604100669657189548f440fcb2ed0f8b7ee21c385629"},
 ]
 fakeredis = [
-    {file = "fakeredis-1.9.4-py3-none-any.whl", hash = "sha256:61afe14095aad3e7413a0a6fe63041da1b4bc3e41d5228a33b60bd03fabf22d8"},
-    {file = "fakeredis-1.9.4.tar.gz", hash = "sha256:17415645d11994061f5394f3f1c76ba4531f3f8b63f9c55a8fd2120bebcbfae9"},
+    {file = "fakeredis-1.10.0-py3-none-any.whl", hash = "sha256:0be420a79fabda234963a2730c4ce609a6d44a598e8dd253ce97785bef944285"},
+    {file = "fakeredis-1.10.0.tar.gz", hash = "sha256:2b02370118535893d832bcd3c099ef282de3f13b29ae3922432e2225794ec334"},
 ]
 filelock = [
     {file = "filelock-3.8.0-py3-none-any.whl", hash = "sha256:617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4"},
@@ -1574,12 +1574,12 @@ httpx = [
     {file = "httpx-0.23.0.tar.gz", hash = "sha256:f28eac771ec9eb4866d3fb4ab65abd42d38c424739e80c08d8d20570de60b0ef"},
 ]
 hypothesis = [
-    {file = "hypothesis-6.56.3-py3-none-any.whl", hash = "sha256:802d236d03dbd54e0e1c55c0daa2ec41aeaadc87a4dcbb41421b78bf3f7a7789"},
-    {file = "hypothesis-6.56.3.tar.gz", hash = "sha256:15dae5d993339aefa57e00f5cb5a5817ff300eeb661d96d1c9d094eb62b04c9a"},
+    {file = "hypothesis-6.56.4-py3-none-any.whl", hash = "sha256:67950103ee930c66673494b3671474a083ea71f1ebe8f0ff849ba8ad5317772d"},
+    {file = "hypothesis-6.56.4.tar.gz", hash = "sha256:313bc1c0f377ec6c98815d3237a69add7558eadee4effe4ed613d0ba36513a52"},
 ]
 identify = [
-    {file = "identify-2.5.7-py2.py3-none-any.whl", hash = "sha256:7a67b2a6208d390fd86fd04fb3def94a3a8b7f0bcbd1d1fcd6736f4defe26390"},
-    {file = "identify-2.5.7.tar.gz", hash = "sha256:5b8fd1e843a6d4bf10685dd31f4520a7f1c7d0e14e9bc5d34b1d6f111cabc011"},
+    {file = "identify-2.5.8-py2.py3-none-any.whl", hash = "sha256:48b7925fe122720088aeb7a6c34f17b27e706b72c61070f27fe3789094233440"},
+    {file = "identify-2.5.8.tar.gz", hash = "sha256:7a214a10313b9489a0d61467db2856ae8d0b8306fc923e03a9effa53d8aedc58"},
 ]
 idna = [
     {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -1601,15 +1601,15 @@ iso8601 = [
     {file = "iso8601-1.1.0-py3-none-any.whl", hash = "sha256:8400e90141bf792bce2634df533dc57e3bee19ea120a87bebcd3da89a58ad73f"},
     {file = "iso8601-1.1.0.tar.gz", hash = "sha256:32811e7b81deee2063ea6d2e94f8819a86d1f3811e49d23623a41fa832bef03f"},
 ]
-Jinja2 = [
+jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
     {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
 ]
-Mako = [
+mako = [
     {file = "Mako-1.2.3-py3-none-any.whl", hash = "sha256:c413a086e38cd885088d5e165305ee8eed04e8b3f8f62df343480da0a385735f"},
     {file = "Mako-1.2.3.tar.gz", hash = "sha256:7fde96466fcfeedb0eed94f187f20b23d85e4cb41444be0e542e2c8c65c396cd"},
 ]
-MarkupSafe = [
+markupsafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
     {file = "MarkupSafe-2.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e"},
@@ -1723,40 +1723,40 @@ pathspec = [
     {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
 ]
 piccolo = [
-    {file = "piccolo-0.94.0-py3-none-any.whl", hash = "sha256:ecf6c2eb4cc6f186be7ecfc91e3e496a788570c4d7a80cfafe97472d3d5c4387"},
-    {file = "piccolo-0.94.0.tar.gz", hash = "sha256:475204b4e2bb98f1b2f97e357d33083b365b9d42e0c96dd8d8085e4894bbfcd8"},
+    {file = "piccolo-0.95.0-py3-none-any.whl", hash = "sha256:e45bc4700bbb208e4f3b0d048477fcef84f6a2ff5d7a6e4b67eaadf7918d5d83"},
+    {file = "piccolo-0.95.0.tar.gz", hash = "sha256:261edce81b1146cccb2962d644a43772b0841b5fb345ee8afd406805c6e2e2fe"},
 ]
 picologging = [
-    {file = "picologging-0.8.1-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:262afe4b6189a2c84db8a0b43255ea44288b3a86caa1f2c997fd79b899882c9d"},
-    {file = "picologging-0.8.1-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:d6f7e80c7036b0d101c61c963089127fe777147d191dcbb6554d17532137fdc0"},
-    {file = "picologging-0.8.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ad5edd2f74432c5520b22dcf3dd18f5c99c6319452d326c3e4c2d2a9e77431a"},
-    {file = "picologging-0.8.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6fd92dd034e19fd9f34af5442a4c3d56876427c8efaeb70bbe1fd60e5e45fbf"},
-    {file = "picologging-0.8.1-cp310-cp310-win32.whl", hash = "sha256:c17351e6fe9bbd1c646105a88e2b54529c85f756c369d3bb030e07dac2ca31ce"},
-    {file = "picologging-0.8.1-cp310-cp310-win_amd64.whl", hash = "sha256:b7e12162ec7c62bac42c2cfafaee73d787ee3006d37425431bc85eae18324c92"},
-    {file = "picologging-0.8.1-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:f76ab45250ea48a5bd8c8f78dc60b6268deca643f3e4d0880a161f96c39b4901"},
-    {file = "picologging-0.8.1-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:aa4278eb5dedc6e34004dd8bf1dec30fac36c89c5730ae46b024a0c6b73792df"},
-    {file = "picologging-0.8.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9470c0ed2c5cb1bb46ed3c25b678ff92c3c7a3072c61451879d85442cdb30e26"},
-    {file = "picologging-0.8.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:625626f283c9c5c17baeb32c1722a048d630cce43cbb064baa16ec192b1a485e"},
-    {file = "picologging-0.8.1-cp311-cp311-win32.whl", hash = "sha256:07ebb45bcc9e4cf59abf902faf408ccab5217eb6e6c0f270bbc055481f9590de"},
-    {file = "picologging-0.8.1-cp311-cp311-win_amd64.whl", hash = "sha256:05b267a0979b4b6fa21ad33a8e9194b72808653fb4785c6682ec9fa958ab9c02"},
-    {file = "picologging-0.8.1-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:307b5e3a8740e1bfe2872448ca0b0410a159bfba8ddeb46a30d97469801d4703"},
-    {file = "picologging-0.8.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d4e48cde8e4302a13fe64869dcbd158a70d49c22f812f19e9e34aaddc4fbf4fa"},
-    {file = "picologging-0.8.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:281f4bff6ec169fe21faa63576b80219471822541fb8e6072f03e231c97c8489"},
-    {file = "picologging-0.8.1-cp37-cp37m-win32.whl", hash = "sha256:392e5823d38531cf6c516ddaaf2d7ffee8640ae5783039401899352048a90a41"},
-    {file = "picologging-0.8.1-cp37-cp37m-win_amd64.whl", hash = "sha256:3b7c3084cbb56a33d20b32ad1f4b7eb1f7bc07f4a737b98c2f374c635a11f0b6"},
-    {file = "picologging-0.8.1-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:a99f94e5ef0e05123a9dfd56979fcb0ef87ef307e5d6955781a7d5af3aae332d"},
-    {file = "picologging-0.8.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:2ea4226d1dad2ad1a7206b23e1969a9593fe47fbd8e3e74c76d59ebe58c2679e"},
-    {file = "picologging-0.8.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f20a93feedaa4617258215444946a3f7ea768465536eeea2172b4754b4d08bb1"},
-    {file = "picologging-0.8.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b25d97b9d94e78f181319f39f25b34f4907ab420df9f8efafae8432e174c576"},
-    {file = "picologging-0.8.1-cp38-cp38-win32.whl", hash = "sha256:04f6cd30441300798b3d20353acba554c51488097b523ff1dff33c689c3e5dde"},
-    {file = "picologging-0.8.1-cp38-cp38-win_amd64.whl", hash = "sha256:ea507fd1f7c71e9da9484ab234ea4613979abf994c59602d64640fced81d994f"},
-    {file = "picologging-0.8.1-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:1c5993c9d219f9c4c6bf8ab9091db4e15d6dfb484cdada7d939ea7902a7b0575"},
-    {file = "picologging-0.8.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:41ff34882e1358a8d6606701394cfceca8b810ce5b289d37229219cacde8bd29"},
-    {file = "picologging-0.8.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bf77b97df9f3a2b754f5237ea96c92fa6b4f703c881f9ffad275b7832b4aa7ac"},
-    {file = "picologging-0.8.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:74933bf930b60904ef66b7b4b695952ca86442c023dcf9917ea63a124de22fa2"},
-    {file = "picologging-0.8.1-cp39-cp39-win32.whl", hash = "sha256:0662cee1a580cbc92c709a703e8be09642c04b1ccd06e22a70af206f571f51c3"},
-    {file = "picologging-0.8.1-cp39-cp39-win_amd64.whl", hash = "sha256:176f2b87e3638b100cde401de64e4886293f3cc2937af805d0b15669561baedb"},
-    {file = "picologging-0.8.1.tar.gz", hash = "sha256:c0e263937a7fad3d3ec91c2311356f7ff699f605e960fac3eae409ff5b2f330a"},
+    {file = "picologging-0.9.0-cp310-cp310-macosx_10_15_universal2.whl", hash = "sha256:e9b2a7977095b618c84239f23c90a861187b0b50dc89f93486f243715866362d"},
+    {file = "picologging-0.9.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:e250c368ccab7205f8f3d88b22d71a95ddcd581be3bd08e8235e21583083e014"},
+    {file = "picologging-0.9.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2f922963fbbadf6c67dba9c6f17722a30ee332d243848d985dafdae3d7b1f6b3"},
+    {file = "picologging-0.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4eb5902aaeaa7df6da8ee3fb314fd3529cc057d8cb6ef931e9f6cec5958914f"},
+    {file = "picologging-0.9.0-cp310-cp310-win32.whl", hash = "sha256:95eec2fc6c293dd388bfde9d0a366733e5e7ccf758e939e375b4c89152700e6d"},
+    {file = "picologging-0.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:41e4f5849771e1b23b37b1144305a64c0197b25b0e5b944451cac5ce8f2ee63d"},
+    {file = "picologging-0.9.0-cp311-cp311-macosx_10_15_universal2.whl", hash = "sha256:be9763a861cf531d77d35a87a1884f867704b23198ba46dc8feed90f1019882f"},
+    {file = "picologging-0.9.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:9129f953b2af99241653234977daa61ba8f3dbb8c5d39c9a09b72470cf25bce2"},
+    {file = "picologging-0.9.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8d9beece9781fd56b70320d1b69adc70d2848bf178413331ac9d8899883c5af9"},
+    {file = "picologging-0.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d64f1d109baa81c4c5e2ca65d41211b0ed1e8eaace036b52dc816d694d416d46"},
+    {file = "picologging-0.9.0-cp311-cp311-win32.whl", hash = "sha256:c36ec7f6485fe64d60b63e5559a7eeae1f00be5a9d769d688960a5b4d61c48b5"},
+    {file = "picologging-0.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:42d03ec656f895f72fb2283524f68b0fea0a3c86ce8b34715fbd21b9e9705825"},
+    {file = "picologging-0.9.0-cp37-cp37m-macosx_10_15_x86_64.whl", hash = "sha256:f826700941220acd947e18d0473d99e6a2b307ed62d750abe8124e2eb78a3e81"},
+    {file = "picologging-0.9.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:002baad47250959aa98e6741e90d219eb258a8fc307ea8dd00ca7e7797e12ff2"},
+    {file = "picologging-0.9.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52e7989ca4affd80e20297666e253eef4512c89031c2d24229b02fb8d0008fa4"},
+    {file = "picologging-0.9.0-cp37-cp37m-win32.whl", hash = "sha256:cc7157e2bc21f26f978e7842ea0941517fa58090012efce15dd3bc1484fd7fe2"},
+    {file = "picologging-0.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d37282eb112d8447b39a483e32e2a1560da68bfd7f547988c4c33fae55ef0802"},
+    {file = "picologging-0.9.0-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:1fa2b7427a235c6ee801643e58487dd2cf4b61457b6eeda9ffcaf5f73fb7aca6"},
+    {file = "picologging-0.9.0-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:5e6074533b1430210f414471db3b89d981e75453b55d246dce524bf43cb23601"},
+    {file = "picologging-0.9.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:75beeff9f3b6e67951abaaae1fecbc5269f8bbe59db26647c91bbaade5366ed4"},
+    {file = "picologging-0.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c942591c72aadd07b13845dbb430e9711cddffbd1c66b0c2d8cbaab3005e4468"},
+    {file = "picologging-0.9.0-cp38-cp38-win32.whl", hash = "sha256:c2f1bcc1fa13b3383578498454c0e50f32d05eb2dcdf7a63981799a077a4b4e6"},
+    {file = "picologging-0.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:128963c1089896d592713023612a4505ef879ed1186ae21bf8ad9ded9575b34f"},
+    {file = "picologging-0.9.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:edd15ded34e7e999fa9f407d5f9616873f336c865af37dc05a3a4dbe265d2f14"},
+    {file = "picologging-0.9.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:1b1d8f5cc0633e0d0d1891b53cc7b3e49022d9cc9238792fef227a5b49f7e7b0"},
+    {file = "picologging-0.9.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9b56724ed1b764b075ce107eb94c7cb12667119225f1aef96b7e493d1e02248d"},
+    {file = "picologging-0.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6dbfa965e5c56166ab7725c7e0b87009646a5d41c56b128664f880c8001cea94"},
+    {file = "picologging-0.9.0-cp39-cp39-win32.whl", hash = "sha256:1defc63d13c94539e4b035e175d0d33cba773656ae3e337895cef073682e9057"},
+    {file = "picologging-0.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:5090f684ce345ae40e0c31ab865334908f844468d594d5e3985df9c453398cf5"},
+    {file = "picologging-0.9.0.tar.gz", hash = "sha256:55ac27faa4129a7d272e23e2bb37d76bbf1a38f1b827e18008af1ff347e311fc"},
 ]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
@@ -1852,7 +1852,7 @@ pytz = [
     {file = "pytz-2022.5-py2.py3-none-any.whl", hash = "sha256:335ab46900b1465e714b4fda4963d87363264eb662aab5e65da039c25f1f5b22"},
     {file = "pytz-2022.5.tar.gz", hash = "sha256:c4d88f472f54d615e9cd582a5004d1e5f624854a6a27a6211591c251f22a6914"},
 ]
-PyYAML = [
+pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
     {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
@@ -1915,7 +1915,7 @@ soupsieve = [
     {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},
     {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
 ]
-SQLAlchemy = [
+sqlalchemy = [
     {file = "SQLAlchemy-1.4.42-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:28e881266a172a4d3c5929182fde6bb6fba22ac93f137d5380cc78a11a9dd124"},
     {file = "SQLAlchemy-1.4.42-cp27-cp27m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ca9389a00f639383c93ed00333ed763812f80b5ae9e772ea32f627043f8c9c88"},
     {file = "SQLAlchemy-1.4.42-cp27-cp27m-win32.whl", hash = "sha256:1d0c23ecf7b3bc81e29459c34a3f4c68ca538de01254e24718a7926810dc39a6"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1125,17 +1125,16 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [extras]
 brotli = ["brotli"]
 cryptography = ["cryptography"]
-full = ["httpx", "brotli", "cryptography", "picologging", "structlog"]
+full = ["brotli", "cryptography", "picologging", "structlog"]
 memcached = ["aiomcache"]
 picologging = ["picologging"]
 redis = ["redis"]
 structlog = ["structlog"]
-testing = ["httpx"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "e50371c633555c5276d3644a6efe60086bab2479bb9c30781e916cc1df8ddd7d"
+content-hash = "140f18c26212d0d8e787086d15ba04aa7b8ac2095dd0e19143c8e03c72f882ac"
 
 [metadata.files]
 aiomcache = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ aiomcache = {version = "*", optional = true}
 anyio = ">=3"
 brotli = { version = "*", optional = true }
 cryptography = { version = "*", optional = true }
-httpx = { version = ">=0.22", optional = true }
+httpx = { version = ">=0.22" }
 orjson = "*"
 picologging = { version = "*", optional = true }
 pydantic = "*"
@@ -84,10 +84,9 @@ trio = "*"
 fakeredis = "^1.9.4"
 
 [tool.poetry.extras]
-testing = ["httpx"]
 brotli = ["brotli"]
 cryptography = ["cryptography"]
-full = ["httpx", "brotli", "cryptography", "picologging", "structlog"]
+full = ["brotli", "cryptography", "picologging", "structlog"]
 picologging = ["picologging"]
 structlog = ["structlog"]
 redis = ["redis"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ trio = "*"
 fakeredis = "^1.9.4"
 
 [tool.poetry.extras]
-testing = ["httpx", "cryptography"]
+testing = ["httpx"]
 brotli = ["brotli"]
 cryptography = ["cryptography"]
 full = ["httpx", "brotli", "cryptography", "picologging", "structlog"]

--- a/starlite/__init__.py
+++ b/starlite/__init__.py
@@ -77,6 +77,7 @@ from starlite.plugins import PluginProtocol
 from starlite.response import Response
 from starlite.router import Router
 from starlite.routes import ASGIRoute, BaseRoute, HTTPRoute, WebSocketRoute
+from starlite.testing import TestClient, create_test_client  # type: ignore[no-redef]
 from starlite.types.partial import Partial
 
 __all__ = (
@@ -97,6 +98,7 @@ __all__ = (
     "CompressionConfig",
     "Controller",
     "Cookie",
+    "create_test_client",
     "DTOFactory",
     "DefineMiddleware",
     "Dependency",
@@ -142,6 +144,7 @@ __all__ = (
     "Template",
     "TemplateConfig",
     "TooManyRequestsException",
+    "TestClient",
     "UploadFile",
     "ValidationException",
     "WebSocket",

--- a/starlite/testing/test_client/client.py
+++ b/starlite/testing/test_client/client.py
@@ -723,7 +723,8 @@ class TestClient(Client, Generic[T]):
                 assert client.get("/test").json() == {"foo": "bar"}
             ```
         """
-        anyio_run(self._set_session_data_async, data)
+        with self.portal() as portal:
+            portal.call(self._set_session_data_async, data)
 
     def get_session_data(self) -> Dict[str, Any]:
         """Get session data.
@@ -753,4 +754,5 @@ class TestClient(Client, Generic[T]):
                 assert client.get_session_data() == {"foo": "bar"}
             ```
         """
-        return anyio_run(self._get_session_data_async)
+        with self.portal() as portal:
+            return portal.call(self._get_session_data_async)

--- a/starlite/testing/test_client/client.py
+++ b/starlite/testing/test_client/client.py
@@ -14,7 +14,6 @@ from typing import (
 )
 from urllib.parse import urljoin
 
-from anyio import run as anyio_run
 from anyio.from_thread import BlockingPortal, start_blocking_portal
 
 from starlite import HttpMethod, ImproperlyConfiguredException
@@ -29,7 +28,7 @@ from starlite.testing.test_client.transport import (
     ConnectionUpgradeException,
     TestClientTransport,
 )
-from starlite.types import ASGIApp
+from starlite.types import AnyIOBackend, ASGIApp
 
 try:
     from httpx import USE_CLIENT_DEFAULT, Client, Response
@@ -52,7 +51,6 @@ if TYPE_CHECKING:
         TimeoutTypes,
         URLTypes,
     )
-    from typing_extensions import Literal
 
     from starlite.middleware.session.base import BaseBackendConfig, BaseSessionBackend
     from starlite.testing.test_client.websocket_test_session import WebSocketTestSession
@@ -79,7 +77,7 @@ class TestClient(Client, Generic[T]):
         base_url: str = "http://testserver",
         raise_server_exceptions: bool = True,
         root_path: str = "",
-        backend: "Literal['asyncio', 'trio' ]" = "asyncio",
+        backend: AnyIOBackend = "asyncio",
         backend_options: Optional[Dict[str, Any]] = None,
         session_config: Optional["BaseBackendConfig"] = None,
         cookies: Optional["CookieTypes"] = None,

--- a/starlite/types/__init__.py
+++ b/starlite/types/__init__.py
@@ -65,7 +65,7 @@ from .composite import (
     ResponseHeadersMap,
 )
 from .empty import Empty, EmptyType
-from .helpers import SingleOrList, SyncOrAsyncUnion
+from .helpers import AnyIOBackend, SingleOrList, SyncOrAsyncUnion
 from .internal_types import (
     ControllerRouterHandler,
     ReservedKwargs,
@@ -77,6 +77,7 @@ from .partial import Partial
 from .protocols import Logger
 
 __all__ = (
+    "AnyIOBackend",
     "ASGIApp",
     "ASGIApp",
     "ASGIVersion",

--- a/starlite/types/helpers.py
+++ b/starlite/types/helpers.py
@@ -1,5 +1,7 @@
 from typing import Awaitable, List, TypeVar, Union
 
+from typing_extensions import Literal
+
 T = TypeVar("T")
 
 SyncOrAsyncUnion = Union[T, Awaitable[T]]
@@ -9,4 +11,8 @@ Types 'T' as a union of T and awaitable T
 SingleOrList = Union[T, List[T]]
 """
 Types 'T' as a single value or a list T
+"""
+AnyIOBackend = Literal["asyncio", "trio"]
+"""
+Anyio backend names
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ from starlite.plugins.sql_alchemy import (
 from tests.mocks import FakeAsyncMemcached
 
 if TYPE_CHECKING:
-    from starlite.types import Receive, Scope, Send
+    from starlite.types import AnyIOBackend, Receive, Scope, Send
 
 
 def pytest_generate_tests(metafunc: Callable) -> None:
@@ -265,3 +265,8 @@ def session_middleware(session_backend: BaseSessionBackend) -> SessionMiddleware
 @pytest.fixture
 def cookie_session_middleware(cookie_session_backend: CookieBackend) -> SessionMiddleware[CookieBackend]:
     return SessionMiddleware(app=mock_asgi_app, backend=cookie_session_backend)
+
+
+@pytest.fixture
+def test_client_backend(anyio_backend_name: str) -> "AnyIOBackend":
+    return cast("AnyIOBackend", anyio_backend_name)

--- a/tests/testing/test_testing.py
+++ b/tests/testing/test_testing.py
@@ -21,6 +21,7 @@ from starlite.testing import RequestFactory, TestClient
 from tests import Pet, PetFactory
 
 if TYPE_CHECKING:
+
     from starlite.middleware.session.base import (
         BaseBackendConfig,
         ServerSideSessionConfig,
@@ -283,12 +284,17 @@ def test_test_client_get_session_data(
 ) -> None:
     session_data = {"foo": "bar"}
 
+    if with_domain:
+        session_config.domain = "testserver.local"
+
     @post(path="/test")
     def set_session_data(request: Request) -> None:
         request.session.update(session_data)
 
     app = Starlite(route_handlers=[set_session_data], middleware=[session_config.middleware])
 
-    with TestClient(app=app, session_config=session_config, backend=test_client_backend) as client:
+    with TestClient(
+        app=app, session_config=session_config, backend=test_client_backend, base_url="http://testserver.local"
+    ) as client:
         client.post("/test")
         assert client.get_session_data() == session_data


### PR DESCRIPTION
- Removes `cryptography` as a dependency of the `testing` package-extra
- Moves `TestClient` async session-backend methods to run in `TestClient.portal` instead of `anyio.run` directly
- Ensures `TestClient` tests in `tests/testing` run with both `asyncio`and `trio` backend

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
