### PR TITLE
Add `*args` override to `Logger` protocol

### DIFF
--- a/starlite/types/protocols.py
+++ b/starlite/types/protocols.py
@@ -20,7 +20,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
-             **kwargs: Any kwargs.
+             *args: Any args.
         """
         ...
 
@@ -29,6 +29,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
+             *args: Any args.
              **kwargs: Any kwargs.
         """
 
@@ -48,7 +49,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
-             **kwargs: Any kwargs.
+             *args: Any args.
         """
         ...
 
@@ -57,6 +58,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
+             *args: Any args.
              **kwargs: Any kwargs.
         """
 
@@ -76,7 +78,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
-             **kwargs: Any kwargs.
+             *args: Any args.
         """
         ...
 
@@ -85,6 +87,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
+             *args: Any args.
              **kwargs: Any kwargs.
         """
 
@@ -104,7 +107,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
-             **kwargs: Any kwargs.
+             *args: Any args.
         """
         ...
 
@@ -113,6 +116,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
+             *args: Any args.
              **kwargs: Any kwargs.
         """
 
@@ -132,7 +136,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
-             **kwargs: Any kwargs.
+             *args: Any args.
         """
         ...
 
@@ -141,6 +145,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
+             *args: Any args.
              **kwargs: Any kwargs.
         """
 
@@ -160,7 +165,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
-             **kwargs: Any kwargs.
+             *args: Any args.
         """
         ...
 
@@ -169,6 +174,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
+             *args: Any args.
              **kwargs: Any kwargs.
         """
 
@@ -192,7 +198,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
-             **kwargs: Any kwargs.
+             *args: Any args.
         """
         ...
 
@@ -203,6 +209,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
+             *args: Any args.
              **kwargs: Any kwargs.
         """
 
@@ -222,7 +229,7 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
-             **kwargs: Any kwargs.
+             *args: Any args.
         """
         ...
 
@@ -231,5 +238,6 @@ class Logger(Protocol):  # pragma: no cover
 
         Args:
              event: Log message.
+             *args: Any args.
              **kwargs: Any kwargs.
         """

--- a/starlite/types/protocols.py
+++ b/starlite/types/protocols.py
@@ -1,9 +1,10 @@
-from typing import Any
+from typing import Any, overload
 
 from typing_extensions import Protocol
 
 
 class Logger(Protocol):  # pragma: no cover
+    @overload
     def debug(self, event: str, **kwargs: Any) -> Any:
         """Outputs a log message at 'DEBUG' level.
 
@@ -11,7 +12,27 @@ class Logger(Protocol):  # pragma: no cover
              event: Log message.
              **kwargs: Any kwargs.
         """
+        ...
 
+    @overload
+    def debug(self, event: str, *args: Any) -> Any:
+        """Outputs a log message at 'DEBUG' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+        ...
+
+    def debug(self, event: str, *args: Any, **kwargs: Any) -> Any:
+        """Outputs a log message at 'DEBUG' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+
+    @overload
     def info(self, event: str, **kwargs: Any) -> Any:
         """Outputs a log message at 'INFO' level.
 
@@ -19,15 +40,55 @@ class Logger(Protocol):  # pragma: no cover
              event: Log message.
              **kwargs: Any kwargs.
         """
+        ...
 
-    def warning(self, event: str, **kwargs: Any) -> Any:
-        """Outputs a log message at 'WARN' level.
+    @overload
+    def info(self, event: str, *args: Any) -> Any:
+        """Outputs a log message at 'INFO' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+        ...
+
+    def info(self, event: str, *args: Any, **kwargs: Any) -> Any:
+        """Outputs a log message at 'INFO' level.
 
         Args:
              event: Log message.
              **kwargs: Any kwargs.
         """
 
+    @overload
+    def warning(self, event: str, **kwargs: Any) -> Any:
+        """Outputs a log message at 'WARNING' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+        ...
+
+    @overload
+    def warning(self, event: str, *args: Any) -> Any:
+        """Outputs a log message at 'WARNING' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+        ...
+
+    def warning(self, event: str, *args: Any, **kwargs: Any) -> Any:
+        """Outputs a log message at 'WARNING' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+
+    @overload
     def warn(self, event: str, **kwargs: Any) -> Any:
         """Outputs a log message at 'WARN' level.
 
@@ -35,7 +96,27 @@ class Logger(Protocol):  # pragma: no cover
              event: Log message.
              **kwargs: Any kwargs.
         """
+        ...
 
+    @overload
+    def warn(self, event: str, *args: Any) -> Any:
+        """Outputs a log message at 'WARN' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+        ...
+
+    def warn(self, event: str, *args: Any, **kwargs: Any) -> Any:
+        """Outputs a log message at 'WARN' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+
+    @overload
     def error(self, event: str, **kwargs: Any) -> Any:
         """Outputs a log message at 'ERROR' level.
 
