### PR TITLE
Added per request caching of dependencies

### DIFF
--- a/docs/usage/6-dependency-injection/3-the-provide-class.md
+++ b/docs/usage/6-dependency-injection/3-the-provide-class.md
@@ -30,3 +30,35 @@ See the [API Reference][starlite.datastructures.Provide] for full details on the
     If `Provide.use_cache` is true, the return value of the function will be memoized the first time it is called and
     then will be used. There is no sophisticated comparison of kwargs, LRU implementation etc. so you should be careful
     when you choose to use this option.
+
+If a dependency should be cached only within a single request, the `cache_per_request` flag can be used.
+This also ensures the dependency is called only once per request.
+
+
+```python
+from starlite import Provide, get
+from random import randint
+
+
+def cached_dependency() -> int:
+    return randint(1, 10)
+
+
+def dependent(first: int) -> int:
+    return first
+
+
+@get(
+    "/some-path",
+    dependencies={
+        "first": Provide(
+            cached_dependency,
+            cache_per_request=True,
+        ),
+        "second": Provide(dependent),
+    },
+)
+def my_handler(first: int, second: int) -> None:
+    assert first == second
+    ...
+```

--- a/starlite/datastructures/provide.py
+++ b/starlite/datastructures/provide.py
@@ -1,4 +1,7 @@
+from inspect import Parameter, Signature
 from typing import TYPE_CHECKING, Any, Optional, cast
+
+from anyio import Lock
 
 from starlite.types import Empty
 from starlite.utils.sync import AsyncCallable, is_async_callable
@@ -6,22 +9,71 @@ from starlite.utils.sync import AsyncCallable, is_async_callable
 if TYPE_CHECKING:
     from typing import Type
 
+    from starlite.connection import Request
     from starlite.signature import SignatureModel
     from starlite.types import AnyCallable
+
+
+def _wrap_cache_for_request(fn: "AnyCallable", override_name: Optional[str]) -> "AnyCallable":
+    """Wrap the function to cache the result per request."""
+    if override_name:
+        key = override_name
+    else:
+        key = fn.__name__
+    lock = Lock()
+    wrapped_sig = sig = Signature.from_callable(fn)
+    include_request = True
+    if "request" not in sig.parameters:
+        include_request = False
+        params = list(sig.parameters.values())
+        params.append(Parameter("request", Parameter.KEYWORD_ONLY, annotation="Request"))
+        wrapped_sig = sig.replace(parameters=params)
+
+    async def wrapped(*args: Any, request: "Request", **kwargs: Any) -> Any:
+        async with lock:
+            request_local_cache = request.state.setdefault("_dependency_cache", {})
+            if key in request_local_cache:
+                return request_local_cache[key]
+
+            if include_request:
+                kwargs["request"] = request
+
+            if is_async_callable(fn):
+                value = await fn(*args, **kwargs)
+            else:
+                value = fn(**kwargs)
+
+            request_local_cache[key] = value
+            return value
+
+    wrapped.__name__ = fn.__name__
+    wrapped.__signature__ = wrapped_sig  # type: ignore[attr-defined]
+    return wrapped
 
 
 class Provide:
     __slots__ = ("dependency", "use_cache", "value", "signature_model")
 
-    def __init__(self, dependency: "AnyCallable", use_cache: bool = False, sync_to_thread: bool = False) -> None:
+    def __init__(
+        self,
+        dependency: "AnyCallable",
+        use_cache: bool = False,
+        cache_per_request: bool = False,
+        cache_key: Optional[str] = None,
+        sync_to_thread: bool = False,
+    ) -> None:
         """A wrapper class used for dependency injection.
 
         Args:
             dependency: Callable to inject, can be a function, method or class.
             use_cache: Cache the dependency return value. Defaults to False.
+            cache_per_request: Cache the dependency return value per request. Defaults to False.
+            cache_key: Override the key for per request caching. Defaults to the function name.
             sync_to_thread: Run sync code in an async thread. Defaults to False.
         """
         self.dependency = cast("AnyCallable", AsyncCallable(dependency) if sync_to_thread else dependency)
+        if cache_per_request:
+            self.dependency = _wrap_cache_for_request(self.dependency, cache_key)
         self.use_cache = use_cache
         self.value: Any = Empty
         self.signature_model: Optional["Type[SignatureModel]"] = None

