### PR TITLE
Cleanup builtin middlewares

### DIFF
--- a/docs/reference/config/3-csrf-config.md
+++ b/docs/reference/config/3-csrf-config.md
@@ -3,14 +3,14 @@
 ::: starlite.config.csrf.CSRFConfig
     options:
         members:
-            - secret
+            - cookie_domain
+            - cookie_httponly
             - cookie_name
             - cookie_path
-            - header_name
-            - cookie_secure
-            - cookie_httponly
             - cookie_samesite
-            - cookie_domain
-            - safe_methods
+            - cookie_secure
             - exclude
             - exclude_from_csrf_key
+            - header_name
+            - safe_methods
+            - secret

--- a/docs/reference/config/4-compression-config.md
+++ b/docs/reference/config/4-compression-config.md
@@ -4,13 +4,13 @@
     options:
         members:
             - backend
-            - minimum_size
-            - gzip_compress_level
-            - brotli_quality
-            - brotli_mode
-            - brotli_lgwin
-            - brotli_lgblock
             - brotli_gzip_fallback
-            - middleware_class
+            - brotli_lgblock
+            - brotli_lgwin
+            - brotli_mode
+            - brotli_quality
             - exclude
             - exclude_opt_key
+            - gzip_compress_level
+            - middleware_class
+            - minimum_size

--- a/docs/reference/middleware/3-rate-limit-middleware.md
+++ b/docs/reference/middleware/3-rate-limit-middleware.md
@@ -6,6 +6,7 @@
             - cache_key_builder
             - check_throttle_handler
             - exclude
+            - exclude_opt_key
             - middleware
             - middleware_class
             - rate_limit

--- a/starlite/config/allowed_hosts.py
+++ b/starlite/config/allowed_hosts.py
@@ -6,6 +6,13 @@ from starlite.types import Scopes
 
 
 class AllowedHostsConfig(BaseModel):
+    """Configuration for allowed hosts protection.
+
+    To enable allowed hosts protection, pass an instance of this class
+    to the [Starlite][starlite.app.Starlite] constructor using the
+    'allowed_hosts' key.
+    """
+
     allowed_hosts: List[str] = ["*"]
     """A list of trusted hosts. Use '*' to allow all hosts, or prefix domains with '*.' to allow all sub domains."""
     exclude: Optional[Union[str, List[str]]] = None

--- a/starlite/config/allowed_hosts.py
+++ b/starlite/config/allowed_hosts.py
@@ -10,11 +10,11 @@ class AllowedHostsConfig(BaseModel):
     """A list of trusted hosts. Use '*' to allow all hosts, or prefix domains with '*.' to allow all sub domains."""
     exclude: Optional[Union[str, List[str]]] = None
     """
-    An identifier to use on routes to disable authentication for a particular route.
+    A pattern or list of patterns to skip in the Allowed Hosts middleware.
     """
     exclude_opt_key: Optional[str] = None
     """
-    A pattern or list of patterns to skip in the authentication middleware.
+    An identifier to use on routes to disable hosts check for a particular route.
     """
     scopes: Optional[Scopes] = None
     """

--- a/starlite/config/compression.py
+++ b/starlite/config/compression.py
@@ -54,9 +54,9 @@ class CompressionConfig(BaseModel):
     """
     exclude: Optional[Union[str, List[str]]] = None
     """
-    An identifier to use on routes to disable authentication for a particular route.
+    A pattern or list of patterns to skip in the compression middleware.
     """
     exclude_opt_key: Optional[str] = None
     """
-    A pattern or list of patterns to skip in the authentication middleware.
+    An identifier to use on routes to disable compression for a particular route.
     """

--- a/starlite/middleware/authentication.py
+++ b/starlite/middleware/authentication.py
@@ -1,12 +1,14 @@
-import re
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, List, Optional, Pattern, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from pydantic import BaseConfig, BaseModel
 
 from starlite.connection import ASGIConnection
 from starlite.enums import ScopeType
-from starlite.middleware.utils import should_bypass_middleware
+from starlite.middleware.utils import (
+    build_exclude_path_pattern,
+    should_bypass_middleware,
+)
 
 if TYPE_CHECKING:
 
