### PR TITLE
Fix Rate-Limit middleware example in the docs

### DIFF
--- a/docs/usage/7-middleware/3-builtin-middlewares/6-rate-limit-middleware.md
+++ b/docs/usage/7-middleware/3-builtin-middlewares/6-rate-limit-middleware.md
@@ -5,16 +5,8 @@ the [IETF RateLimit draft specification](https://datatracker.ietf.org/doc/draft-
 
 To use the rate limit middleware, use the [`RateLimitConfig`][starlite.middleware.rate_limit.RateLimitConfig]:
 
-```python
-from starlite import Starlite
-from starlite.middleware import RateLimitConfig
-
-RateLimitConfig(
-    rate_limit=("second", 1),
-    exclude=["/schema"],
-)
-
-app = Starlite(route_handlers=[...], middleware=[RateLimitConfig.middleware])
+``` py
+--8<-- "examples/middleware/rate_limit.py"
 ```
 
 The only required configuration kwarg is `rate_limit`, which expects a tuple containing a time-unit (`second`, `minute`

--- a/examples/middleware/rate_limit.py
+++ b/examples/middleware/rate_limit.py
@@ -1,0 +1,13 @@
+from starlite import Starlite, get
+from starlite.middleware import RateLimitConfig
+
+rate_limit_config = RateLimitConfig(rate_limit=("minute", 1), exclude=["/schema"])
+
+
+@get("/")
+def handler() -> str:
+    """Handler which should not be accessed more than once per minute."""
+    return "ok"
+
+
+app = Starlite(route_handlers=[handler], middleware=[rate_limit_config.middleware])

--- a/examples/tests/middleware/test_rate_limit_middleware.py
+++ b/examples/tests/middleware/test_rate_limit_middleware.py
@@ -1,0 +1,13 @@
+from examples.middleware.rate_limit import app
+from starlite.status_codes import HTTP_200_OK, HTTP_429_TOO_MANY_REQUESTS
+from starlite.testing import TestClient
+
+
+def test_rate_limit_middleware_example() -> None:
+    with TestClient(app=app) as client:
+        response = client.get("/")
+        assert response.status_code == HTTP_200_OK
+        assert response.text == "ok"
+
+        response = client.get("/")
+        assert response.status_code == HTTP_429_TOO_MANY_REQUESTS

--- a/starlite/__init__.py
+++ b/starlite/__init__.py
@@ -77,7 +77,7 @@ from starlite.plugins import PluginProtocol
 from starlite.response import Response
 from starlite.router import Router
 from starlite.routes import ASGIRoute, BaseRoute, HTTPRoute, WebSocketRoute
-from starlite.testing import TestClient, create_test_client  # type: ignore[no-redef]
+from starlite.testing import TestClient, create_test_client
 from starlite.types.partial import Partial
 
 __all__ = (

--- a/starlite/asgi/routing_trie/utils.py
+++ b/starlite/asgi/routing_trie/utils.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from starlite.asgi.routing_trie.types import RouteTrieNode  # type: ignore[attr-defined] # isort: skip
+    from starlite.asgi.routing_trie.types import RouteTrieNode
 
 
 def create_node() -> "RouteTrieNode":


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

I noticed that example on the RateLimit middleware is incorrect. Middleware should be created by accessing `middleware` property on config object.