@@ -43,15 +124,55 @@ class Logger(Protocol):  # pragma: no cover
              event: Log message.
              **kwargs: Any kwargs.
         """
+        ...
 
-    def fatal(self, event: str, **kwargs: Any) -> Any:
-        """Outputs a log message at 'CRITICAL' level.
+    @overload
+    def error(self, event: str, *args: Any) -> Any:
+        """Outputs a log message at 'ERROR' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+        ...
+
+    def error(self, event: str, *args: Any, **kwargs: Any) -> Any:
+        """Outputs a log message at 'ERROR' level.
 
         Args:
              event: Log message.
              **kwargs: Any kwargs.
         """
 
+    @overload
+    def fatal(self, event: str, **kwargs: Any) -> Any:
+        """Outputs a log message at 'FATAL' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+        ...
+
+    @overload
+    def fatal(self, event: str, *args: Any) -> Any:
+        """Outputs a log message at 'FATAL' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+        ...
+
+    def fatal(self, event: str, *args: Any, **kwargs: Any) -> Any:
+        """Outputs a log message at 'FATAL' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+
+    @overload
     def exception(self, event: str, **kwargs: Any) -> Any:
         """Logs a message with level 'ERROR' on this logger. The arguments are
         interpreted as for debug(). Exception info is added to the logging
@@ -61,9 +182,52 @@ class Logger(Protocol):  # pragma: no cover
              event: Log message.
              **kwargs: Any kwargs.
         """
+        ...
 
+    @overload
+    def exception(self, event: str, *args: Any) -> Any:
+        """Logs a message with level 'ERROR' on this logger. The arguments are
+        interpreted as for debug(). Exception info is added to the logging
+        message.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+        ...
+
+    def exception(self, event: str, *args: Any, **kwargs: Any) -> Any:
+        """Logs a message with level 'ERROR' on this logger. The arguments are
+        interpreted as for debug(). Exception info is added to the logging
+        message.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+
+    @overload
     def critical(self, event: str, **kwargs: Any) -> Any:
         """Outputs a log message at 'CRITICAL' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+        ...
+
+    @overload
+    def critical(self, event: str, *args: Any) -> Any:
+        """Outputs a log message at 'CRITICAL' level.
+
+        Args:
+             event: Log message.
+             **kwargs: Any kwargs.
+        """
+        ...
+
+    def critical(self, event: str, *args: Any, **kwargs: Any) -> Any:
+        """Outputs a log message at 'INFO' level.
 
         Args:
              event: Log message.

--- a/starlite/types/protocols.py
+++ b/starlite/types/protocols.py
@@ -1,29 +1,9 @@
-from typing import Any, overload
+from typing import Any
 
 from typing_extensions import Protocol
 
 
 class Logger(Protocol):  # pragma: no cover
-    @overload
-    def debug(self, event: str, **kwargs: Any) -> Any:
-        """Outputs a log message at 'DEBUG' level.
-
-        Args:
-             event: Log message.
-             **kwargs: Any kwargs.
-        """
-        ...
-
-    @overload
-    def debug(self, event: str, *args: Any) -> Any:
-        """Outputs a log message at 'DEBUG' level.
-
-        Args:
-             event: Log message.
-             *args: Any args.
-        """
-        ...
-
     def debug(self, event: str, *args: Any, **kwargs: Any) -> Any:
         """Outputs a log message at 'DEBUG' level.
 
@@ -32,26 +12,6 @@ class Logger(Protocol):  # pragma: no cover
              *args: Any args.
              **kwargs: Any kwargs.
         """
-
-    @overload
-    def info(self, event: str, **kwargs: Any) -> Any:
-        """Outputs a log message at 'INFO' level.
-
-        Args:
-             event: Log message.
-             **kwargs: Any kwargs.
-        """
-        ...
-
-    @overload
-    def info(self, event: str, *args: Any) -> Any:
-        """Outputs a log message at 'INFO' level.
-
-        Args:
-             event: Log message.
-             *args: Any args.
-        """
-        ...
 
     def info(self, event: str, *args: Any, **kwargs: Any) -> Any:
         """Outputs a log message at 'INFO' level.
@@ -62,26 +22,6 @@ class Logger(Protocol):  # pragma: no cover
              **kwargs: Any kwargs.
         """
 
-    @overload
-    def warning(self, event: str, **kwargs: Any) -> Any:
-        """Outputs a log message at 'WARNING' level.
-
-        Args:
-             event: Log message.
-             **kwargs: Any kwargs.
-        """
-        ...
-
-    @overload
-    def warning(self, event: str, *args: Any) -> Any:
-        """Outputs a log message at 'WARNING' level.
-
-        Args:
-             event: Log message.
-             *args: Any args.
-        """
-        ...
-
     def warning(self, event: str, *args: Any, **kwargs: Any) -> Any:
         """Outputs a log message at 'WARNING' level.
 
@@ -90,26 +30,6 @@ class Logger(Protocol):  # pragma: no cover
              *args: Any args.
              **kwargs: Any kwargs.
         """
