### PR TITLE
Ensures `path_params` key always exists in scope.

### DIFF
--- a/starlite/asgi/routing_trie/traversal.py
+++ b/starlite/asgi/routing_trie/traversal.py
@@ -165,11 +165,10 @@ def parse_scope_to_route(root_node: "RouteTrieNode", scope: "Scope", plain_route
     """
 
     path = scope["path"].strip().rstrip("/") or "/"
+    scope["path_params"] = {}
 
     if path in plain_routes:
         current_node: "RouteTrieNode" = root_node["children"][path]
-        scope["path_params"] = {}
-
     else:
         current_node, path_params = traverse_route_map(
             current_node=root_node,
@@ -178,15 +177,11 @@ def parse_scope_to_route(root_node: "RouteTrieNode", scope: "Scope", plain_route
             path_params=[],
             scope=scope,
         )
-        scope["path_params"] = (
-            parse_path_parameters(
+        if path_params:
+            scope["path_params"] = parse_path_parameters(
                 path_parameter_definitions=current_node["path_parameters"],
                 request_path_parameter_values=path_params,
             )
-            if path_params
-            else {}
-        )
-
     try:
         if current_node["is_asgi"]:
             return current_node["asgi_handlers"]["asgi"]

--- a/tests/asgi_router/test_routing_trie_traversal.py
+++ b/tests/asgi_router/test_routing_trie_traversal.py
@@ -1,0 +1,29 @@
+from typing import TYPE_CHECKING
+
+import pytest
+
+from starlite.asgi.routing_trie.traversal import parse_scope_to_route
+from starlite.exceptions import NotFoundException
+
+if TYPE_CHECKING:
+    from starlite.asgi.routing_trie.types import RouteTrieNode
+
+
+def test_parse_scope_to_route_adds_path_params_to_scope_on_404() -> None:
+    """Test that 'path_params' key is added to scope when no route resolved for
+    path."""
+    node: "RouteTrieNode" = {
+        "asgi_handlers": {},
+        "child_keys": set(),
+        "children": {},
+        "is_asgi": False,
+        "is_mount": False,
+        "is_path_type": False,
+        "is_static": False,
+        "path_parameters": [],
+    }
+    fake_scope = {"path": "/not-found"}
+    with pytest.raises(NotFoundException):
+        parse_scope_to_route(node, fake_scope, plain_routes=set())  # type:ignore[arg-type]
+
+    assert "path_params" in fake_scope


### PR DESCRIPTION
The logging middleware doesn't log if 404/405 is raised during routing, so I'm using a before send handler instead. 

If the connection data extractor is called on a connection where a 404 is raised we get the below exception.

This PR moves the setting of `scope["path_params"]` so that it exists irrespective of the result of the routing.

```python-traceback
2022-11-07 12:42:29,033 loglevel=ERROR  logger=uvicorn.error run_asgi() L412  Exception in ASGI application
Traceback (most recent call last):
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/middleware/exceptions.py", line 46, in __call__
    await self.app(scope, receive, send)
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/middleware/base.py", line 124, in wrapped_call
    await original__call__(self, scope, receive, send)
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/middleware/compression.py", line 123, in __call__
    await self.app(
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/asgi/asgi_router.py", line 62, in __call__
    asgi_app, handler = parse_scope_to_route(
                        ^^^^^^^^^^^^^^^^^^^^^
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/asgi/routing_trie/traversal.py", line 174, in parse_scope_to_route
    current_node, path_params = traverse_route_map(
                                ^^^^^^^^^^^^^^^^^^^
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/asgi/routing_trie/traversal.py", line 121, in traverse_route_map
    raise NotFoundException()
starlite.exceptions.http_exceptions.NotFoundException: 404: Not Found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/uvicorn/protocols/http/h11_impl.py", line 407, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/app.py", line 390, in __call__
    await self.asgi_handler(scope, receive, self._wrap_send(send=send, scope=scope))  # type: ignore[arg-type]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/middleware/exceptions.py", line 57, in __call__
    await response(scope=scope, receive=receive, send=send)
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/response/base.py", line 326, in __call__
    await self.send_body(send=send, receive=receive)
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/response/base.py", line 307, in send_body
    await send(event)
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/app.py", line 627, in wrapped_send
    await hook(message, self.state, scope)
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/utils/sync.py", line 68, in __call__
    return cast("T", await self.wrapped_callable.value(*args, **kwargs))  # type: ignore
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/peter/PycharmProjects/starlite-saqlalchemy/src/starlite_saqlalchemy/log/controller.py", line 134, in __call__
    await self.log_request(scope)
  File "/home/peter/PycharmProjects/starlite-saqlalchemy/src/starlite_saqlalchemy/log/controller.py", line 147, in log_request
    extracted_data = await self.extract_request_data(request=scope["app"].request_class(scope))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/peter/PycharmProjects/starlite-saqlalchemy/src/starlite_saqlalchemy/log/controller.py", line 170, in extract_request_data
    extracted_data = self.request_extractor(connection=request)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/utils/extractors.py", line 157, in __call__
    return cast("ExtractedRequestData", {key: extractor(connection) for key, extractor in extractors.items()})
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/utils/extractors.py", line 157, in <dictcomp>
    return cast("ExtractedRequestData", {key: extractor(connection) for key, extractor in extractors.items()})
                                              ^^^^^^^^^^^^^^^^^^^^^
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/utils/extractors.py", line 239, in extract_path_params
    return connection.path_params
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/peter/.cache/pypoetry/virtualenvs/tmpl-starlite-saqlalchemy-ar_RcmG--py3.11/lib/python3.11/site-packages/starlite/connection/base.py", line 175, in path_params
    return self.scope["path_params"]
           ~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'path_params'
```

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
