### PR TITLE
Layering for opt dictionary

### DIFF
--- a/docs/reference/config/0-app-config.md
+++ b/docs/reference/config/0-app-config.md
@@ -28,6 +28,7 @@
             - on_shutdown
             - on_startup
             - openapi_config
+            - opt
             - parameters
             - plugins
             - request_class

--- a/docs/reference/config/0-app-config.md
+++ b/docs/reference/config/0-app-config.md
@@ -20,6 +20,7 @@
             - csrf_config
             - debug
             - dependencies
+            - etag
             - exception_handlers
             - guards
             - logging_config

--- a/docs/reference/handlers/0-base-handler.md
+++ b/docs/reference/handlers/0-base-handler.md
@@ -1,3 +1,6 @@
 # Base Route Handler
 
 ::: starlite.handlers.base.BaseRouteHandler
+    options:
+        members:
+            - opt

--- a/docs/usage/2-route-handlers/5-handler-opts.md
+++ b/docs/usage/2-route-handlers/5-handler-opts.md
@@ -34,4 +34,4 @@ assert handler.opt["my_key"] == "some-value"
 
 You can specify the `opt` dictionary at all levels of your application. On specific route handlers, on a controller, a router, and even on the app instance itself.
 
-Resulting dictionary is constructed by merging opt dictionaries of all levels. If multiple layers define the same key, the value from the closest layer to the response handler will take precedence
+The resulting dictionary is constructed by merging opt dictionaries of all levels. If multiple layers define the same key, the value from the closest layer to the response handler will take precedence

