### PR TITLE
Remove leading whitespaces from docstrings in OpenAPI description

### DIFF
--- a/starlite/openapi/path_item.py
+++ b/starlite/openapi/path_item.py
@@ -1,3 +1,4 @@
+from inspect import cleandoc
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, cast
 
 from pydantic_openapi_schema.v3_1_0.operation import Operation
@@ -31,7 +32,7 @@ def get_description_for_handler(route_handler: "HTTPRouteHandler", use_handler_d
     """
     handler_description = route_handler.description
     if handler_description is None and use_handler_docstrings:
-        return route_handler.fn.__doc__
+        return cleandoc(route_handler.fn.__doc__) if route_handler.fn.__doc__ else None
     return handler_description
 
 

--- a/tests/openapi/test_path_item.py
+++ b/tests/openapi/test_path_item.py
@@ -41,3 +41,10 @@ def test_create_path_item_use_handler_docstring_true(route: HTTPRoute) -> None:
     assert schema.get.description == "Description in docstring."
     assert schema.patch
     assert schema.patch.description == "Description in decorator"
+    assert schema.put
+    assert schema.put.description
+    # make sure multiline docstring is fully included
+    assert "Line 3." in schema.put.description
+    # make sure internal docstring indentation used to line up with the code
+    # is removed from description
+    assert "    " not in schema.put.description

--- a/tests/openapi/utils.py
+++ b/tests/openapi/utils.py
@@ -109,6 +109,10 @@ class PersonController(Controller):
 
     @put(path="/{person_id:str}")
     def update_person(self, person_id: str, data: Person) -> Person:
+        """Multiline docstring example.
+
+        Line 3.
+        """
         return data
 
     @delete(path="/{person_id:str}")


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

This PR closes #770 

Apply `inspect.cleandoc` to handler docstring when generating description for OpenAPI.

Difference can be seen in the example below.

```python
from inspect import cleandoc

def f():
    """Multiline docstring example.

    Line 3.
    Line 4.
    """
    pass

print(f.__doc__)
print(cleandoc(f.__doc__))
```

```bash
> python test.py 
Multiline docstring example.

    Line 3.
    Line 4.
    
Multiline docstring example.

Line 3.
Line 4.
```
