### PR TITLE
Update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,9 +48,6 @@ jobs:
         with:
           path: .venv
           key: v1-venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: |
-            v1-venv-${{ runner.os }}-${{ matrix.python-version }}
-            v1-venv-${{ runner.os }}
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
       - name: Set pythonpath


### PR DESCRIPTION
Remove the `restore_keys` key to prevent wrong venvs being loaded across multiple runs

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
