### PR TITLE
Fix #706: Change base_url of TestClient

### DIFF
--- a/starlite/testing/create_test_client.py
+++ b/starlite/testing/create_test_client.py
@@ -50,7 +50,7 @@ def create_test_client(
     allowed_hosts: Optional[List[str]] = None,
     backend: "Literal['asyncio', 'trio']" = "asyncio",
     backend_options: Optional[Dict[str, Any]] = None,
-    base_url: str = "http://testserver",
+    base_url: str = "http://testserver.local",
     before_request: Optional["BeforeRequestHookHandler"] = None,
     before_send: Optional["SingleOrList[BeforeMessageSendHookHandler]"] = None,
     before_shutdown: Optional["SingleOrList[LifeSpanHookHandler]"] = None,

--- a/starlite/testing/test_client/client.py
+++ b/starlite/testing/test_client/client.py
@@ -74,7 +74,7 @@ class TestClient(Client, Generic[T]):
     def __init__(
         self,
         app: T,
-        base_url: str = "http://testserver",
+        base_url: str = "http://testserver.local",
         raise_server_exceptions: bool = True,
         root_path: str = "",
         backend: AnyIOBackend = "asyncio",
@@ -97,6 +97,13 @@ class TestClient(Client, Generic[T]):
                 route handlers.
             cookies: Cookies to set on the client.
         """
+        if "." not in base_url:
+            warnings.warn(
+                f"The base_url {base_url!r} might cause issues. Try adding a domain name such as .local: "
+                f"'{base_url}.local'",
+                UserWarning,
+            )
+
         self._session_backend: Optional["BaseSessionBackend"] = None
         if session_config:
             self._session_backend = session_config._backend_class(config=session_config)

--- a/tests/connection/request/test_request.py
+++ b/tests/connection/request/test_request.py
@@ -63,7 +63,7 @@ def test_request_url_for() -> None:
 
     with create_test_client(route_handlers=[proxy, root, test_none]) as client:
         response = client.get("/test")
-        assert response.json() == {"url": "http://testserver/proxy"}
+        assert response.json() == {"url": "http://testserver.local/proxy"}
 
         response = client.get("/test-none")
         assert response.status_code == 500
@@ -83,7 +83,7 @@ def test_request_asset_url(tmp_path: "Path") -> None:
         static_files_config=StaticFilesConfig(path="/static/js", directories=[tmp_path], name="js"),
     ) as client:
         response = client.get("/resolver")
-        assert response.json() == {"url": "http://testserver/static/js/main.js"}
+        assert response.json() == {"url": "http://testserver.local/static/js/main.js"}
 
         response = client.get("/resolver-none")
         assert response.status_code == 500
@@ -127,7 +127,7 @@ def test_request_url() -> None:
 
     client = TestClient(app)
     response = client.get("/123?a=abc")
-    assert response.json() == {"method": "GET", "url": "http://testserver/123?a=abc"}
+    assert response.json() == {"method": "GET", "url": "http://testserver.local/123?a=abc"}
 
     response = client.get("https://example.org:123/")
     assert response.json() == {"method": "GET", "url": "https://example.org:123/"}

--- a/tests/middleware/test_logging.py
+++ b/tests/middleware/test_logging.py
@@ -48,7 +48,7 @@ def test_logging_middleware_regular_logger(caplog: "LogCaptureFixture") -> None:
 
         assert (
             caplog.messages[0] == 'HTTP Request: path=/, method=GET, content_type=["",{}], '
-            'headers={"host":"testserver","accept":"*/*","accept-encoding":"gzip, '
+            'headers={"host":"testserver.local","accept":"*/*","accept-encoding":"gzip, '
             'deflate, br","connection":"keep-alive","user-agent":"testclient",'
             '"request-header":"1","cookie":"request-cookie=abc"}, '
             'cookies={"request-cookie":"abc"}, query={}, path_params={}, body=None'
@@ -77,7 +77,7 @@ def test_logging_middleware_struct_logger() -> None:
             "body": None,
             "content_type": ("", {}),
             "headers": {
-                "host": "testserver",
+                "host": "testserver.local",
                 "accept": "*/*",
                 "accept-encoding": "gzip, deflate, br",
                 "connection": "keep-alive",

--- a/tests/response/test_redirect_response.py
+++ b/tests/response/test_redirect_response.py
@@ -27,7 +27,7 @@ def test_redirect_response() -> None:
     client = TestClient(app)
     response = client.get("/redirect")
     assert response.text == "hello, world"
-    assert response.url == "http://testserver/"
+    assert response.url == "http://testserver.local/"
 
 
 def test_quoting_redirect_response() -> None:
@@ -41,7 +41,7 @@ def test_quoting_redirect_response() -> None:
     client = TestClient(app)
     response = client.get("/redirect", follow_redirects=True)
     assert response.text == "hello, world"
-    assert str(response.url) == "http://testserver/test/"
+    assert str(response.url) == "http://testserver.local/test/"
 
 
 def test_redirect_response_content_length_header() -> None:
@@ -54,7 +54,7 @@ def test_redirect_response_content_length_header() -> None:
 
     client: TestClient = TestClient(app)
     response = client.request("GET", "/redirect", follow_redirects=False)
-    assert str(response.url) == "http://testserver/redirect"
+    assert str(response.url) == "http://testserver.local/redirect"
     assert "content-length" not in response.headers
 
 

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -180,7 +180,7 @@ def test_dependency_validation_failure_raises_500() -> None:
         resp = client.get("/?param=13")
 
     assert resp.json() == {
-        "detail": "A dependency failed validation for GET http://testserver/?param=13",
+        "detail": "A dependency failed validation for GET http://testserver.local/?param=13",
         "extra": [{"loc": ["dep"], "msg": "value is not a valid integer", "type": "type_error.integer"}],
         "status_code": 500,
     }
@@ -197,7 +197,7 @@ def test_validation_failure_raises_400() -> None:
         resp = client.get("/?param=thirteen")
 
     assert resp.json() == {
-        "detail": "Validation failed for GET http://testserver/?param=thirteen",
+        "detail": "Validation failed for GET http://testserver.local/?param=thirteen",
         "extra": [{"loc": ["param"], "msg": "value is not a valid integer", "type": "type_error.integer"}],
         "status_code": 400,
     }
@@ -214,7 +214,7 @@ def test_client_error_precedence_over_server_error() -> None:
         resp = client.get("/?param=thirteen")
 
     assert resp.json() == {
-        "detail": "Validation failed for GET http://testserver/?param=thirteen",
+        "detail": "Validation failed for GET http://testserver.local/?param=thirteen",
         "extra": [{"loc": ["param"], "msg": "value is not a valid integer", "type": "type_error.integer"}],
         "status_code": 400,
     }

--- a/tests/testing/test_test_client.py
+++ b/tests/testing/test_test_client.py
@@ -85,3 +85,12 @@ def test_client_interface(method: str, test_client_backend: "AnyIOBackend") -> N
     else:
         response = client.options("/")
     assert response.status_code == HTTP_200_OK
+
+
+async def mock_asgi_app(scope: "Scope", receive: "Receive", send: "Send") -> None:
+    pass
+
+
+def test_warns_problematic_domain() -> None:
+    with pytest.warns(UserWarning):
+        TestClient(app=mock_asgi_app, base_url="http://testserver")

--- a/tests/testing/test_testing.py
+++ b/tests/testing/test_testing.py
@@ -18,6 +18,7 @@ from starlite.datastructures import Cookie
 from starlite.enums import ParamType
 from starlite.middleware.session import SessionCookieConfig
 from starlite.testing import RequestFactory, TestClient
+from starlite.testing.create_test_client import create_test_client
 from tests import Pet, PetFactory
 
 if TYPE_CHECKING:
@@ -293,8 +294,11 @@ def test_test_client_get_session_data(
 
     app = Starlite(route_handlers=[set_session_data], middleware=[session_config.middleware])
 
-    with TestClient(
-        app=app, session_config=session_config, backend=test_client_backend, base_url="http://testserver.local"
-    ) as client:
+    with TestClient(app=app, session_config=session_config, backend=test_client_backend) as client:
         client.post("/test")
         assert client.get_session_data() == session_data
+
+
+def test_create_test_clientwarns_problematic_domain() -> None:
+    with pytest.warns(UserWarning):
+        create_test_client(base_url="http://testserver", route_handlers=[])


### PR DESCRIPTION
This addresses #706 by changing its base_url default from `http://testserver` to `http://testserver.local`. It also adds a check  in `TestClient` that emits a warning when a possibly problematic `base_url` is being used.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