@@ -51,11 +53,8 @@ class AbstractAuthenticationMiddleware(ABC):
             exclude_from_auth_key: An identifier to use on routes to disable authentication for a particular route.
         """
         self.app = app
-        self.exclude: Optional[Pattern[str]] = None
         self.exclude_from_auth_key = exclude_from_auth_key
-
-        if exclude:
-            self.exclude = re.compile("|".join(exclude)) if isinstance(exclude, list) else re.compile(exclude)
+        self.exclude = build_exclude_path_pattern(exclude=exclude)
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
         """

--- a/starlite/middleware/base.py
+++ b/starlite/middleware/base.py
@@ -1,11 +1,13 @@
-import re
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Pattern, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
 
 from typing_extensions import Protocol, runtime_checkable
 
 from starlite.enums import ScopeType
-from starlite.middleware.utils import should_bypass_middleware
+from starlite.middleware.utils import (
+    build_exclude_path_pattern,
+    should_bypass_middleware,
+)
 
 if TYPE_CHECKING:
     from starlite.types import Scopes
@@ -99,12 +101,7 @@ class AbstractMiddleware:
         self.app = app
         self.scopes = scopes or self.scopes
         self.exclude_opt_key = exclude_opt_key or self.exclude_opt_key
-
-        self.exclude_pattern: Optional[Pattern] = None
-
-        exclude = exclude or self.exclude
-        if exclude is not None:
-            self.exclude_pattern = re.compile("|".join(exclude)) if isinstance(exclude, list) else re.compile(exclude)
+        self.exclude_pattern = build_exclude_path_pattern(exclude=(exclude or self.exclude))
 
     @classmethod
     def __init_subclass__(cls, **kwargs: Any) -> None:

--- a/starlite/middleware/utils.py
+++ b/starlite/middleware/utils.py
@@ -1,8 +1,32 @@
-from typing import TYPE_CHECKING, Optional, Pattern
+import re
+from typing import TYPE_CHECKING, List, Optional, Pattern, Union
+
+from starlite.exceptions import ImproperlyConfiguredException
 
 if TYPE_CHECKING:
 
     from starlite.types import Scope, Scopes
+
+
+def build_exclude_path_pattern(*, exclude: Optional[Union[str, List[str]]] = None) -> Optional[Pattern]:
+    """Build single path pattern from list of patterns to opt-out from
+    middleware processing.
+
+    Args:
+        exclude: A pattern or a list of patterns.
+
+    Returns:
+        An optional pattern to match against scope["path"] to opt-out from middleware processing.
+    """
+    if exclude is None:
+        return None
+
+    try:
+        return re.compile("|".join(exclude)) if isinstance(exclude, list) else re.compile(exclude)
+    except re.error as e:
+        raise ImproperlyConfiguredException(
+            "Unable to compile exclude patterns for middleware. Please make sure you passed a valid regular expression."
+        ) from e
 
 
 def should_bypass_middleware(


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

Here I add `exclude_opt_key` to all middlewares (logging, rate_limiting) and do some code cleanup by reusing code either from utils or AbstractMiddleware where applicable, fixing typos in docstrings and unifying parameter typing.

I need to write a few tests (while we have tests for exclusion for AbstractMiddleware we need to make sure that params from config are properly wired to __init__ args and we need at least one test per middleware for that) and update docs that all builtin middleware support exclusion via pattern list or opt key

Also, there is another question that needs to be discussed I think.

At the moment `AbstractAuthenticationMiddleware`  uses `exclude_from_auth_key` param with the default value of `exclude_from_auth`. `CSRFMiddleware` uses `exclude_from_csrf_key` config property (default value is `exclude_from_csrf`) and session middleware has `exclude_opt_key` config prop with the default value of `skip_session`. All other middleware use `exclude_opt_key` param with `None` as its default value. 

While having default value is ok for a middleware that users want to disable often (I think turning off CSRF or Auth happens more frequently than disabling logging on some handlers) but I think it would be great to be consistent with param name. So what do you think about deprecation and switching in the future to the same param name?