### PR TITLE
Fix #783 by setting content-disposition to inline in html_mode

### DIFF
--- a/starlite/static_files/base.py
+++ b/starlite/static_files/base.py
@@ -1,5 +1,5 @@
 from os.path import commonpath, join
-from typing import TYPE_CHECKING, List, Literal, Tuple, Union
+from typing import TYPE_CHECKING, List, Tuple, Union
 
 from starlite.enums import ScopeType
 from starlite.exceptions import MethodNotAllowedException, NotFoundException
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from starlite.types import Receive, Scope, Send
     from starlite.types.composite_types import PathType
     from starlite.types.file_types import FileInfo, FileSystemProtocol
+    from typing_extensions import Literal
 
 
 class StaticFiles:

--- a/starlite/static_files/base.py
+++ b/starlite/static_files/base.py
@@ -75,6 +75,7 @@ class StaticFiles:
                 file_system=self.adapter.file_system,
                 filename=filename,
                 is_head_response=scope["method"] == "HEAD",
+                content_disposition_type="inline",
             )(scope, receive, send)
             return
 

--- a/starlite/static_files/base.py
+++ b/starlite/static_files/base.py
@@ -8,11 +8,11 @@ from starlite.status_codes import HTTP_404_NOT_FOUND
 from starlite.utils.file import FileSystemAdapter
 
 if TYPE_CHECKING:
+    from typing_extensions import Literal
 
     from starlite.types import Receive, Scope, Send
     from starlite.types.composite_types import PathType
     from starlite.types.file_types import FileInfo, FileSystemProtocol
-    from typing_extensions import Literal
 
 
 class StaticFiles:
@@ -62,7 +62,7 @@ class StaticFiles:
         filename = split_path[-1]
         joined_path = join(*split_path)  # noqa: PL118
         resolved_path, fs_info = await self.get_fs_info(directories=self.directories, file_path=joined_path)
-        content_disposition_type: Literal["inline", "attachment"] = "attachment"
+        content_disposition_type: "Literal['inline', 'attachment']" = "attachment"
 
         if self.is_html_mode:
             content_disposition_type = "inline"

--- a/starlite/static_files/base.py
+++ b/starlite/static_files/base.py
@@ -1,5 +1,5 @@
 from os.path import commonpath, join
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import TYPE_CHECKING, List, Literal, Tuple, Union
 
 from starlite.enums import ScopeType
 from starlite.exceptions import MethodNotAllowedException, NotFoundException
@@ -61,12 +61,15 @@ class StaticFiles:
         filename = split_path[-1]
         joined_path = join(*split_path)  # noqa: PL118
         resolved_path, fs_info = await self.get_fs_info(directories=self.directories, file_path=joined_path)
+        content_disposition_type: Literal["inline", "attachment"] = "attachment"
 
-        if fs_info and fs_info["type"] == "directory" and self.is_html_mode:
-            filename = "index.html"
-            resolved_path, fs_info = await self.get_fs_info(
-                directories=self.directories, file_path=join(resolved_path or joined_path, filename)
-            )
+        if self.is_html_mode:
+            content_disposition_type = "inline"
+            if fs_info and fs_info["type"] == "directory":
+                filename = "index.html"
+                resolved_path, fs_info = await self.get_fs_info(
+                    directories=self.directories, file_path=join(resolved_path or joined_path, filename)
+                )
 
         if fs_info and fs_info["type"] == "file":
             await FileResponse(
@@ -75,7 +78,7 @@ class StaticFiles:
                 file_system=self.adapter.file_system,
                 filename=filename,
                 is_head_response=scope["method"] == "HEAD",
-                content_disposition_type="inline" if self.is_html_mode else "attachment",
+                content_disposition_type=content_disposition_type,
             )(scope, receive, send)
             return
 
@@ -90,6 +93,7 @@ class StaticFiles:
                     filename=filename,
                     is_head_response=scope["method"] == "HEAD",
                     status_code=HTTP_404_NOT_FOUND,
+                    content_disposition_type=content_disposition_type,
                 )(scope, receive, send)
                 return
 

--- a/starlite/static_files/base.py
+++ b/starlite/static_files/base.py
@@ -75,7 +75,7 @@ class StaticFiles:
                 file_system=self.adapter.file_system,
                 filename=filename,
                 is_head_response=scope["method"] == "HEAD",
-                content_disposition_type="inline",
+                content_disposition_type="inline" if self.is_html_mode else "attachment",
             )(scope, receive, send)
             return
 

--- a/tests/static_files/test_file_serving_resolution.py
+++ b/tests/static_files/test_file_serving_resolution.py
@@ -149,3 +149,16 @@ def test_static_files_response_mimetype(tmpdir: "Path", extension: str) -> None:
         assert expected_mime_type
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"].startswith(expected_mime_type)
+
+
+@pytest.mark.parametrize("html_mode,disposition", [(True, "inline"), (False, "attachment")])
+def test_static_files_response_content_disposition(tmpdir: "Path", html_mode: bool, disposition: str) -> None:
+    fn = "test.txt"
+    path = tmpdir / fn
+    path.write_text("content", "utf-8")
+    static_files_config = StaticFilesConfig(path="/static", directories=[tmpdir], html_mode=html_mode)
+
+    with create_test_client([], static_files_config=static_files_config) as client:
+        response = client.get(f"/static/{fn}")
+        assert response.status_code == HTTP_200_OK
+        assert response.headers["content-disposition"].startswith(disposition)

--- a/tests/static_files/test_html_mode.py
+++ b/tests/static_files/test_html_mode.py
@@ -26,6 +26,7 @@ def test_staticfiles_is_html_mode(tmpdir: "Path", file_system: "FileSystemProtoc
         assert response.status_code == HTTP_200_OK
         assert response.text == "content"
         assert response.headers["content-type"] == "text/html; charset=utf-8"
+        assert response.headers["content-disposition"].startswith("inline")
 
 
 @pytest.mark.parametrize("file_system", (BaseLocalFileSystem(), LocalFileSystem()))


### PR DESCRIPTION
This fixes #783, by correctly setting the `Content-Disposition` header to `inline` instead of `attachment`.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