--- a/starlite/datastructures/provide.py
+++ b/starlite/datastructures/provide.py
@@ -1,4 +1,3 @@
-from inspect import Parameter, Signature
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 from anyio import Lock
@@ -9,50 +8,12 @@ from starlite.utils.sync import AsyncCallable, is_async_callable
 if TYPE_CHECKING:
     from typing import Type
 
-    from starlite.connection import Request
     from starlite.signature import SignatureModel
     from starlite.types import AnyCallable
 
 
-def _wrap_cache_for_request(fn: "AnyCallable", override_name: Optional[str]) -> "AnyCallable":
-    """Wrap the function to cache the result per request."""
-    if override_name:
-        key = override_name
-    else:
-        key = fn.__name__
-    lock = Lock()
-    wrapped_sig = sig = Signature.from_callable(fn)
-    include_request = True
-    if "request" not in sig.parameters:
-        include_request = False
-        params = list(sig.parameters.values())
-        params.append(Parameter("request", Parameter.KEYWORD_ONLY, annotation="Request"))
-        wrapped_sig = sig.replace(parameters=params)
-
-    async def wrapped(*args: Any, request: "Request", **kwargs: Any) -> Any:
-        async with lock:
-            request_local_cache = request.state.setdefault("_dependency_cache", {})
-            if key in request_local_cache:
-                return request_local_cache[key]
-
-            if include_request:
-                kwargs["request"] = request
-
-            if is_async_callable(fn):
-                value = await fn(*args, **kwargs)
-            else:
-                value = fn(**kwargs)
-
-            request_local_cache[key] = value
-            return value
-
-    wrapped.__name__ = fn.__name__
-    wrapped.__signature__ = wrapped_sig  # type: ignore[attr-defined]
-    return wrapped
-
-
 class Provide:
-    __slots__ = ("dependency", "use_cache", "value", "signature_model")
+    __slots__ = ("dependency", "use_cache", "cache_per_request", "cache_key", "lock", "value", "signature_model")
 
     def __init__(
         self,
@@ -72,9 +33,10 @@ class Provide:
             sync_to_thread: Run sync code in an async thread. Defaults to False.
         """
         self.dependency = cast("AnyCallable", AsyncCallable(dependency) if sync_to_thread else dependency)
-        if cache_per_request:
-            self.dependency = _wrap_cache_for_request(self.dependency, cache_key)
         self.use_cache = use_cache
+        self.cache_per_request = cache_per_request
+        self.cache_key = cache_key if cache_key else getattr(dependency, "__name__", "anonymous")
+        self.lock = Lock()
         self.value: Any = Empty
         self.signature_model: Optional["Type[SignatureModel]"] = None
 

--- a/tests/dependency_injection/test_request_local_caching.py
+++ b/tests/dependency_injection/test_request_local_caching.py
@@ -1,0 +1,50 @@
+from starlite import Provide, Request, create_test_client, get
+from starlite.status_codes import HTTP_200_OK
+
+
+def test_caching_per_request() -> None:
+    value = 1
+
+    def first_dependency() -> int:
+        nonlocal value
+        tmp = value
+        value += 1
+        return tmp  # noqa: R504
+
+    def second_dependency(first: int) -> int:
+        return first + 5
+
+    @get()
+    def route(first: int, second: int) -> int:
+        return first + second
+
+    with create_test_client(
+        route,
+        dependencies={
+            "first": Provide(first_dependency, cache_per_request=True),
+            "second": Provide(second_dependency),
+        },
+    ) as client:
+        response = client.get("/")
+        assert response.status_code == HTTP_200_OK
+        assert response.content == b"7"  # 1 + 1 + 5
+
+        response2 = client.get("/")
+        assert response2.status_code == HTTP_200_OK
+        assert response2.content == b"9"  # 2 + 2 + 5
+
+
+def test_explicit_key() -> None:
+    @get()
+    def route(first: int, request: Request) -> bool:
+        return request.state["_dependency_cache"]["override"] == first  # type: ignore[no-any-return]
+
+    with create_test_client(
+        route,
+        dependencies={
+            "first": Provide(lambda: 1, cache_per_request=True, cache_key="override"),
+        },
+    ) as client:
+        response = client.get("/")
+        assert response.status_code == HTTP_200_OK
+        assert response.content == b"true"


### PR DESCRIPTION
This avoids executing a dependency multiple times, if it's used more than once in the dependency tree.

Still unsure about the following:
* using `request.state` for the cache
  * the key `"_dependency_cache"` in general, without the leading underscore perhaps?
  Basically: Should this be part of the public interface?
* is there still a use case for `use_cache`?

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