-
-    @overload
-    def warn(self, event: str, **kwargs: Any) -> Any:
-        """Outputs a log message at 'WARN' level.
-
-        Args:
-             event: Log message.
-             **kwargs: Any kwargs.
-        """
-        ...
-
-    @overload
-    def warn(self, event: str, *args: Any) -> Any:
-        """Outputs a log message at 'WARN' level.
-
-        Args:
-             event: Log message.
-             *args: Any args.
-        """
-        ...
 
     def warn(self, event: str, *args: Any, **kwargs: Any) -> Any:
         """Outputs a log message at 'WARN' level.
@@ -120,26 +40,6 @@ class Logger(Protocol):  # pragma: no cover
              **kwargs: Any kwargs.
         """
 
-    @overload
-    def error(self, event: str, **kwargs: Any) -> Any:
-        """Outputs a log message at 'ERROR' level.
-
-        Args:
-             event: Log message.
-             **kwargs: Any kwargs.
-        """
-        ...
-
-    @overload
-    def error(self, event: str, *args: Any) -> Any:
-        """Outputs a log message at 'ERROR' level.
-
-        Args:
-             event: Log message.
-             *args: Any args.
-        """
-        ...
-
     def error(self, event: str, *args: Any, **kwargs: Any) -> Any:
         """Outputs a log message at 'ERROR' level.
 
@@ -149,26 +49,6 @@ class Logger(Protocol):  # pragma: no cover
              **kwargs: Any kwargs.
         """
 
-    @overload
-    def fatal(self, event: str, **kwargs: Any) -> Any:
-        """Outputs a log message at 'FATAL' level.
-
-        Args:
-             event: Log message.
-             **kwargs: Any kwargs.
-        """
-        ...
-
-    @overload
-    def fatal(self, event: str, *args: Any) -> Any:
-        """Outputs a log message at 'FATAL' level.
-
-        Args:
-             event: Log message.
-             *args: Any args.
-        """
-        ...
-
     def fatal(self, event: str, *args: Any, **kwargs: Any) -> Any:
         """Outputs a log message at 'FATAL' level.
 
@@ -177,30 +57,6 @@ class Logger(Protocol):  # pragma: no cover
              *args: Any args.
              **kwargs: Any kwargs.
         """
-
-    @overload
-    def exception(self, event: str, **kwargs: Any) -> Any:
-        """Logs a message with level 'ERROR' on this logger. The arguments are
-        interpreted as for debug(). Exception info is added to the logging
-        message.
-
-        Args:
-             event: Log message.
-             **kwargs: Any kwargs.
-        """
-        ...
-
-    @overload
-    def exception(self, event: str, *args: Any) -> Any:
-        """Logs a message with level 'ERROR' on this logger. The arguments are
-        interpreted as for debug(). Exception info is added to the logging
-        message.
-
-        Args:
-             event: Log message.
-             *args: Any args.
-        """
-        ...
 
     def exception(self, event: str, *args: Any, **kwargs: Any) -> Any:
         """Logs a message with level 'ERROR' on this logger. The arguments are
@@ -212,26 +68,6 @@ class Logger(Protocol):  # pragma: no cover
              *args: Any args.
              **kwargs: Any kwargs.
         """
-
-    @overload
-    def critical(self, event: str, **kwargs: Any) -> Any:
-        """Outputs a log message at 'CRITICAL' level.
-
-        Args:
-             event: Log message.
-             **kwargs: Any kwargs.
-        """
-        ...
-
-    @overload
-    def critical(self, event: str, *args: Any) -> Any:
-        """Outputs a log message at 'CRITICAL' level.
-
-        Args:
-             event: Log message.
-             *args: Any args.
-        """
-        ...
 
     def critical(self, event: str, *args: Any, **kwargs: Any) -> Any:
         """Outputs a log message at 'INFO' level.

--- a/tests/logging_config/test_logging_config.py
+++ b/tests/logging_config/test_logging_config.py
@@ -79,6 +79,7 @@ def test_standard_queue_listener_logger(logger: "Logger", caplog: "LogCaptureFix
         assert "Testing now!" in caplog.text
         var = "test_var"
         logger.info("%s", var)
+        assert var in caplog.text
 
 
 @pytest.mark.xfail(reason="see: https://github.com/microsoft/picologging/issues/90")

--- a/tests/logging_config/test_logging_config.py
+++ b/tests/logging_config/test_logging_config.py
@@ -77,6 +77,8 @@ def test_standard_queue_listener_logger(logger: "Logger", caplog: "LogCaptureFix
     with caplog.at_level("INFO"):
         logger.info("Testing now!")
         assert "Testing now!" in caplog.text
+        var = "test_var"
+        logger.info("%s", var)
 
 
 @pytest.mark.xfail(reason="see: https://github.com/microsoft/picologging/issues/90")


### PR DESCRIPTION
This PR extends the `Logger` protocol to include overrides for `*args`.  This prevents `logger.info("%s finished",my_var)` from being reported as a typing error.
