### PR TITLE
Replace starlettes `Headers` and `MutableHeaders`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,6 +105,7 @@ repos:
             httpx,
             jinja2,
             mako,
+            multidict,
             orjson,
             piccolo,
             picologging,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,6 +128,7 @@ repos:
         args: ["--unsafe-load-any-extension=y"]
         additional_dependencies:
           [
+            multidict,
             orjson,
             piccolo,
             picologging,
@@ -151,6 +152,7 @@ repos:
           [
             aiomcache,
             httpx,
+            multidict,
             orjson,
             piccolo,
             picologging,
@@ -183,6 +185,7 @@ repos:
             httpx,
             hypothesis,
             mako,
+            multidict,
             orjson,
             jinja2,
             piccolo,

--- a/docs/reference/datastructures/3-headers.md
+++ b/docs/reference/datastructures/3-headers.md
@@ -1,5 +1,38 @@
 # Headers
 
+::: starlite.datastructures.Headers
+    options:
+        members:
+            - __init__
+            - from_scope
+            - from_message
+            - raw
+            - keys
+            - values
+            - items
+            - getlist
+            - mutablecopy
+
+
+::: starlite.datastructures.MutableHeaders
+    options:
+        members:
+            - __init__
+            - from_scope
+            - from_message
+            - raw
+            - keys
+            - values
+            - items
+            - getall
+            - getlist
+            - mutablecopy
+            - setdefault
+            - update
+            - append
+            - add_vary_header
+
+
 ::: starlite.datastructures.ResponseHeader
     options:
         members:

--- a/docs/usage/2-route-handlers/0-route-handlers-concept.md
+++ b/docs/usage/2-route-handlers/0-route-handlers-concept.md
@@ -99,7 +99,7 @@ Additionally, you can specify the following special kwargs, what's called "reser
 ```python
 from typing import Any, Dict
 from starlite import State, Request, get
-from starlette.datastructures import Headers
+from starlite.datastructures import Headers
 
 
 @get(path="/")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -185,7 +185,7 @@ nav:
           - reference/datastructures/0-state.md
           - reference/datastructures/1-cookie.md
           - reference/datastructures/2-provide.md
-          - reference/datastructures/3-header.md
+          - reference/datastructures/3-headers.md
           - reference/datastructures/4-background.md
           - reference/datastructures/5-response-containers.md
           - reference/datastructures/6-upload-file.md

--- a/poetry.lock
+++ b/poetry.lock
@@ -511,6 +511,14 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "multidict"
+version = "6.0.2"
+description = "multidict implementation"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -1134,7 +1142,7 @@ structlog = ["structlog"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "416c4f61a33cfb6efde867abb686e9bb20a5300fef6faee8ba98d4c559acf34e"
+content-hash = "d2d47a7d6b94922f3af7004d0c785ebed19108dcdf699b42e627430a00211421"
 
 [metadata.files]
 aiomcache = [
@@ -1649,6 +1657,67 @@ markupsafe = [
     {file = "MarkupSafe-2.1.1-cp39-cp39-win32.whl", hash = "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c"},
     {file = "MarkupSafe-2.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247"},
     {file = "MarkupSafe-2.1.1.tar.gz", hash = "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b"},
+]
+multidict = [
+    {file = "multidict-6.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b9e95a740109c6047602f4db4da9949e6c5945cefbad34a1299775ddc9a62e2"},
+    {file = "multidict-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac0e27844758d7177989ce406acc6a83c16ed4524ebc363c1f748cba184d89d3"},
+    {file = "multidict-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:041b81a5f6b38244b34dc18c7b6aba91f9cdaf854d9a39e5ff0b58e2b5773b9c"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fdda29a3c7e76a064f2477c9aab1ba96fd94e02e386f1e665bca1807fc5386f"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3368bf2398b0e0fcbf46d85795adc4c259299fec50c1416d0f77c0a843a3eed9"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f4f052ee022928d34fe1f4d2bc743f32609fb79ed9c49a1710a5ad6b2198db20"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:225383a6603c086e6cef0f2f05564acb4f4d5f019a4e3e983f572b8530f70c88"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:50bd442726e288e884f7be9071016c15a8742eb689a593a0cac49ea093eef0a7"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:47e6a7e923e9cada7c139531feac59448f1f47727a79076c0b1ee80274cd8eee"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0556a1d4ea2d949efe5fd76a09b4a82e3a4a30700553a6725535098d8d9fb672"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:626fe10ac87851f4cffecee161fc6f8f9853f0f6f1035b59337a51d29ff3b4f9"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:8064b7c6f0af936a741ea1efd18690bacfbae4078c0c385d7c3f611d11f0cf87"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2d36e929d7f6a16d4eb11b250719c39560dd70545356365b494249e2186bc389"},
+    {file = "multidict-6.0.2-cp310-cp310-win32.whl", hash = "sha256:fcb91630817aa8b9bc4a74023e4198480587269c272c58b3279875ed7235c293"},
+    {file = "multidict-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:8cbf0132f3de7cc6c6ce00147cc78e6439ea736cee6bca4f068bcf892b0fd658"},
+    {file = "multidict-6.0.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:05f6949d6169878a03e607a21e3b862eaf8e356590e8bdae4227eedadacf6e51"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2c2e459f7050aeb7c1b1276763364884595d47000c1cddb51764c0d8976e608"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d0509e469d48940147e1235d994cd849a8f8195e0bca65f8f5439c56e17872a3"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:514fe2b8d750d6cdb4712346a2c5084a80220821a3e91f3f71eec11cf8d28fd4"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19adcfc2a7197cdc3987044e3f415168fc5dc1f720c932eb1ef4f71a2067e08b"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9d153e7f1f9ba0b23ad1568b3b9e17301e23b042c23870f9ee0522dc5cc79e8"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:aef9cc3d9c7d63d924adac329c33835e0243b5052a6dfcbf7732a921c6e918ba"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4571f1beddff25f3e925eea34268422622963cd8dc395bb8778eb28418248e43"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:d48b8ee1d4068561ce8033d2c344cf5232cb29ee1a0206a7b828c79cbc5982b8"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:45183c96ddf61bf96d2684d9fbaf6f3564d86b34cb125761f9a0ef9e36c1d55b"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:75bdf08716edde767b09e76829db8c1e5ca9d8bb0a8d4bd94ae1eafe3dac5e15"},
+    {file = "multidict-6.0.2-cp37-cp37m-win32.whl", hash = "sha256:a45e1135cb07086833ce969555df39149680e5471c04dfd6a915abd2fc3f6dbc"},
+    {file = "multidict-6.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6f3cdef8a247d1eafa649085812f8a310e728bdf3900ff6c434eafb2d443b23a"},
+    {file = "multidict-6.0.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:0327292e745a880459ef71be14e709aaea2f783f3537588fb4ed09b6c01bca60"},
+    {file = "multidict-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e875b6086e325bab7e680e4316d667fc0e5e174bb5611eb16b3ea121c8951b86"},
+    {file = "multidict-6.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:feea820722e69451743a3d56ad74948b68bf456984d63c1a92e8347b7b88452d"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc57c68cb9139c7cd6fc39f211b02198e69fb90ce4bc4a094cf5fe0d20fd8b0"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:497988d6b6ec6ed6f87030ec03280b696ca47dbf0648045e4e1d28b80346560d"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:89171b2c769e03a953d5969b2f272efa931426355b6c0cb508022976a17fd376"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:684133b1e1fe91eda8fa7447f137c9490a064c6b7f392aa857bba83a28cfb693"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd9fc9c4849a07f3635ccffa895d57abce554b467d611a5009ba4f39b78a8849"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e07c8e79d6e6fd37b42f3250dba122053fddb319e84b55dd3a8d6446e1a7ee49"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:4070613ea2227da2bfb2c35a6041e4371b0af6b0be57f424fe2318b42a748516"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:47fbeedbf94bed6547d3aa632075d804867a352d86688c04e606971595460227"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:5774d9218d77befa7b70d836004a768fb9aa4fdb53c97498f4d8d3f67bb9cfa9"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2957489cba47c2539a8eb7ab32ff49101439ccf78eab724c828c1a54ff3ff98d"},
+    {file = "multidict-6.0.2-cp38-cp38-win32.whl", hash = "sha256:e5b20e9599ba74391ca0cfbd7b328fcc20976823ba19bc573983a25b32e92b57"},
+    {file = "multidict-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:8004dca28e15b86d1b1372515f32eb6f814bdf6f00952699bdeb541691091f96"},
+    {file = "multidict-6.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2e4a0785b84fb59e43c18a015ffc575ba93f7d1dbd272b4cdad9f5134b8a006c"},
+    {file = "multidict-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6701bf8a5d03a43375909ac91b6980aea74b0f5402fbe9428fc3f6edf5d9677e"},
+    {file = "multidict-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a007b1638e148c3cfb6bf0bdc4f82776cef0ac487191d093cdc316905e504071"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07a017cfa00c9890011628eab2503bee5872f27144936a52eaab449be5eaf032"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c207fff63adcdf5a485969131dc70e4b194327666b7e8a87a97fbc4fd80a53b2"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:373ba9d1d061c76462d74e7de1c0c8e267e9791ee8cfefcf6b0b2495762c370c"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfba7c6d5d7c9099ba21f84662b037a0ffd4a5e6b26ac07d19e423e6fdf965a9"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19d9bad105dfb34eb539c97b132057a4e709919ec4dd883ece5838bcbf262b80"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:de989b195c3d636ba000ee4281cd03bb1234635b124bf4cd89eeee9ca8fcb09d"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7c40b7bbece294ae3a87c1bc2abff0ff9beef41d14188cda94ada7bcea99b0fb"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:d16cce709ebfadc91278a1c005e3c17dd5f71f5098bfae1035149785ea6e9c68"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:a2c34a93e1d2aa35fbf1485e5010337c72c6791407d03aa5f4eed920343dd360"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:feba80698173761cddd814fa22e88b0661e98cb810f9f986c54aa34d281e4937"},
+    {file = "multidict-6.0.2-cp39-cp39-win32.whl", hash = "sha256:23b616fdc3c74c9fe01d76ce0d1ce872d2d396d8fa8e4899398ad64fb5aa214a"},
+    {file = "multidict-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:4bae31803d708f6f15fd98be6a6ac0b6958fcf68fda3c77a048a4f9073704aae"},
+    {file = "multidict-6.0.2.tar.gz", hash = "sha256:5ff3bd75f38e4c43f1f470f2df7a4d430b821c4ce22be384e1459cb57d6bb013"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ starlette = ">=0.21"
 starlite-multipart = ">=1.2.0"
 structlog = { version = "*", optional = true }
 typing-extensions = "*"
+multidict = "^6.0.2"
 
 [tool.poetry.group.dev.dependencies]
 aiomcache = "*"

--- a/starlite/connection/base.py
+++ b/starlite/connection/base.py
@@ -12,8 +12,8 @@ from typing import (
 
 from starlette.datastructures import URL, Address, URLPath
 
-from starlite.datastructures.state import State
 from starlite.datastructures.headers import Headers
+from starlite.datastructures.state import State
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.parsers import parse_cookie_string, parse_query_params
 from starlite.types.empty import Empty
@@ -152,7 +152,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
         """
         if self._headers is Empty:
             self.scope.setdefault("headers", [])
-            self._headers = self.scope["_headers"] = Headers(scope=self.scope)  # type: ignore[typeddict-item]
+            self._headers = self.scope["_headers"] = Headers.from_scope(self.scope)  # type: ignore[typeddict-item]
         return cast("Headers", self._headers)
 
     @property

--- a/starlite/connection/base.py
+++ b/starlite/connection/base.py
@@ -10,9 +10,10 @@ from typing import (
     cast,
 )
 
-from starlette.datastructures import URL, Address, Headers, URLPath
+from starlette.datastructures import URL, Address, URLPath
 
 from starlite.datastructures.state import State
+from starlite.datastructures.headers import Headers
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.parsers import parse_cookie_string, parse_query_params
 from starlite.types.empty import Empty

--- a/starlite/connection/websocket.py
+++ b/starlite/connection/websocket.py
@@ -12,7 +12,8 @@ from typing import (
 )
 
 from orjson import OPT_OMIT_MICROSECONDS, OPT_SERIALIZE_NUMPY, dumps, loads
-from starlette.datastructures import Headers
+from starlite.datastructures.headers import Headers
+
 
 from starlite.connection.base import (
     ASGIConnection,

--- a/starlite/connection/websocket.py
+++ b/starlite/connection/websocket.py
@@ -12,8 +12,6 @@ from typing import (
 )
 
 from orjson import OPT_OMIT_MICROSECONDS, OPT_SERIALIZE_NUMPY, dumps, loads
-from starlite.datastructures.headers import Headers
-
 
 from starlite.connection.base import (
     ASGIConnection,
@@ -22,6 +20,7 @@ from starlite.connection.base import (
     empty_receive,
     empty_send,
 )
+from starlite.datastructures.headers import Headers
 from starlite.exceptions import WebSocketDisconnect, WebSocketException
 from starlite.status_codes import WS_1000_NORMAL_CLOSURE
 from starlite.utils.serialization import default_serializer

--- a/starlite/datastructures/__init__.py
+++ b/starlite/datastructures/__init__.py
@@ -1,7 +1,12 @@
 from starlite.datastructures.background_tasks import BackgroundTask, BackgroundTasks
 from starlite.datastructures.cookie import Cookie
 from starlite.datastructures.form_multi_dict import FormMultiDict
-from starlite.datastructures.headers import CacheControlHeader, ETag
+from starlite.datastructures.headers import (
+    CacheControlHeader,
+    ETag,
+    Headers,
+    MutableHeaders,
+)
 from starlite.datastructures.provide import Provide
 from starlite.datastructures.response_containers import (
     File,
@@ -13,7 +18,6 @@ from starlite.datastructures.response_containers import (
 from starlite.datastructures.response_header import ResponseHeader
 from starlite.datastructures.state import State
 from starlite.datastructures.upload_file import UploadFile
-from starlite.datastructures.headers import MutableHeaders, Headers
 
 __all__ = (
     "BackgroundTask",

--- a/starlite/datastructures/__init__.py
+++ b/starlite/datastructures/__init__.py
@@ -13,6 +13,7 @@ from starlite.datastructures.response_containers import (
 from starlite.datastructures.response_header import ResponseHeader
 from starlite.datastructures.state import State
 from starlite.datastructures.upload_file import UploadFile
+from starlite.datastructures.headers import MutableHeaders, Headers
 
 __all__ = (
     "BackgroundTask",
@@ -22,6 +23,8 @@ __all__ = (
     "ETag",
     "File",
     "FormMultiDict",
+    "Headers",
+    "MutableHeaders",
     "Provide",
     "Redirect",
     "ResponseContainer",

--- a/starlite/datastructures/headers.py
+++ b/starlite/datastructures/headers.py
@@ -1,128 +1,318 @@
+"""The code for `MutableHeaders` and parts of `Headers` was adopted from https:
+
+//github.com/encode/starlette/blob/e7d000a76d9e4ea5951a8b3b028a057e4df9484c/sta
+rlette/datastructures.py.
+
+Copyright © 2018, [Encode OSS Ltd](https://www.encode.io/).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
 import re
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Dict, Iterator, List, Mapping, Optional, Tuple
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    Union,
+)
 
 from multidict import CIMultiDict, CIMultiDictProxy
 from pydantic import BaseModel, Extra, Field, ValidationError, validator
 from typing_extensions import Annotated
 
 from starlite.exceptions import ImproperlyConfiguredException
+from starlite.utils import deprecated
+
+if TYPE_CHECKING:
+    from starlite.types.asgi_types import Message, RawHeadersList, Scope
 
 ETAG_RE = re.compile(r'([Ww]/)?"(.+)"')
 
 
-class Headers(CIMultiDictProxy[str, str]):
-    """
-    An immutable, case-insensitive multidict.
-    """
+def _encode_headers(headers: Iterable[Tuple[str, str]]) -> "RawHeadersList":
+    return [(key.lower().encode("latin-1"), value.encode("latin-1")) for key, value in headers]
 
-    def __init__(
-        self,
-        headers: Optional[Mapping[str, str]] = None,
-        raw: Optional[List[Tuple[bytes, bytes]]] = None,
-        scope: Optional[Mapping[str, Any]] = None,
-    ) -> None:
-        _list: List[Tuple[str, str]] = []
-        if headers is not None:
-            assert raw is None, 'Cannot set both "headers" and "raw".'
-            assert scope is None, 'Cannot set both "headers" and "scope".'
-            _list = [(key.lower(), value) for key, value in headers.items()]
-        elif raw is not None:
-            assert scope is None, 'Cannot set both "raw" and "scope".'
-            _list = [(key.decode("latin-1"), value.decode("latin-1")) for key, value in raw]
-        elif scope is not None:
-            _list = [(key.decode("latin-1"), value.decode("latin-1")) for key, value in scope["headers"]]
-        super().__init__(CIMultiDict(_list))
+
+class Headers(CIMultiDictProxy[str]):
+    """An immutable, case-insensitive multidict."""
+
+    def __init__(self, headers: Optional[Union[Mapping[str, str], "RawHeadersList"]] = None) -> None:
+        headers_: Union[Mapping[str, str], List[Tuple[str, str]]] = {}
+        if isinstance(headers, list):
+            headers_ = [(key.decode("latin-1"), value.decode("latin-1")) for key, value in headers]
+        elif headers:
+            headers_ = headers
+
+        super().__init__(CIMultiDict(headers_))
+
+    @classmethod
+    def from_scope(cls, scope: "Scope") -> "Headers":
+        """Create headers from a `Scope`.
+
+        Args:
+            scope: An ASGI Scope
+
+        Returns:
+            Headers
+        """
+        return cls(list(scope["headers"]))
+
+    @classmethod
+    def from_message(cls, message: "Message") -> "Headers":
+        """
+        Create headers from a send-message.
+        Args:
+            message: An message
+
+        Returns:
+            Headers
+
+        Raises:
+            ValueError: If the message does not have a `headers` key
+        """
+        try:
+            return cls(message["headers"])  # type: ignore[typeddict-item]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported message type: {message['type']!r}") from exc
 
     @property
-    def raw(self) -> List[Tuple[bytes, bytes]]:
-        return [(key.encode("latin-1"), value.encode("latin-1")) for key in self for value in self.getlist(key)]
+    def raw(self) -> "RawHeadersList":
+        """Raw header value.
 
+        Returns:
+            A list of tuples contain the header and header-value as bytes
+        """
+        return _encode_headers((key, value) for key in set(self) for value in self.getlist(key))
+
+    def keys(self) -> List[str]:  # type: ignore[override]
+        """Get a list of all header names. Contains duplicates.
+
+        Returns:
+            A list of strings
+        """
+        return list(super().keys())
+
+    def values(self) -> List[str]:  # type: ignore[override]
+        """Get a list of all header values, including values of duplicate
+        headers.
+
+        Returns:
+            A list of strings
+        """
+        return list(super().values())
+
+    def items(self) -> List[Tuple[str, str]]:  # type: ignore[override]
+        """Get a list of all headers and values.
+
+        Returns:
+            A list of tuples containing header names and values
+        """
+        return list(super().items())
+
+    @deprecated("1.36.0", alternative="Headers.getall")
     def getlist(self, key: str) -> List[str]:
+        """Get all values of a header.
+
+        Args:
+            key: Name of the header
+
+        Returns:
+            A list of values
+        """
         return super().getall(key, [])
 
     def mutablecopy(self) -> "MutableHeaders":
-        return MutableHeaders(raw=self.raw)
+        """Create a mutable copy.
 
-    def keys(self) -> List[str]:
-        return list(super().keys())
-
-    def values(self) -> List[str]:
-        return list(super().values())
-
-    def items(self) -> List[str]:
-        return list(super().items())
+        Returns:
+            A [MutableHeaders][starlite.datastructures.headers.MutableHeaders] instance
+        """
+        return MutableHeaders(self.raw[:])
 
 
-class MutableHeaders(Mapping[str, str]):
-    """
-    An immutable, case-insensitive multidict.
-    """
+class MutableHeaders(Mapping):
+    def __init__(self, headers: Optional[Union[Mapping[str, str], "RawHeadersList"]] = None) -> None:
+        self._list: "RawHeadersList" = []
+        if headers:
+            if not isinstance(headers, list):
+                self._list = _encode_headers(headers.items())
+            else:
+                self._list = headers
 
-    def __init__(
-        self,
-        headers: Optional[Mapping[str, str]] = None,
-        raw: Optional[List[Tuple[bytes, bytes]]] = None,
-        scope: Optional[Mapping[str, Any]] = None,
-    ) -> None:
-        self._list: List[Tuple[bytes, bytes]] = []
-        if headers is not None:
-            assert raw is None, 'Cannot set both "headers" and "raw".'
-            assert scope is None, 'Cannot set both "headers" and "scope".'
-            self._list = [(key.lower().encode("latin-1"), value.encode("latin-1")) for key, value in headers.items()]
-        elif raw is not None:
-            assert scope is None, 'Cannot set both "raw" and "scope".'
-            self._list = raw
-        elif scope is not None:
-            self._list = scope["headers"]
+    @classmethod
+    def from_scope(cls, scope: "Scope") -> "MutableHeaders":
+        """Create headers from a `Scope`.
+
+        Args:
+            scope: An ASGI Scope
+
+        Returns:
+            Headers
+        """
+        return cls(scope["headers"])
+
+    @classmethod
+    def from_message(cls, message: "Message") -> "MutableHeaders":
+        """
+        Create headers from a send-message.
+        Args:
+            message: An message
+
+        Returns:
+            Headers
+
+        Raises:
+            ValueError: If the message does not have a `headers` key
+        """
+        try:
+            return cls(message["headers"])  # type: ignore[typeddict-item]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported message type: {message['type']!r}") from exc
 
     @property
-    def raw(self) -> List[Tuple[bytes, bytes]]:
+    def raw(self) -> "RawHeadersList":
+        """Raw header value.
+
+        Returns:
+            A list of tuples contain the header and header-value as bytes
+        """
         return self._list
 
-    def keys(self) -> List[str]:  # type: ignore
+    def keys(self) -> List[str]:  # type: ignore[override]
+        """Get a list of all header names.
+
+        Returns:
+            A list of strings
+        """
         return [key.decode("latin-1") for key, value in self._list]
 
-    def values(self) -> List[str]:  # type: ignore
+    def values(self) -> List[str]:  # type: ignore[override]
+        """Get a list of all header values, including values of duplicate
+        headers.
+
+        Returns:
+            A list of strings
+        """
         return [value.decode("latin-1") for key, value in self._list]
 
-    def items(self) -> List[Tuple[str, str]]:  # type: ignore
+    def items(self) -> List[Tuple[str, str]]:  # type: ignore[override]
+        """Get a list of all headers and values.
+
+        Returns:
+            A list of tuples containing header names and values
+        """
         return [(key.decode("latin-1"), value.decode("latin-1")) for key, value in self._list]
 
-    def getlist(self, key: str) -> List[str]:
+    def getall(self, key: str) -> List[str]:
+        """Get all values of a header.
+
+        Args:
+            key: Name of the header
+
+        Returns:
+            A list of values
+        """
         get_header_key = key.lower().encode("latin-1")
         return [item_value.decode("latin-1") for item_key, item_value in self._list if item_key == get_header_key]
 
+    @deprecated("1.36.0", alternative="MutableHeaders.getall")
+    def getlist(self, key: str) -> List[str]:
+        """Get all values of a header.
+
+        Args:
+            key: Name of the header
+
+        Returns:
+            A list of values
+        """
+        return self.getall(key)
+
     def mutablecopy(self) -> "MutableHeaders":
-        return MutableHeaders(raw=self._list[:])
+        """Create a mutable copy.
+
+        Returns:
+            A [MutableHeaders][starlite.datastructures.headers.MutableHeaders] instance
+        """
+        return MutableHeaders(self._list[:])
 
     def setdefault(self, key: str, value: str) -> str:
-        """
-        If the header `key` does not exist, then set it to `value`.
+        """If the header `key` does not exist, then set it to `value`.
+
         Returns the header value.
         """
         set_key = key.lower().encode("latin-1")
         set_value = value.encode("latin-1")
 
-        for idx, (item_key, item_value) in enumerate(self._list):
+        for item_key, item_value in self._list:
             if item_key == set_key:
                 return item_value.decode("latin-1")
         self._list.append((set_key, set_value))
         return value
 
     def update(self, other: Mapping) -> None:
+        """Update headers.
+
+        Args:
+            other: A mapping containing header names and values
+
+        Returns:
+            None
+        """
         for key, val in other.items():
             self[key] = val
 
     def append(self, key: str, value: str) -> None:
-        """
-        Append a header, preserving any duplicate entries.
+        """Append a header, preserving any duplicate entries.
+
+        Args:
+            key: Header name
+            value: Header value
         """
         append_key = key.lower().encode("latin-1")
         append_value = value.encode("latin-1")
         self._list.append((append_key, append_value))
 
     def add_vary_header(self, vary: str) -> None:
+        """Add a `vary` header, updating an existing one.
+
+        Args:
+            vary: Header value
+
+        Returns:
+            None
+        """
         existing = self.get("vary")
         if existing is not None:
             vary = ", ".join([existing, vary])
@@ -136,11 +326,8 @@ class MutableHeaders(Mapping[str, str]):
         raise KeyError(key)
 
     def __contains__(self, key: Any) -> bool:
-        get_header_key = key.lower().encode("latin-1")
-        for header_key, header_value in self._list:
-            if header_key == get_header_key:
-                return True
-        return False
+        encoded_header_key = key.lower().encode("latin-1")
+        return any(header_key == encoded_header_key for header_key, _ in self._list)
 
     def __iter__(self) -> Iterator[Any]:
         return iter(self.keys())
@@ -154,15 +341,15 @@ class MutableHeaders(Mapping[str, str]):
         return sorted(self.raw) == sorted(other.raw)
 
     def __setitem__(self, key: str, value: str) -> None:
-        """
-        Set the header `key` to `value`, removing any duplicate entries.
+        """Set the header `key` to `value`, removing any duplicate entries.
+
         Retains insertion order.
         """
         set_key = key.lower().encode("latin-1")
         set_value = value.encode("latin-1")
 
         found_indexes = []
-        for idx, (item_key, item_value) in enumerate(self._list):
+        for idx, (item_key, _) in enumerate(self._list):
             if item_key == set_key:
                 found_indexes.append(idx)
 
@@ -176,13 +363,11 @@ class MutableHeaders(Mapping[str, str]):
             self._list.append((set_key, set_value))
 
     def __delitem__(self, key: str) -> None:
-        """
-        Remove the header `key`.
-        """
+        """Remove the header `key`."""
         del_key = key.lower().encode("latin-1")
 
         pop_indexes = []
-        for idx, (item_key, item_value) in enumerate(self._list):
+        for idx, (item_key, _) in enumerate(self._list):
             if item_key == del_key:
                 pop_indexes.append(idx)
 

--- a/starlite/datastructures/headers.py
+++ b/starlite/datastructures/headers.py
@@ -55,6 +55,8 @@ from typing_extensions import Annotated
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.utils import deprecated
 
+from starlette.datastructures import Headers
+
 if TYPE_CHECKING:
     from starlite.types.asgi_types import Message, RawHeadersList, Scope
 
@@ -66,7 +68,8 @@ def _encode_headers(headers: Iterable[Tuple[str, str]]) -> "RawHeadersList":
 
 
 class Headers(CIMultiDictProxy[str]):
-    """An immutable, case-insensitive multidict."""
+    """An immutable, case-insensitive [multidict](https://multidict.aio-
+    libs.org/en/stable/multidict.html#cimultidictproxy) for HTTP headers."""
 
     def __init__(self, headers: Optional[Union[Mapping[str, str], "RawHeadersList"]] = None) -> None:
         headers_: Union[Mapping[str, str], List[Tuple[str, str]]] = {}
@@ -163,6 +166,8 @@ class Headers(CIMultiDictProxy[str]):
 
 
 class MutableHeaders(Mapping):
+    """A case-insensitive multidict for HTTP headers."""
+
     def __init__(self, headers: Optional[Union[Mapping[str, str], "RawHeadersList"]] = None) -> None:
         self._list: "RawHeadersList" = []
         if headers:

--- a/starlite/datastructures/headers.py
+++ b/starlite/datastructures/headers.py
@@ -1,10 +1,9 @@
 import re
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Dict, Iterator, List, Mapping, Optional, Tuple
-from multidict import MultiDict, CIMultiDictProxy, CIMultiDict
 
+from multidict import CIMultiDict, CIMultiDictProxy
 from pydantic import BaseModel, Extra, Field, ValidationError, validator
-from starlette.datastructures import MutableHeaders
 from typing_extensions import Annotated
 
 from starlite.exceptions import ImproperlyConfiguredException
@@ -53,6 +52,155 @@ class Headers(CIMultiDictProxy[str, str]):
 
     def items(self) -> List[str]:
         return list(super().items())
+
+
+class MutableHeaders(Mapping[str, str]):
+    """
+    An immutable, case-insensitive multidict.
+    """
+
+    def __init__(
+        self,
+        headers: Optional[Mapping[str, str]] = None,
+        raw: Optional[List[Tuple[bytes, bytes]]] = None,
+        scope: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        self._list: List[Tuple[bytes, bytes]] = []
+        if headers is not None:
+            assert raw is None, 'Cannot set both "headers" and "raw".'
+            assert scope is None, 'Cannot set both "headers" and "scope".'
+            self._list = [(key.lower().encode("latin-1"), value.encode("latin-1")) for key, value in headers.items()]
+        elif raw is not None:
+            assert scope is None, 'Cannot set both "raw" and "scope".'
+            self._list = raw
+        elif scope is not None:
+            self._list = scope["headers"]
+
+    @property
+    def raw(self) -> List[Tuple[bytes, bytes]]:
+        return self._list
+
+    def keys(self) -> List[str]:  # type: ignore
+        return [key.decode("latin-1") for key, value in self._list]
+
+    def values(self) -> List[str]:  # type: ignore
+        return [value.decode("latin-1") for key, value in self._list]
+
+    def items(self) -> List[Tuple[str, str]]:  # type: ignore
+        return [(key.decode("latin-1"), value.decode("latin-1")) for key, value in self._list]
+
+    def getlist(self, key: str) -> List[str]:
+        get_header_key = key.lower().encode("latin-1")
+        return [item_value.decode("latin-1") for item_key, item_value in self._list if item_key == get_header_key]
+
+    def mutablecopy(self) -> "MutableHeaders":
+        return MutableHeaders(raw=self._list[:])
+
+    def setdefault(self, key: str, value: str) -> str:
+        """
+        If the header `key` does not exist, then set it to `value`.
+        Returns the header value.
+        """
+        set_key = key.lower().encode("latin-1")
+        set_value = value.encode("latin-1")
+
+        for idx, (item_key, item_value) in enumerate(self._list):
+            if item_key == set_key:
+                return item_value.decode("latin-1")
+        self._list.append((set_key, set_value))
+        return value
+
+    def update(self, other: Mapping) -> None:
+        for key, val in other.items():
+            self[key] = val
+
+    def append(self, key: str, value: str) -> None:
+        """
+        Append a header, preserving any duplicate entries.
+        """
+        append_key = key.lower().encode("latin-1")
+        append_value = value.encode("latin-1")
+        self._list.append((append_key, append_value))
+
+    def add_vary_header(self, vary: str) -> None:
+        existing = self.get("vary")
+        if existing is not None:
+            vary = ", ".join([existing, vary])
+        self["vary"] = vary
+
+    def __getitem__(self, key: str) -> str:
+        get_header_key = key.lower().encode("latin-1")
+        for header_key, header_value in self._list:
+            if header_key == get_header_key:
+                return header_value.decode("latin-1")
+        raise KeyError(key)
+
+    def __contains__(self, key: Any) -> bool:
+        get_header_key = key.lower().encode("latin-1")
+        for header_key, header_value in self._list:
+            if header_key == get_header_key:
+                return True
+        return False
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self.keys())
+
+    def __len__(self) -> int:
+        return len(self._list)
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Headers):
+            return False
+        return sorted(self.raw) == sorted(other.raw)
+
+    def __setitem__(self, key: str, value: str) -> None:
+        """
+        Set the header `key` to `value`, removing any duplicate entries.
+        Retains insertion order.
+        """
+        set_key = key.lower().encode("latin-1")
+        set_value = value.encode("latin-1")
+
+        found_indexes = []
+        for idx, (item_key, item_value) in enumerate(self._list):
+            if item_key == set_key:
+                found_indexes.append(idx)
+
+        for idx in reversed(found_indexes[1:]):
+            del self._list[idx]
+
+        if found_indexes:
+            idx = found_indexes[0]
+            self._list[idx] = (set_key, set_value)
+        else:
+            self._list.append((set_key, set_value))
+
+    def __delitem__(self, key: str) -> None:
+        """
+        Remove the header `key`.
+        """
+        del_key = key.lower().encode("latin-1")
+
+        pop_indexes = []
+        for idx, (item_key, item_value) in enumerate(self._list):
+            if item_key == del_key:
+                pop_indexes.append(idx)
+
+        for idx in reversed(pop_indexes):
+            del self._list[idx]
+
+    def __ior__(self, other: Mapping) -> "MutableHeaders":
+        if not isinstance(other, Mapping):
+            raise TypeError(f"Expected a mapping but got {other.__class__.__name__}")
+        self.update(other)
+        return self
+
+    def __or__(self, other: Mapping) -> "MutableHeaders":
+        if not isinstance(other, Mapping):
+            raise TypeError(f"Expected a mapping but got {other.__class__.__name__}")
+        new = self.mutablecopy()
+        new.update(other)
+        return new
 
 
 class Header(BaseModel, ABC):

--- a/starlite/middleware/compression/brotli.py
+++ b/starlite/middleware/compression/brotli.py
@@ -2,7 +2,8 @@ import io
 from enum import Enum
 from typing import TYPE_CHECKING, Optional, cast
 
-from starlette.datastructures import Headers, MutableHeaders
+from starlette.datastructures import MutableHeaders
+from starlite.datastructures.headers import Headers
 from starlette.middleware.gzip import GZipResponder
 from typing_extensions import Literal
 

--- a/starlite/middleware/compression/brotli.py
+++ b/starlite/middleware/compression/brotli.py
@@ -2,7 +2,7 @@ import io
 from enum import Enum
 from typing import TYPE_CHECKING, Optional, cast
 
-from starlette.datastructures import MutableHeaders
+from starlite.datastructures import MutableHeaders
 from starlite.datastructures.headers import Headers
 from starlette.middleware.gzip import GZipResponder
 from typing_extensions import Literal

--- a/starlite/middleware/compression/brotli.py
+++ b/starlite/middleware/compression/brotli.py
@@ -2,11 +2,11 @@ import io
 from enum import Enum
 from typing import TYPE_CHECKING, Optional, cast
 
-from starlite.datastructures import MutableHeaders
-from starlite.datastructures.headers import Headers
 from starlette.middleware.gzip import GZipResponder
 from typing_extensions import Literal
 
+from starlite.datastructures import MutableHeaders
+from starlite.datastructures.headers import Headers
 from starlite.enums import ScopeType
 from starlite.exceptions import MissingDependencyException
 from starlite.middleware.base import MiddlewareProtocol
@@ -76,7 +76,7 @@ class BrotliMiddleware(MiddlewareProtocol):
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
         if scope["type"] == ScopeType.HTTP:
-            headers = Headers(scope=scope)
+            headers = Headers.from_scope(scope)
             if CompressionEncoding.BROTLI in headers.get("Accept-Encoding", ""):
                 await self.brotli_responder(scope, receive, send)
                 return
@@ -172,7 +172,7 @@ class BrotliResponder:
                 elif not more_body:
                     # Standard Brotli response.
                     body = self.br_file.process(body) + self.br_file.finish()
-                    headers = MutableHeaders(raw=initial_message["headers"])
+                    headers = MutableHeaders(initial_message["headers"])
                     headers["Content-Encoding"] = CompressionEncoding.BROTLI
                     headers["Content-Length"] = str(len(body))
                     headers.add_vary_header("Accept-Encoding")
@@ -182,7 +182,7 @@ class BrotliResponder:
                     await send(message)
                 else:
                     # Initial body in streaming Brotli response.
-                    headers = MutableHeaders(raw=initial_message["headers"])
+                    headers = MutableHeaders(initial_message["headers"])
                     headers["Content-Encoding"] = CompressionEncoding.BROTLI
                     headers.add_vary_header("Accept-Encoding")
                     del headers["Content-Length"]

--- a/starlite/middleware/csrf.py
+++ b/starlite/middleware/csrf.py
@@ -2,8 +2,7 @@ import re
 import secrets
 from typing import TYPE_CHECKING, Any, Optional, Pattern
 
-from starlette.datastructures import MutableHeaders
-
+from starlite.datastructures import MutableHeaders
 from starlite.datastructures.cookie import Cookie
 from starlite.enums import RequestEncodingType, ScopeType
 from starlite.exceptions import PermissionDeniedException

--- a/starlite/middleware/csrf.py
+++ b/starlite/middleware/csrf.py
@@ -111,7 +111,7 @@ class CSRFMiddleware(MiddlewareProtocol):
         return send_wrapper
 
     def _set_cookie_if_needed(self, message: "HTTPSendMessage", token: str) -> None:
-        headers = MutableHeaders(scope=message)
+        headers = MutableHeaders.from_message(message)
         cookie = Cookie(
             key=self.config.cookie_name,
             value=token,

--- a/starlite/middleware/rate_limit.py
+++ b/starlite/middleware/rate_limit.py
@@ -16,10 +16,10 @@ from typing import (
 
 from orjson import dumps, loads
 from pydantic import BaseModel, validator
-from starlite.datastructures import MutableHeaders
 from typing_extensions import Literal
 
 from starlite.connection import Request
+from starlite.datastructures import MutableHeaders
 from starlite.enums import ScopeType
 from starlite.exceptions import TooManyRequestsException
 from starlite.middleware.base import DefineMiddleware
@@ -128,7 +128,7 @@ class RateLimitMiddleware:
             """
             if message["type"] == "http.response.start":
                 message.setdefault("headers", [])
-                headers = MutableHeaders(scope=message)
+                headers = MutableHeaders.from_message(message)
                 for key, value in self.create_response_headers(cache_object=cache_object).items():
                     headers.append(key, value)
             await send(message)

--- a/starlite/middleware/rate_limit.py
+++ b/starlite/middleware/rate_limit.py
@@ -16,7 +16,7 @@ from typing import (
 
 from orjson import dumps, loads
 from pydantic import BaseModel, validator
-from starlette.datastructures import MutableHeaders
+from starlite.datastructures import MutableHeaders
 from typing_extensions import Literal
 
 from starlite.connection import Request

--- a/starlite/middleware/session/base.py
+++ b/starlite/middleware/session/base.py
@@ -19,10 +19,10 @@ from typing import (
 
 from orjson import OPT_SERIALIZE_NUMPY, dumps, loads
 from pydantic import BaseConfig, BaseModel, PrivateAttr, conint, conlist, constr
-from starlite.datastructures import MutableHeaders
 from typing_extensions import Literal
 
 from starlite import ASGIConnection, Cookie, DefineMiddleware
+from starlite.datastructures import MutableHeaders
 from starlite.middleware.base import MiddlewareProtocol
 from starlite.middleware.util import should_bypass_middleware
 from starlite.types import Empty
@@ -273,7 +273,7 @@ class ServerSideBackend(Generic[ServerConfigT], BaseSessionBackend[ServerConfigT
             None
         """
         scope = connection.scope
-        headers = MutableHeaders(scope=message)
+        headers = MutableHeaders.from_message(message)
         session_id = connection.cookies.get(self.config.key)
         if session_id == "null":
             session_id = None

--- a/starlite/middleware/session/base.py
+++ b/starlite/middleware/session/base.py
@@ -19,7 +19,7 @@ from typing import (
 
 from orjson import OPT_SERIALIZE_NUMPY, dumps, loads
 from pydantic import BaseConfig, BaseModel, PrivateAttr, conint, conlist, constr
-from starlette.datastructures import MutableHeaders
+from starlite.datastructures import MutableHeaders
 from typing_extensions import Literal
 
 from starlite import ASGIConnection, Cookie, DefineMiddleware

--- a/starlite/middleware/session/cookie_backend.py
+++ b/starlite/middleware/session/cookie_backend.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
 from orjson import dumps, loads
 from pydantic import SecretBytes, validator
-from starlite.datastructures import MutableHeaders
 
+from starlite.datastructures import MutableHeaders
 from starlite.datastructures.cookie import Cookie
 from starlite.exceptions import MissingDependencyException
 from starlite.types import Empty
@@ -128,7 +128,7 @@ class CookieBackend(BaseSessionBackend["CookieBackendConfig"]):
         """
 
         scope = connection.scope
-        headers = MutableHeaders(scope=message)
+        headers = MutableHeaders.from_message(message)
         cookie_keys = self.get_cookie_keys(connection)
 
         if scope_session and scope_session is not Empty:

--- a/starlite/middleware/session/cookie_backend.py
+++ b/starlite/middleware/session/cookie_backend.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
 from orjson import dumps, loads
 from pydantic import SecretBytes, validator
-from starlette.datastructures import MutableHeaders
+from starlite.datastructures import MutableHeaders
 
 from starlite.datastructures.cookie import Cookie
 from starlite.exceptions import MissingDependencyException

--- a/starlite/testing/test_client/client.py
+++ b/starlite/testing/test_client/client.py
@@ -26,6 +26,7 @@ from starlite.testing.test_client.transport import (
     TestClientTransport,
 )
 from starlite.types import AnyIOBackend, ASGIApp, HTTPResponseStartEvent
+from starlite.utils import deprecated
 
 try:
     from httpx import USE_CLIENT_DEFAULT, Client, Cookies, Request, Response
@@ -146,12 +147,8 @@ class TestClient(Client, Generic[T]):
         )
 
     @property
+    @deprecated("1.34.0", alternative="session_backend", pending=True, kind="property")
     def session(self) -> "CookieBackend":
-        warnings.warn(
-            "Accessing the session via this property is deprecated and will be removed in future version."
-            "To access the session backend directly, use the session_backend attribute",
-            PendingDeprecationWarning,
-        )
         from starlite.middleware.session.cookie_backend import CookieBackend
 
         if not isinstance(self.session_backend, CookieBackend):
@@ -604,6 +601,7 @@ class TestClient(Client, Generic[T]):
         else:
             raise RuntimeError("Expected WebSocket upgrade")  # pragma: no cover
 
+    @deprecated("1.34.0", alternative="set_session_data", pending=True)
     def create_session_cookies(self, session_data: Dict[str, Any]) -> Dict[str, str]:
         """Creates raw session cookies that are loaded into the session by the
         Session Middleware. It creates cookies the same way as if they are
@@ -643,15 +641,11 @@ class TestClient(Client, Generic[T]):
                     test_client.get(url="/my_route")
             ```
         """
-        warnings.warn(
-            "This method is deprecated and will be removed in a future version. Use"
-            "TestClient.set_session_data instead",
-            PendingDeprecationWarning,
-        )
         if self._session_backend is None:
             return {}
         return self._create_session_cookies(self.session, session_data)
 
+    @deprecated("1.34.0", alternative="get_session_data", pending=True)
     def get_session_from_cookies(self) -> Dict[str, Any]:
         """Raw session cookies are a serialized image of session which are
         created by session middleware and sent with the response. To assert
@@ -673,11 +667,6 @@ class TestClient(Client, Generic[T]):
                 assert "user" in session
             ```
         """
-        warnings.warn(
-            "This method is deprecated and will be removed in a future version. Use"
-            "TestClient.get_session_data instead",
-            PendingDeprecationWarning,
-        )
         if self._session_backend is None:
             return {}
         return self.get_session_data()

--- a/starlite/testing/test_client/client.py
+++ b/starlite/testing/test_client/client.py
@@ -16,9 +16,9 @@ from typing import (
 from urllib.parse import urljoin
 
 from anyio.from_thread import BlockingPortal, start_blocking_portal
-from starlite.datastructures import MutableHeaders
 
 from starlite import ASGIConnection, HttpMethod, ImproperlyConfiguredException
+from starlite.datastructures import MutableHeaders
 from starlite.exceptions import MissingDependencyException
 from starlite.testing.test_client.life_span_handler import LifeSpanHandler
 from starlite.testing.test_client.transport import (

--- a/starlite/testing/test_client/client.py
+++ b/starlite/testing/test_client/client.py
@@ -16,7 +16,7 @@ from typing import (
 from urllib.parse import urljoin
 
 from anyio.from_thread import BlockingPortal, start_blocking_portal
-from starlette.datastructures import MutableHeaders
+from starlite.datastructures import MutableHeaders
 
 from starlite import ASGIConnection, HttpMethod, ImproperlyConfiguredException
 from starlite.exceptions import MissingDependencyException

--- a/starlite/types/asgi_types.py
+++ b/starlite/types/asgi_types.py
@@ -69,7 +69,7 @@ class BaseScope(TypedDict):
     auth: Any
     client: Optional[Tuple[str, int]]
     extensions: Optional[Dict[str, Dict[object, object]]]
-    headers: List[Tuple[bytes, bytes]]
+    headers: "RawHeadersList"
     http_version: str
     path: str
     path_params: Dict[str, str]
@@ -109,7 +109,7 @@ class HTTPRequestEvent(TypedDict):
 class HTTPResponseStartEvent(TypedDict):
     type: Literal["http.response.start"]
     status: int
-    headers: List[Tuple[bytes, bytes]]
+    headers: "RawHeadersList"
 
 
 class HTTPResponseBodyEvent(TypedDict):
@@ -121,7 +121,7 @@ class HTTPResponseBodyEvent(TypedDict):
 class HTTPServerPushEvent(TypedDict):
     type: Literal["http.response.push"]
     path: str
-    headers: List[Tuple[bytes, bytes]]
+    headers: "RawHeadersList"
 
 
 class HTTPDisconnectEvent(TypedDict):
@@ -135,7 +135,7 @@ class WebSocketConnectEvent(TypedDict):
 class WebSocketAcceptEvent(TypedDict):
     type: Literal["websocket.accept"]
     subprotocol: Optional[str]
-    headers: List[Tuple[bytes, bytes]]
+    headers: "RawHeadersList"
 
 
 class WebSocketReceiveEvent(TypedDict):
@@ -153,7 +153,7 @@ class WebSocketSendEvent(TypedDict):
 class WebSocketResponseStartEvent(TypedDict):
     type: Literal["websocket.http.response.start"]
     status: int
-    headers: List[Tuple[bytes, bytes]]
+    headers: "RawHeadersList"
 
 
 class WebSocketResponseBodyEvent(TypedDict):
@@ -239,3 +239,4 @@ Scope = Union[HTTPScope, WebSocketScope]
 Receive = Callable[..., Awaitable[Union[HTTPReceiveMessage, WebSocketReceiveMessage]]]
 Send = Callable[[Message], Awaitable[None]]
 ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+RawHeadersList = List[Tuple[bytes, bytes]]

--- a/starlite/utils/__init__.py
+++ b/starlite/utils/__init__.py
@@ -1,3 +1,5 @@
+from starlite.utils.deprecation import deprecated, warn_deprecation
+
 from .csrf import generate_csrf_hash, generate_csrf_token
 from .dependency import is_dependency_field, should_skip_dependency_validation
 from .exception import (
@@ -44,6 +46,8 @@ __all__ = (
     "create_exception_response",
     "create_parsed_model_field",
     "default_serializer",
+    "deprecated",
+    "warn_deprecation",
     "find_index",
     "generate_csrf_hash",
     "generate_csrf_token",

--- a/starlite/utils/deprecation.py
+++ b/starlite/utils/deprecation.py
@@ -1,0 +1,95 @@
+import inspect
+from functools import wraps
+from typing import Callable, Optional, TypeVar
+from warnings import warn
+
+from typing_extensions import Literal, ParamSpec
+
+T = TypeVar("T")
+P = ParamSpec("P")
+DeprecatedKind = Literal["function", "method", "attribute", "property", "class", "parameter"]
+
+
+def warn_deprecation(
+    version: str,
+    deprecated_name: str,
+    kind: DeprecatedKind,
+    *,
+    removal_in: Optional[str] = None,
+    alternative: Optional[str] = None,
+    info: Optional[str] = None,
+    pending: bool = False,
+) -> None:
+    """Warn about a call to a (soon to be) deprecated function.
+
+    Args:
+        version: Starlite version where the deprecation will occur
+        deprecated_name: Name of the deprecated function
+        removal_in: Starlite version where the deprecated function will be removed
+        alternative: Name of a function that should be used instead
+        info: Additional information
+        pending: Use `PendingDeprecationWarning` instead of `DeprecationWarning`
+        kind: Type of the deprecated thing
+    """
+    parts = []
+    access_type = "Call to" if kind in {"function", "method"} else "Use of"
+    if pending:
+        parts.append(f"{access_type} {kind} awaiting deprecation {deprecated_name!r}")
+    else:
+        parts.append(f"{access_type} deprecated {kind} {deprecated_name!r}")
+    parts.append(f"Deprecated in starlite {version}")
+    if removal_in:
+        parts.append(f"This {kind} will be removed in {removal_in}")
+    if alternative:
+        parts.append(f"Use {alternative!r} instead")
+    if info:
+        parts.append(info)
+
+    text = ". ".join(parts)
+    warning_class = PendingDeprecationWarning if pending else DeprecationWarning
+
+    warn(text, warning_class)
+
+
+def deprecated(
+    version: str,
+    *,
+    removal_in: Optional[str] = None,
+    alternative: Optional[str] = None,
+    info: Optional[str] = None,
+    pending: bool = False,
+    kind: Optional[Literal["function", "method", "property"]] = None,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Create a decorator wrapping a function, method or property with a
+    warning call about a (pending) deprecation.
+
+    Args:
+        version: Starlite version where the deprecation will occur
+        removal_in: Starlite version where the deprecated function will be removed
+        alternative: Name of a function that should be used instead
+        info: Additional information
+        pending: Use `PendingDeprecationWarning` instead of `DeprecationWarning`
+        kind: Type of the deprecated callable. If `None`, will use `inspect` to figure
+            out if it's a function or method
+
+    Returns:
+        A decorator wrapping the function call with a warning
+    """
+
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
+        @wraps(func)
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
+            warn_deprecation(
+                version=version,
+                deprecated_name=func.__name__,
+                info=info,
+                alternative=alternative,
+                pending=pending,
+                removal_in=removal_in,
+                kind=kind or ("method" if inspect.ismethod(func) else "function"),
+            )
+            return func(*args, **kwargs)
+
+        return wrapped
+
+    return decorator

--- a/tests/app/test_before_send.py
+++ b/tests/app/test_before_send.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Dict
 
-from starlette.datastructures import MutableHeaders
+from starlite.datastructures import MutableHeaders
 
 from starlite import get
 from starlite.status_codes import HTTP_200_OK

--- a/tests/app/test_before_send.py
+++ b/tests/app/test_before_send.py
@@ -1,8 +1,7 @@
 from typing import TYPE_CHECKING, Dict
 
-from starlite.datastructures import MutableHeaders
-
 from starlite import get
+from starlite.datastructures import MutableHeaders
 from starlite.status_codes import HTTP_200_OK
 from starlite.testing import create_test_client
 
@@ -18,7 +17,7 @@ def test_before_send() -> None:
 
     async def before_send_hook_handler(message: "Message", state: "State") -> None:
         if message["type"] == "http.response.start":
-            headers = MutableHeaders(scope=message)
+            headers = MutableHeaders.from_message(message)
             headers.append("My Header", state.message)
 
     def on_startup(state: "State") -> None:

--- a/tests/connection/websocket/test_websocket.py
+++ b/tests/connection/websocket/test_websocket.py
@@ -8,9 +8,9 @@ from typing import TYPE_CHECKING, Any
 
 import anyio
 import pytest
-from starlite.datastructures.headers import Headers
 
 from starlite.connection import WebSocket
+from starlite.datastructures.headers import Headers
 from starlite.exceptions import WebSocketDisconnect, WebSocketException
 from starlite.handlers.websocket import websocket
 from starlite.status_codes import WS_1001_GOING_AWAY

--- a/tests/connection/websocket/test_websocket.py
+++ b/tests/connection/websocket/test_websocket.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import anyio
 import pytest
-from starlette.datastructures import Headers
+from starlite.datastructures.headers import Headers
 
 from starlite.connection import WebSocket
 from starlite.exceptions import WebSocketDisconnect, WebSocketException

--- a/tests/datastructures/test_headers.py
+++ b/tests/datastructures/test_headers.py
@@ -1,8 +1,143 @@
+"""Parts of the code testing `MutableHeaders` and parts of `Headers` was
+adopted from https://github.com/encode/starlette/blob/e7d000a76d9e4ea5951a8b3b0
+28a057e4df9484c/tests/test_datastructures.py.
+
+Copyright © 2018, [Encode OSS Ltd](https://www.encode.io/).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""
+
 import pytest
 from pydantic import ValidationError
 
-from starlite.datastructures import CacheControlHeader, ETag
+from starlite.datastructures import CacheControlHeader, ETag, Headers, MutableHeaders
 from starlite.exceptions import ImproperlyConfiguredException
+
+
+def test_headers() -> None:
+    h = Headers([(b"a", b"123"), (b"a", b"456"), (b"b", b"789")])
+    assert "a" in h
+    assert "A" in h
+    assert "b" in h
+    assert "B" in h
+    assert "c" not in h
+    assert h["a"] == "123"
+    assert h.get("a") == "123"
+    assert h.get("nope", default=None) is None
+    assert h.getlist("a") == ["123", "456"]
+    assert h.keys() == ["a", "a", "b"]
+    assert h.values() == ["123", "456", "789"]
+    assert h.items() == [("a", "123"), ("a", "456"), ("b", "789")]
+    assert list(h) == ["a", "a", "b"]
+    assert dict(h) == {"a": "123", "b": "789"}
+    assert h != Headers([(b"a", b"123"), (b"b", b"789"), (b"a", b"456")])
+    assert h != [(b"a", b"123"), (b"A", b"456"), (b"b", b"789")]  # type: ignore[comparison-overlap]
+
+    h = Headers({"a": "123", "b": "789"})
+    assert h["A"] == "123"
+    assert h["B"] == "789"
+    assert sorted(h.raw) == sorted([(b"a", b"123"), (b"b", b"789")])
+
+
+def test_mutable_headers() -> None:
+    h = MutableHeaders()
+    assert dict(h) == {}
+    h["a"] = "1"
+    assert dict(h) == {"a": "1"}
+    h["a"] = "2"
+    assert dict(h) == {"a": "2"}
+    h.setdefault("a", "3")
+    assert dict(h) == {"a": "2"}
+    h.setdefault("b", "4")
+    assert dict(h) == {"a": "2", "b": "4"}
+    del h["a"]
+    assert dict(h) == {"b": "4"}
+    assert h.raw == [(b"b", b"4")]
+
+
+def test_mutable_headers_merge() -> None:
+    h = MutableHeaders()
+    h = h | MutableHeaders({"a": "1"})
+    assert isinstance(h, MutableHeaders)
+    assert dict(h) == {"a": "1"}
+    assert h.items() == [("a", "1")]
+    assert h.raw == [(b"a", b"1")]
+
+
+def test_mutable_headers_merge_dict() -> None:
+    h = MutableHeaders()
+    h = h | {"a": "1"}
+    assert isinstance(h, MutableHeaders)
+    assert dict(h) == {"a": "1"}
+    assert h.items() == [("a", "1")]
+    assert h.raw == [(b"a", b"1")]
+
+
+def test_mutable_headers_update() -> None:
+    h = MutableHeaders()
+    h |= MutableHeaders({"a": "1"})
+    assert isinstance(h, MutableHeaders)
+    assert dict(h) == {"a": "1"}
+    assert h.items() == [("a", "1")]
+    assert h.raw == [(b"a", b"1")]
+
+
+def test_mutable_headers_update_dict() -> None:
+    h = MutableHeaders()
+    h |= {"a": "1"}
+    assert isinstance(h, MutableHeaders)
+    assert dict(h) == {"a": "1"}
+    assert h.items() == [("a", "1")]
+    assert h.raw == [(b"a", b"1")]
+
+
+def test_mutable_headers_merge_not_mapping() -> None:
+    h = MutableHeaders()
+    with pytest.raises(TypeError):
+        h |= {"not_mapping"}  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        h | {"not_mapping"}  # type: ignore[operator]
+
+
+def test_headers_mutablecopy() -> None:
+    h = Headers([(b"a", b"123"), (b"a", b"456"), (b"b", b"789")])
+    copy = h.mutablecopy()
+    assert sorted(copy.items()) == sorted([("a", "123"), ("a", "456"), ("b", "789")])
+    copy["a"] = "abc"
+    assert sorted(copy.items()) == sorted([("a", "abc"), ("b", "789")])
+
+
+def test_mutable_headers_from_scope() -> None:
+    h = MutableHeaders.from_scope({"headers": [(b"a", b"1")]})  # type: ignore
+    assert dict(h) == {"a": "1"}
+    h.update({"b": "2"})
+    assert dict(h) == {"a": "1", "b": "2"}
+    assert list(h.items()) == [("a", "1"), ("b", "2")]
+    assert list(h.raw) == [(b"a", b"1"), (b"b", b"2")]
 
 
 def test_cache_control_to_header() -> None:


### PR DESCRIPTION
This is part of #640 and replaces starlette's `Headers` with our own `multidict`-based version, and `MutableHeaders` with an adapted version from starlette

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
