### PR TITLE
CodeQL configuration.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Initialize CodeQL
+      - name: Initialize CodeQL With Dependencies
+        if: github.event_name == 'push' && github.ref_name == 'main'
         uses: github/codeql-action/init@v2
+      - name: Initialize CodeQL Without Dependencies
+        if: github.event_name == 'pull_request'
+        uses: github/codeql-action/init@v2
+        with:
+          setup-python-dependencies: false
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
- PRs run CodeQL w/out dependencies installed.
- Push to main runs CodeQL with dependencies installed.

This makes sure we aren't waiting too long for CI on PRs but gives us a run with the full dependency tree on any code that is merged into main.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