--- a/docs/usage/2-route-handlers/5-handler-opts.md
+++ b/docs/usage/2-route-handlers/5-handler-opts.md
@@ -31,3 +31,7 @@ def handler() -> None:
 
 assert handler.opt["my_key"] == "some-value"
 ```
+
+You can specify the `opt` dictionary at all levels of your application. On specific route handlers, on a controller, a router, and even on the app instance itself.
+
+Resulting dictionary is constructed by merging opt dictionaries of all levels. If multiple layers define the same key, the value from the closest layer to the response handler will take precedence

--- a/docs/usage/5-responses/4-response-headers.md
+++ b/docs/usage/5-responses/4-response-headers.md
@@ -232,10 +232,11 @@ router = Router(
 ## Specific Headers Implementation
 
 Starlite has a dedicated implementation for a few headers that are commonly used. These headers can be set separately
-imported from `response_headers` with dedicated keyword arguments or as class attributes on all layers of the app
-(individual route handlers, controllers, routers and the app itself).
+with dedicated keyword arguments or as class attributes on all layers of the app (individual route handlers, controllers,
+routers and the app itself). Each layer overrides the layer above it - thus, the headers defined for a specific route
+handler will override those defined on its router, which will in turn override those defined on the app level.
 
-These header implementations allow easy creating, serialisation and parsing according to the associated header
+These header implementations allow easy creating, serialization and parsing according to the associated header
 specifications.
 
 ### Cache Control

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -286,7 +286,7 @@ class Starlite(Router):
             on_shutdown=on_shutdown or [],
             on_startup=on_startup or [],
             openapi_config=openapi_config,
-            opt=opt,
+            opt=opt or {},
             parameters=parameters or {},
             plugins=plugins or [],
             request_class=request_class,

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -158,6 +158,7 @@ class Starlite(Router):
         on_shutdown: Optional[List["LifeSpanHandler"]] = None,
         on_startup: Optional[List["LifeSpanHandler"]] = None,
         openapi_config: Optional[OpenAPIConfig] = DEFAULT_OPENAPI_CONFIG,
+        opt: Optional[Dict[str, Any]] = None,
         parameters: Optional["ParametersMap"] = None,
         plugins: Optional[List["PluginProtocol"]] = None,
         request_class: Optional[Type["Request"]] = None,
@@ -229,6 +230,8 @@ class Starlite(Router):
             on_startup: A list of [LifeSpanHandler][starlite.types.LifeSpanHandler] called during
                 application startup.
             openapi_config: Defaults to [DEFAULT_OPENAPI_CONFIG][starlite.app.DEFAULT_OPENAPI_CONFIG]
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you
+                have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             parameters: A mapping of [Parameter][starlite.params.Parameter] definitions available to all
                 application paths.
             plugins: List of plugins.
@@ -283,6 +286,7 @@ class Starlite(Router):
             on_shutdown=on_shutdown or [],
             on_startup=on_startup or [],
             openapi_config=openapi_config,
+            opt=opt,
             parameters=parameters or {},
             plugins=plugins or [],
             request_class=request_class,
@@ -331,6 +335,7 @@ class Starlite(Router):
             exception_handlers=config.exception_handlers,
             guards=config.guards,
             middleware=config.middleware,
+            opt=config.opt,
             parameters=config.parameters,
             path="",
             response_class=config.response_class,
@@ -407,7 +412,7 @@ class Starlite(Router):
                 self._create_handler_signature_model(route_handler=route_handler)
                 route_handler.resolve_guards()
                 route_handler.resolve_middleware()
-
+                route_handler.resolve_opts()
                 if isinstance(route_handler, HTTPRouteHandler):
                     route_handler.resolve_before_request()
                     route_handler.resolve_after_response()

--- a/starlite/config/app.py
+++ b/starlite/config/app.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 
 from pydantic import BaseConfig, BaseModel
 from pydantic_openapi_schema.v3_1_0 import SecurityRequirement
@@ -160,6 +160,12 @@ class AppConfig(BaseModel):
     openapi_config: Optional[OpenAPIConfig]
     """
     Defaults to [DEFAULT_OPENAPI_CONFIG][starlite.app.DEFAULT_OPENAPI_CONFIG]
+    """
+    opt: Optional[Dict[str, Any]]
+    """
+    A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you
+    have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope]. Can be overridden
+    by routers and router handlers.
     """
     parameters: ParametersMap
     """

--- a/starlite/config/app.py
+++ b/starlite/config/app.py
@@ -161,7 +161,7 @@ class AppConfig(BaseModel):
     """
     Defaults to [DEFAULT_OPENAPI_CONFIG][starlite.app.DEFAULT_OPENAPI_CONFIG]
     """
-    opt: Optional[Dict[str, Any]]
+    opt: Dict[str, Any]
     """
     A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you
     have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope]. Can be overridden

--- a/starlite/config/app.py
+++ b/starlite/config/app.py
@@ -130,8 +130,8 @@ class AppConfig(BaseModel):
     """
     etag: Optional[ETag]
     """
-        An `etag` header of type [ETag][starlite.datastructures.ETag] to add to route handlers of this app.
-        Can be overridden by route handlers.
+    An `etag` header of type [ETag][starlite.datastructures.ETag] to add to route handlers of this app.
+    Can be overridden by route handlers.
     """
     exception_handlers: ExceptionHandlersMap
     """

--- a/starlite/controller.py
+++ b/starlite/controller.py
@@ -1,5 +1,5 @@
 from copy import copy
-from typing import TYPE_CHECKING, List, Optional, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 from starlite.handlers import BaseRouteHandler
 from starlite.utils import AsyncCallable, normalize_path
@@ -40,6 +40,7 @@ class Controller:
         "exception_handlers",
         "guards",
         "middleware",
+        "opt",
         "owner",
         "parameters",
         "path",
@@ -91,6 +92,11 @@ class Controller:
     middleware: Optional[List["Middleware"]]
     """
         A list of [Middleware][starlite.types.Middleware].
+    """
+    opt: Optional[Dict[str, Any]]
+    """
+        A string key dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or
+        wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
     """
     owner: "Router"
     """

--- a/starlite/handlers/asgi.py
+++ b/starlite/handlers/asgi.py
@@ -35,7 +35,7 @@ class ASGIRouteHandler(BaseRouteHandler["ASGIRouteHandler"]):
             exception_handlers: A dictionary that maps handler functions to status codes and/or exception types.
             guards: A list of [Guard][starlite.types.Guard] callables.
             name: A string identifying the route handler.
-            opt: A string key dictionary of arbitrary values that can be accessed [Guards][starlite.types.Guard].
+            opt: A string key dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             path: A path fragment for the route handler function or a list of path fragments. If not given defaults to '/'
             is_mount: A boolean dictating whether the handler's paths should be regarded as mount paths. Mount path accept
                 any arbitrary paths that begin with the defined prefixed path. For example, a mount with the path `/some-path/`

--- a/starlite/handlers/base.py
+++ b/starlite/handlers/base.py
@@ -188,6 +188,21 @@ class BaseRouteHandler(Generic[T]):
             resolved_exception_handlers.update(layer.exception_handlers or {})
         return resolved_exception_handlers
 
+    def resolve_opts(self) -> None:
+        """Build route handler opt dictionary by going from top to bottom.
+
+        If multiple layers define the same key, the value from the
+        closest layer to the response handler will take precedence.
+        """
+
+        opt: Dict[str, Any] = {}
+        for layer in self.ownership_layers:
+            opt.update(layer.opt or {})
+
+        # we are operating on a copy of route handler so
+        # we can safely update self.opt
+        self.opt = opt
+
     async def authorize_connection(self, connection: "ASGIConnection") -> None:
         """Ensures the connection is authorized by running all the route guards
         in scope."""

--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -321,7 +321,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
                 valid IANA Media-Type.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string key dictionary of arbitrary values that can be accessed [Guards][starlite.types.Guard].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             response_class: A custom subclass of [starlite.response.Response] to be used as route handler's
                 default response.
             response_cookies: A list of [Cookie](starlite.datastructures.Cookie] instances.
@@ -691,7 +691,7 @@ class get(HTTPRouteHandler):
                 valid IANA Media-Type.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string key dictionary of arbitrary values that can be accessed [Guards][starlite.types.Guard].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             response_class: A custom subclass of [starlite.response.Response] to be used as route handler's
                 default response.
             response_cookies: A list of [Cookie](starlite.datastructures.Cookie] instances.
@@ -829,7 +829,7 @@ class post(HTTPRouteHandler):
                 valid IANA Media-Type.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string key dictionary of arbitrary values that can be accessed [Guards][starlite.types.Guard].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             response_class: A custom subclass of [starlite.response.Response] to be used as route handler's
                 default response.
             response_cookies: A list of [Cookie](starlite.datastructures.Cookie] instances.
@@ -966,7 +966,7 @@ class put(HTTPRouteHandler):
                 valid IANA Media-Type.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string key dictionary of arbitrary values that can be accessed [Guards][starlite.types.Guard].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             response_class: A custom subclass of [starlite.response.Response] to be used as route handler's
                 default response.
             response_cookies: A list of [Cookie](starlite.datastructures.Cookie] instances.
@@ -1105,7 +1105,7 @@ class patch(HTTPRouteHandler):
                 valid IANA Media-Type.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string key dictionary of arbitrary values that can be accessed [Guards][starlite.types.Guard].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             response_class: A custom subclass of [starlite.response.Response] to be used as route handler's
                 default response.
             response_cookies: A list of [Cookie](starlite.datastructures.Cookie] instances.
@@ -1242,7 +1242,7 @@ class delete(HTTPRouteHandler):
                 valid IANA Media-Type.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string key dictionary of arbitrary values that can be accessed [Guards][starlite.types.Guard].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             response_class: A custom subclass of [starlite.response.Response] to be used as route handler's
                 default response.
             response_cookies: A list of [Cookie](starlite.datastructures.Cookie] instances.

--- a/starlite/handlers/websocket.py
+++ b/starlite/handlers/websocket.py
@@ -35,7 +35,7 @@ class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):
             guards: A list of [Guard][starlite.types.Guard] callables.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string key dictionary of arbitrary values that can be accessed [Guards][starlite.types.Guard].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             path: A path fragment for the route handler function or a list of path fragments. If not given defaults to '/'
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """

--- a/starlite/router.py
+++ b/starlite/router.py
@@ -1,6 +1,6 @@
 import collections
 from copy import copy
-from typing import TYPE_CHECKING, Dict, ItemsView, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, ItemsView, List, Optional, Union, cast
 
 from pydantic import validate_arguments
 from pydantic_openapi_schema.v3_1_0 import SecurityRequirement
@@ -53,6 +53,7 @@ class Router:
         "exception_handlers",
         "guards",
         "middleware",
+        "opt",
         "owner",
         "parameters",
         "path",
@@ -78,6 +79,7 @@ class Router:
         exception_handlers: Optional[ExceptionHandlersMap] = None,
         guards: Optional[List[Guard]] = None,
         middleware: Optional[List[Middleware]] = None,
+        opt: Optional[Dict[str, Any]] = None,
         parameters: Optional[ParametersMap] = None,
         response_class: Optional[ResponseType] = None,
         response_cookies: Optional[ResponseCookies] = None,
@@ -108,6 +110,7 @@ class Router:
             exception_handlers: A dictionary that maps handler functions to status codes and/or exception types.
             guards: A list of [Guard][starlite.types.Guard] callables.
             middleware: A list of [Middleware][starlite.types.Middleware].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             parameters: A mapping of [Parameter][starlite.params.Parameter] definitions available to all
                 application paths.
             path: A path fragment that is prefixed to all route handlers, controllers and other routers associated
@@ -132,6 +135,7 @@ class Router:
         self.exception_handlers = exception_handlers or {}
         self.guards = guards or []
         self.middleware = middleware or []
+        self.opt: Dict[str, Any] = opt or {}
         self.owner: Optional["Router"] = None
         self.parameters = parameters or {}
         self.path = normalize_path(path)

--- a/tests/app/test_app_config.py
+++ b/tests/app/test_app_config.py
@@ -36,7 +36,7 @@ def app_config_object() -> AppConfig:
         on_shutdown=[],
         on_startup=[],
         openapi_config=None,
-        opt=None,
+        opt={},
         parameters={},
         plugins=[],
         response_class=None,

--- a/tests/app/test_app_config.py
+++ b/tests/app/test_app_config.py
@@ -36,6 +36,7 @@ def app_config_object() -> AppConfig:
         on_shutdown=[],
         on_startup=[],
         openapi_config=None,
+        opt=None,
         parameters={},
         plugins=[],
         response_class=None,

--- a/tests/handlers/base/test_opt.py
+++ b/tests/handlers/base/test_opt.py
@@ -1,8 +1,19 @@
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable, Dict
 
 import pytest
 
-from starlite import asgi, delete, get, patch, post, put, websocket
+from starlite import (
+    Controller,
+    Router,
+    Starlite,
+    asgi,
+    delete,
+    get,
+    patch,
+    post,
+    put,
+    websocket,
+)
 
 if TYPE_CHECKING:
     from starlite import WebSocket
@@ -37,3 +48,85 @@ def test_opt_settings(decorator: "RouteHandlerType", handler: Callable) -> None:
     base_opt = {"base": 1, "kwarg_value": 0}
     result = decorator("/", opt=base_opt, kwarg_value=2)(handler)  # type: ignore
     assert result.opt == {"base": 1, "kwarg_value": 2}
+
+
+@pytest.mark.parametrize(
+    "app_opt, router_opt, controller_opt, route_opt, expected_opt",
+    [
+        [
+            {"app": "app"},
+            {"router": "router"},
+            {"controller": "controller"},
+            {"route": "route"},
+            {"app": "app", "router": "router", "controller": "controller", "route": "route"},
+        ],
+        [
+            {"override": "app"},
+            {"router": "router"},
+            None,
+            {"override": "route"},
+            {"router": "router", "override": "route"},
+        ],
+        [None, None, None, None, {}],
+    ],
+)
+def test_opt_resolution(
+    app_opt: Dict[str, Any],
+    router_opt: Dict[str, Any],
+    controller_opt: Dict[str, Any],
+    route_opt: Dict[str, Any],
+    expected_opt: Dict[str, Any],
+) -> None:
+    class MyController(Controller):
+        path = "/controller"
+        opt = controller_opt
+
+        @get(opt=route_opt)
+        def handler(self) -> None:
+            ...
+
+    router = Router("/router", route_handlers=[MyController], opt=router_opt)
+    app = Starlite(route_handlers=[router], opt=app_opt)
+    assert (
+        app.asgi_router.root_route_map_node["children"]["/router/controller"]["asgi_handlers"]["GET"][1].opt
+        == expected_opt
+    )
+
+
+def test_opt_not_affected_by_route_handler_copying() -> None:
+    class MyController(Controller):
+        path = "/controller"
+
+        @get(opt={"route": "route"})
+        def handler(self) -> None:
+            ...
+
+    @get("/fn_handler", opt={"fn_route": "fn_route"})
+    def fn_handler() -> None:
+        ...
+
+    router = Router("/router", route_handlers=[MyController, fn_handler], opt={"router": "router"})
+    another_router = Router("/another_router", route_handlers=[MyController, fn_handler])
+
+    app = Starlite(route_handlers=[router, another_router])
+
+    assert app.asgi_router.root_route_map_node["children"]["/router/controller"]["asgi_handlers"]["GET"][1].opt == {
+        "router": "router",
+        "route": "route",
+    }
+    assert app.asgi_router.root_route_map_node["children"]["/router/fn_handler"]["asgi_handlers"]["GET"][1].opt == {
+        "router": "router",
+        "fn_route": "fn_route",
+    }
+
+    assert app.asgi_router.root_route_map_node["children"]["/another_router/controller"]["asgi_handlers"]["GET"][
+        1
+    ].opt == {
+        "route": "route",
+    }
+
+    assert app.asgi_router.root_route_map_node["children"]["/another_router/fn_handler"]["asgi_handlers"]["GET"][
+        1
+    ].opt == {
+        "fn_route": "fn_route",
+    }


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

Since #718 adds bypassing a middleware based on a flag in `opt` dictionary of a route handler it makes sense to apply layering for `opt` too.