### PR TITLE
Introduce `send_as_attachment` flag for `StaticFiles`.

### DIFF
--- a/docs/reference/config/6-static-files-config.md
+++ b/docs/reference/config/6-static-files-config.md
@@ -12,3 +12,4 @@
             - name
             - opt
             - path
+            - send_as_attachment

--- a/docs/usage/0-the-starlite-app/3-static-files.md
+++ b/docs/usage/0-the-starlite-app/3-static-files.md
@@ -20,6 +20,7 @@ app = Starlite(
 )
 ```
 
+
 Matching is done based on filename, for example, assume we have a request that is trying to retrieve the path
 `/files/file.txt`, the **directory for the base path** `/files` **will be searched** for the file `file.txt`. If it is
 found, the file will be sent, otherwise a **404 response** will be sent.
@@ -46,6 +47,29 @@ app = Starlite(
 
 url_path = app.url_for_static_asset("static", "file.pdf")
 # /some_folder/static/path/file.pdf
+```
+
+
+## Sending files as attachments
+
+By default, files are sent "inline", meaning they will have a `Content-Disposition: inline` header.
+To send them as attachments, use the `send_as_attachment=True` flag, which will add a
+`Content-Disposition: attachment` header:
+
+```python
+from starlite import Starlite, StaticFilesConfig
+
+app = Starlite(
+    route_handlers=[...],
+    static_files_config=[
+        StaticFilesConfig(
+            directories=["static"],
+            path="/some_folder/static/path",
+            name="static",
+            send_as_attachment=True,
+        ),
+    ],
+)
 ```
 
 ## File System Support and Cloud Files

--- a/starlite/config/static_files.py
+++ b/starlite/config/static_files.py
@@ -63,6 +63,8 @@ class StaticFilesConfig(BaseModel):
     """
         A dictionary that maps handler functions to status codes and/or exception types.
     """
+    send_as_attachment: bool = False
+    """Whether to send the file as an attachment"""
 
     @validator("path", always=True)
     def validate_path(cls, value: str) -> str:  # pylint: disable=no-self-argument
@@ -100,7 +102,12 @@ class StaticFilesConfig(BaseModel):
         Returns:
             [StaticFiles][starlite.static_files.StaticFiles]
         """
-        static_files = StaticFiles(is_html_mode=self.html_mode, directories=self.directories, file_system=self.file_system)  # type: ignore
+        static_files = StaticFiles(
+            is_html_mode=self.html_mode,
+            directories=self.directories,
+            file_system=self.file_system,
+            send_as_attachment=self.send_as_attachment,
+        )
         return asgi(
             path=self.path,
             name=self.name,

--- a/starlite/static_files/base.py
+++ b/starlite/static_files/base.py
@@ -1,5 +1,5 @@
 from os.path import commonpath, join
-from typing import TYPE_CHECKING, List, Tuple, Union
+from typing import TYPE_CHECKING, Sequence, Tuple, Union
 
 from starlite.enums import ScopeType
 from starlite.exceptions import MethodNotAllowedException, NotFoundException
@@ -16,12 +16,16 @@ if TYPE_CHECKING:
 
 
 class StaticFiles:
-    """ASGI callable serving static files from a `FileSystemProtocol`"""
+    __slots__ = ("is_html_mode", "directories", "adapter", "send_as_attachment")
 
-    __slots__ = ("is_html_mode", "directories", "adapter")
-
-    def __init__(self, is_html_mode: bool, directories: List["PathType"], file_system: "FileSystemProtocol") -> None:
-        """Initialize the application.
+    def __init__(
+        self,
+        is_html_mode: bool,
+        directories: Sequence["PathType"],
+        file_system: "FileSystemProtocol",
+        send_as_attachment: bool = False,
+    ) -> None:
+        """This class is an ASGI App that handles file sending.
 
         Args:
             is_html_mode: Flag dictating whether serving html. If true, the default file will be 'index.html'.
@@ -31,9 +35,10 @@ class StaticFiles:
         self.adapter = FileSystemAdapter(file_system)
         self.directories = directories
         self.is_html_mode = is_html_mode
+        self.send_as_attachment = send_as_attachment
 
     async def get_fs_info(
-        self, directories: List["PathType"], file_path: str
+        self, directories: Sequence["PathType"], file_path: str
     ) -> Union[Tuple[str, "FileInfo"], Tuple[None, None]]:
         """Resolves the file path and returns the resolved path and a.
 
