### PR TITLE
Ensures `filename` parameter to `FileResponse` set for `StaticFiles` response.

### DIFF
--- a/tests/static_files/test_file_serving_resolution.py
+++ b/tests/static_files/test_file_serving_resolution.py
@@ -133,3 +133,19 @@ def test_static_substring_of_self(tmpdir: "Path") -> None:
         response = client.get("/static/static_part/static/test.txt")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content"
+
+
+@pytest.mark.parametrize(
+    ("extension", "exp"),
+    [("css", "text/css"), ("js", "application/javascript"), ("html", "text/html"), ("json", "application/json")],
+)
+def test_static_files_response_mimetype(tmpdir: "Path", extension: str, exp: str) -> None:
+    fn = f"test.{extension}"
+    path = tmpdir / fn
+    path.write_text("content", "utf-8")
+    static_files_config = StaticFilesConfig(path="/static", directories=[tmpdir])
+
+    with create_test_client([], static_files_config=static_files_config) as client:
+        response = client.get(f"/static/{fn}")
+        assert response.status_code == HTTP_200_OK
+        assert response.headers["content-type"].startswith(exp)

--- a/tests/static_files/test_html_mode.py
+++ b/tests/static_files/test_html_mode.py
@@ -25,6 +25,7 @@ def test_staticfiles_is_html_mode(tmpdir: "Path", file_system: "FileSystemProtoc
         response = client.get("/static")
         assert response.status_code == HTTP_200_OK
         assert response.text == "content"
+        assert response.headers["content-type"] == "text/html; charset=utf-8"
 
 
 @pytest.mark.parametrize("file_system", (BaseLocalFileSystem(), LocalFileSystem()))
@@ -38,6 +39,7 @@ def test_staticfiles_is_html_mode_serves_404_when_present(tmpdir: "Path", file_s
         response = client.get("/static")
         assert response.status_code == HTTP_404_NOT_FOUND
         assert response.text == "not found"
+        assert response.headers["content-type"] == "text/html; charset=utf-8"
 
 
 @pytest.mark.parametrize("file_system", (BaseLocalFileSystem(), LocalFileSystem()))


### PR DESCRIPTION
Passing a `filename` is required for mimetype detection, without which static files were always served with `content-type: application/octet-stream`

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