@@ -74,15 +79,15 @@ class StaticFiles:
         filename = split_path[-1]
         joined_path = join(*split_path)  # noqa: PL118
         resolved_path, fs_info = await self.get_fs_info(directories=self.directories, file_path=joined_path)
-        content_disposition_type: "Literal['inline', 'attachment']" = "attachment"
+        content_disposition_type: "Literal['inline', 'attachment']" = (
+            "attachment" if self.send_as_attachment else "inline"
+        )
 
-        if self.is_html_mode:
-            content_disposition_type = "inline"
-            if fs_info and fs_info["type"] == "directory":
-                filename = "index.html"
-                resolved_path, fs_info = await self.get_fs_info(
-                    directories=self.directories, file_path=join(resolved_path or joined_path, filename)
-                )
+        if self.is_html_mode and fs_info and fs_info["type"] == "directory":
+            filename = "index.html"
+            resolved_path, fs_info = await self.get_fs_info(
+                directories=self.directories, file_path=join(resolved_path or joined_path, filename)
+            )
 
         if fs_info and fs_info["type"] == "file":
             await FileResponse(

--- a/starlite/static_files/base.py
+++ b/starlite/static_files/base.py
@@ -44,8 +44,7 @@ class StaticFiles:
     async def get_fs_info(
         self, directories: Sequence["PathType"], file_path: str
     ) -> Union[Tuple[str, "FileInfo"], Tuple[None, None]]:
-        """Resolves the file path and returns the resolved path and a
-        [stat_result][os.stat_result].
+        """Return the resolved path and a [stat_result][os.stat_result].
 
         Args:
             directories: A list of directory paths.

--- a/starlite/static_files/base.py
+++ b/starlite/static_files/base.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 
 class StaticFiles:
+    """This class is an ASGI App that handles file sending."""
+
     __slots__ = ("is_html_mode", "directories", "adapter", "send_as_attachment")
 
     def __init__(
@@ -25,12 +27,14 @@ class StaticFiles:
         file_system: "FileSystemProtocol",
         send_as_attachment: bool = False,
     ) -> None:
-        """This class is an ASGI App that handles file sending.
+        """Initialize the Application.
 
         Args:
             is_html_mode: Flag dictating whether serving html. If true, the default file will be 'index.html'.
             directories: A list of directories to serve files from.
             file_system: The file_system spec to use for serving files.
+            send_as_attachment: Whether to send the file with a `content-disposition` header of
+             `attachment` or `inline`
         """
         self.adapter = FileSystemAdapter(file_system)
         self.directories = directories
@@ -40,8 +44,7 @@ class StaticFiles:
     async def get_fs_info(
         self, directories: Sequence["PathType"], file_path: str
     ) -> Union[Tuple[str, "FileInfo"], Tuple[None, None]]:
-        """Resolves the file path and returns the resolved path and a.
-
+        """Resolves the file path and returns the resolved path and a
         [stat_result][os.stat_result].
 
         Args:

--- a/tests/static_files/test_file_serving_resolution.py
+++ b/tests/static_files/test_file_serving_resolution.py
@@ -151,14 +151,14 @@ def test_static_files_response_mimetype(tmpdir: "Path", extension: str) -> None:
         assert response.headers["content-type"].startswith(expected_mime_type)
 
 
-@pytest.mark.parametrize("html_mode,disposition", [(True, "inline"), (False, "attachment")])
-def test_static_files_response_content_disposition(tmpdir: "Path", html_mode: bool, disposition: str) -> None:
-    fn = "test.txt"
-    path = tmpdir / fn
+@pytest.mark.parametrize("send_as_attachment,disposition", [(True, "attachment"), (False, "inline")])
+def test_static_files_content_disposition(tmpdir: "Path", send_as_attachment: bool, disposition: str) -> None:
+    path = tmpdir.mkdir("static_part").mkdir("static") / "test.txt"  # type: ignore
     path.write_text("content", "utf-8")
-    static_files_config = StaticFilesConfig(path="/static", directories=[tmpdir], html_mode=html_mode)
+
+    static_files_config = StaticFilesConfig(path="/static", directories=[tmpdir], send_as_attachment=send_as_attachment)
 
     with create_test_client([], static_files_config=static_files_config) as client:
-        response = client.get(f"/static/{fn}")
+        response = client.get("/static/static_part/static/test.txt")
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-disposition"].startswith(disposition)


### PR DESCRIPTION
This flag can be used to set the `content-disposition` to be either `inline` (`False`) or `attachment` (`True`). It defaults to `True`, mimicking the default behaviour of known web servers and frameworks.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
