### PR TITLE
Apply basic google docstring convention throughout the project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,13 @@ repos:
     hooks:
       - id: docformatter
         args: [--in-place, --close-quotes-on-newline]
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.1.1
+    hooks:
+      - id: pydocstyle
+        exclude: "test*|examples*"
+        additional_dependencies:
+          - pydocstyle[toml]
   - repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,6 @@ strict-imports = false
 
 [tool.pydocstyle]
 add-ignore = "D100,D104,D105,D106,D202,D205,D415,D418"
-#add-select = "D401,D404,D417"
+#add-select = "D401,D404,D417"  # currently disabled, should be addressed and enabled later
 convention = "google"
 match_dir = "starlite"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,7 @@ strict-imports = false
 
 
 [tool.pydocstyle]
-add-ignore = "D104,D415,D205,D100,D106"
-#add-select = "D401,D404" # disabled for now, conversion will happen at a later point
+add-ignore = "D100,D104,D105,D106,D202,D205,D415,D418"
+#add-select = "D401,D404,D417"
 convention = "google"
 match_dir = "starlite"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ strict-imports = false
 
 
 [tool.pydocstyle]
-add-ignore = "D104,D415,D205"
+add-ignore = "D104,D415,D205,D100,D106"
+#add-select = "D401,D404" # disabled for now, conversion will happen at a later point
 convention = "google"
 match_dir = "starlite"

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -80,8 +80,7 @@ DEFAULT_CACHE_CONFIG = CacheConfig()
 
 
 class HandlerIndex(TypedDict):
-    """This class is used to map route handler names to a mapping of paths +
-    route handler.
+    """Map route handler names to a mapping of paths + route handler.
 
     It's returned from the 'get_handler_index_by_name' utility method.
     """
@@ -373,7 +372,7 @@ class Starlite(Router):
         receive: Union["Receive", "LifeSpanReceive"],
         send: Union["Send", "LifeSpanSend"],
     ) -> None:
-        """The application entry point.
+        """Application entry point.
 
         Lifespan events (startup / shutdown) are sent to the lifespan handler, otherwise the ASGI handler is used
 
@@ -393,8 +392,9 @@ class Starlite(Router):
         await self.asgi_handler(scope, receive, self._wrap_send(send=send, scope=scope))  # type: ignore[arg-type]
 
     def register(self, value: "ControllerRouterHandler") -> None:  # type: ignore[override]
-        """Registers a route handler on the app. This method can be used to
-        dynamically add endpoints to an application.
+        """Register a route handler on the app.
+
+        This method can be used to dynamically add endpoints to an application.
 
         Args:
             value: an instance of [Router][starlite.router.Router], a subclasses of
@@ -580,7 +580,7 @@ class Starlite(Router):
         return route_map
 
     def _create_asgi_handler(self) -> "ASGIApp":
-        """Creates an ASGIApp that wraps the ASGI router inside an exception
+        """Create an ASGIApp that wraps the ASGI router inside an exception
         handler.
 
         If CORS or TrustedHost configs are provided to the constructor,
@@ -598,8 +598,8 @@ class Starlite(Router):
         )
 
     def _create_handler_signature_model(self, route_handler: "BaseRouteHandler") -> None:
-        """Creates function signature models for all route handler functions
-        and provider dependencies.
+        """Create function signature models for all route handler functions and
+        provider dependencies.
         """
         if not route_handler.signature_model:
             route_handler.signature_model = SignatureModelFactory(
@@ -616,7 +616,7 @@ class Starlite(Router):
                 ).create_signature_model()
 
     def _wrap_send(self, send: "Send", scope: "Scope") -> "Send":
-        """Wraps the ASGI send and handles any 'before send' hooks.
+        """Wrap the ASGI send and handles any 'before send' hooks.
 
         Args:
             send: The ASGI send function.

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -95,6 +95,14 @@ class HandlerIndex(TypedDict):
 
 
 class Starlite(Router):
+    """The Starlite application.
+
+    `Starlite` is the root level of the app - it has the base path of "/" and all root level
+    Controllers, Routers and Route Handlers should be registered on it.
+
+    Inherits from the [Router][starlite.router.Router] class
+    """
+
     __slots__ = (
         "after_exception",
         "after_shutdown",
@@ -169,12 +177,7 @@ class Starlite(Router):
         template_config: Optional["TemplateConfig"] = None,
         websocket_class: Optional[Type["WebSocket"]] = None,
     ) -> None:
-        """The Starlite application.
-
-        `Starlite` is the root level of the app - it has the base path of "/" and all root level
-        Controllers, Routers and Route Handlers should be registered on it.
-
-        It inherits from the [Router][starlite.router.Router] class.
+        """Initialize a `Starlite` application.
 
         Args:
             after_exception: An application level [exception hook handler][starlite.types.AfterExceptionHookHandler]
@@ -565,9 +568,10 @@ class Starlite(Router):
 
     @property
     def route_handler_method_view(self) -> Dict[str, List[str]]:
-        """
+        """Map route handlers to paths.
+
         Returns:
-            A dictionary mapping route handlers to paths.
+            A dictionary of router handlers and lists of paths as strings
         """
         route_map: Dict[str, List[str]] = {}
         for handler, routes in self.asgi_router.route_mapping.items():

--- a/starlite/asgi/asgi_router.py
+++ b/starlite/asgi/asgi_router.py
@@ -33,7 +33,8 @@ if TYPE_CHECKING:
 class ASGIRouter:
     """Starlite ASGI router.
 
-    Handling both the ASGI lifespan events and routing of connection requests.
+    Handling both the ASGI lifespan events and routing of connection
+    requests.
     """
 
     __slots__ = (

--- a/starlite/asgi/asgi_router.py
+++ b/starlite/asgi/asgi_router.py
@@ -31,6 +31,11 @@ if TYPE_CHECKING:
 
 
 class ASGIRouter:
+    """Starlite ASGI router.
+
+    Handling both the ASGI lifespan events and routing of connection requests.
+    """
+
     __slots__ = (
         "_plain_routes",
         "_registered_routes",
@@ -40,12 +45,8 @@ class ASGIRouter:
         "route_mapping",
     )
 
-    def __init__(
-        self,
-        app: "Starlite",
-    ) -> None:
-        """This class is the Starlite ASGI router. It handles both the ASGI
-        lifespan event and routing connection requests.
+    def __init__(self, app: "Starlite") -> None:
+        """Initialize `ASGIRouter`.
 
         Args:
             app: The Starlite app instance

--- a/starlite/cache/base.py
+++ b/starlite/cache/base.py
@@ -15,7 +15,8 @@ class CacheBackendProtocol(Protocol):  # pragma: no cover
     """Protocol for cache backends."""
 
     @overload  # type: ignore[misc]
-    def get(self, key: str) -> Any:  # pyright: ignore  # noqa: D102
+    def get(self, key: str) -> Any:  # pyright: ignore
+        """Overload."""
         ...
 
     async def get(self, key: str) -> Any:
@@ -29,7 +30,8 @@ class CacheBackendProtocol(Protocol):  # pragma: no cover
         """
 
     @overload  # type: ignore[misc]
-    def set(self, key: str, value: Any, expiration: int) -> Any:  # pyright: ignore  # noqa: D102
+    def set(self, key: str, value: Any, expiration: int) -> Any:  # pyright: ignore
+        """Overload."""
         ...
 
     async def set(self, key: str, value: Any, expiration: int) -> Any:
@@ -50,7 +52,8 @@ class CacheBackendProtocol(Protocol):  # pragma: no cover
         """
 
     @overload  # type: ignore[misc]
-    def delete(self, key: str) -> Any:  # pyright: ignore  # noqa: D102
+    def delete(self, key: str) -> Any:  # pyright: ignore
+        """Overload."""
         ...
 
     async def delete(self, key: str) -> Any:

--- a/starlite/cache/base.py
+++ b/starlite/cache/base.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class CacheBackendProtocol(Protocol):  # pragma: no cover
-    """Protocol for cache backends"""
+    """Protocol for cache backends."""
 
     @overload  # type: ignore[misc]
     def get(self, key: str) -> Any:  # pyright: ignore  # noqa: D102
@@ -68,11 +68,11 @@ class CacheBackendProtocol(Protocol):  # pragma: no cover
 
 
 class Cache:
-    """Wrapper for a provided CacheBackend that ensures it is called in
-    an async and thread-safe fashion.
+    """Wrapper for a provided CacheBackend that ensures it is called in an
+    async and thread-safe fashion.
 
-    This enables the use of normal sync libraries (such as the standard Redis python client)
-    for caching responses.
+    This enables the use of normal sync libraries (such as the standard
+    Redis python client) for caching responses.
     """
 
     __slots__ = ("backend", "lock", "default_expiration", "key_builder")

--- a/starlite/cache/base.py
+++ b/starlite/cache/base.py
@@ -12,12 +12,14 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class CacheBackendProtocol(Protocol):  # pragma: no cover
+    """Protocol for cache backends"""
+
     @overload  # type: ignore[misc]
-    def get(self, key: str) -> Any:  # pyright: ignore
+    def get(self, key: str) -> Any:  # pyright: ignore  # noqa: D102
         ...
 
     async def get(self, key: str) -> Any:
-        """Retrieves a value from cache corresponding to the given key.
+        """Retrieve a value from cache corresponding to the given key.
 
         Args:
             key: name of cached value.
@@ -27,11 +29,11 @@ class CacheBackendProtocol(Protocol):  # pragma: no cover
         """
 
     @overload  # type: ignore[misc]
-    def set(self, key: str, value: Any, expiration: int) -> Any:  # pyright: ignore
+    def set(self, key: str, value: Any, expiration: int) -> Any:  # pyright: ignore  # noqa: D102
         ...
 
     async def set(self, key: str, value: Any, expiration: int) -> Any:
-        """Set sa value in cache for a given key for a duration determined by
+        """Set a value in cache for a given key for a duration determined by
         expiration.
 
         Args:
@@ -48,7 +50,7 @@ class CacheBackendProtocol(Protocol):  # pragma: no cover
         """
 
     @overload  # type: ignore[misc]
-    def delete(self, key: str) -> Any:  # pyright: ignore
+    def delete(self, key: str) -> Any:  # pyright: ignore  # noqa: D102
         ...
 
     async def delete(self, key: str) -> Any:
@@ -66,15 +68,19 @@ class CacheBackendProtocol(Protocol):  # pragma: no cover
 
 
 class Cache:
+    """Wrapper for a provided CacheBackend that ensures it is called in
+    an async and thread-safe fashion.
+
+    This enables the use of normal sync libraries (such as the standard Redis python client)
+    for caching responses.
+    """
+
     __slots__ = ("backend", "lock", "default_expiration", "key_builder")
 
     def __init__(
         self, backend: CacheBackendProtocol, default_expiration: int, cache_key_builder: "CacheKeyBuilder"
     ) -> None:
-        """This class wraps a provided CacheBackend and ensures it is called in
-        an async thread-safe fashion. This enables the use of normal sync
-        libraries (such as the standard Redis python client) for caching
-        responses.
+        """Initialize `Cache`.
 
         Args:
             backend: A class instance fulfilling the Starlite [CacheBackendProtocol][starlite.cache.base.CacheBackendProtocol].
@@ -87,7 +93,7 @@ class Cache:
         self.lock = Lock()
 
     async def get(self, key: str) -> Any:
-        """Proxies 'self.backend.get'.
+        """Proxy 'self.backend.get'.
 
         Args:
             key: name of cached value.
@@ -102,7 +108,7 @@ class Cache:
             return self.backend.get(key)
 
     async def set(self, key: str, value: Any, expiration: Optional[int] = None) -> Any:
-        """Proxies 'self.backend.set'.
+        """Proxy 'self.backend.set'.
 
         Args:
             key: key to cache `value` under.
@@ -123,7 +129,7 @@ class Cache:
             return self.backend.set(key, value, expiration or self.default_expiration)
 
     async def delete(self, key: str) -> Any:
-        """Proxies 'self.backend.delete'.
+        """Proxy 'self.backend.delete'.
 
         Args:
             key: key to be deleted from the cache.
@@ -141,8 +147,8 @@ class Cache:
             return self.backend.delete(key)
 
     def build_cache_key(self, request: "Request", cache_key_builder: Optional["CacheKeyBuilder"]) -> str:
-        """
-        Constructs a unique cache key from the request instance.
+        """Construct a unique cache key from the request instance.
+
         Args:
             request: A [Request][starlite.connection.Request] instance.
             cache_key_builder: An optional [CacheKeyBuilder][starlite.types.CacheKeyBuilder] function.

--- a/starlite/cache/memcached_cache_backend.py
+++ b/starlite/cache/memcached_cache_backend.py
@@ -34,10 +34,12 @@ class MemcachedCacheBackendConfig(BaseModel):
 
 
 class MemcachedCacheBackend(CacheBackendProtocol):
+    """Memcached-based cache backend"""
+
     _client: Client
 
     def __init__(self, config: MemcachedCacheBackendConfig) -> None:
-        """This class offers a cache backend based on memcached.
+        """Initialize `MemcachedCacheBackend`.
 
         Args:
             config: required configuration to connect to memcached.

--- a/starlite/cache/memcached_cache_backend.py
+++ b/starlite/cache/memcached_cache_backend.py
@@ -34,7 +34,7 @@ class MemcachedCacheBackendConfig(BaseModel):
 
 
 class MemcachedCacheBackend(CacheBackendProtocol):
-    """Memcached-based cache backend"""
+    """Memcached-based cache backend."""
 
     _client: Client
 

--- a/starlite/cache/redis_cache_backend.py
+++ b/starlite/cache/redis_cache_backend.py
@@ -32,8 +32,10 @@ class RedisCacheBackendConfig(BaseModel):
 
 
 class RedisCacheBackend(CacheBackendProtocol):
+    """Redis-based cache backend"""
+
     def __init__(self, config: RedisCacheBackendConfig):
-        """This class offers a cache backend based on Redis.
+        """Initialize `RedisCacheBackend`
 
         Args:
             config: required configuration to connect to Redis.
@@ -50,7 +52,7 @@ class RedisCacheBackend(CacheBackendProtocol):
         return self._redis_int
 
     async def get(self, key: str) -> Any:  # pylint: disable=invalid-overridden-method
-        """Retrieves a value from cache corresponding to the given key.
+        """Retrieve a value from cache corresponding to the given key.
 
         Args:
             key: name of cached value.
@@ -62,7 +64,7 @@ class RedisCacheBackend(CacheBackendProtocol):
         return await self._redis.get(key)
 
     async def set(self, key: str, value: Any, expiration: int) -> None:  # pylint: disable=invalid-overridden-method
-        """Set sa value in cache for a given key for a duration determined by
+        """Set a value in cache for a given key for a duration determined by
         expiration.
 
         Args:
@@ -81,7 +83,7 @@ class RedisCacheBackend(CacheBackendProtocol):
         await self._redis.set(key, value, ex=expiration)
 
     async def delete(self, key: str) -> None:  # pylint: disable=invalid-overridden-method
-        """Deletes a value from the cache and removes the given key.
+        """Delete a value from the cache and removes the given key.
 
         Args:
             key: key to be deleted from the cache.

--- a/starlite/cache/redis_cache_backend.py
+++ b/starlite/cache/redis_cache_backend.py
@@ -32,7 +32,7 @@ class RedisCacheBackendConfig(BaseModel):
 
 
 class RedisCacheBackend(CacheBackendProtocol):
-    """Redis-based cache backend"""
+    """Redis-based cache backend."""
 
     def __init__(self, config: RedisCacheBackendConfig):
         """Initialize `RedisCacheBackend`

--- a/starlite/cache/simple_cache_backend.py
+++ b/starlite/cache/simple_cache_backend.py
@@ -18,10 +18,10 @@ class CacheObject:
 
 
 class SimpleCacheBackend(CacheBackendProtocol):
+    """In-memory cache backend"""
+
     def __init__(self) -> None:
-        """This class offers a simple thread safe cache backend that stores
-        values in local memory using a `dict`.
-        """
+        """Initialize `SimpleCacheBackend`"""
         self._store: Dict[str, CacheObject] = {}
         self._lock = Lock()
 

--- a/starlite/cache/simple_cache_backend.py
+++ b/starlite/cache/simple_cache_backend.py
@@ -18,7 +18,7 @@ class CacheObject:
 
 
 class SimpleCacheBackend(CacheBackendProtocol):
-    """In-memory cache backend"""
+    """In-memory cache backend."""
 
     def __init__(self) -> None:
         """Initialize `SimpleCacheBackend`"""

--- a/starlite/config/logging.py
+++ b/starlite/config/logging.py
@@ -24,9 +24,10 @@ from starlite.exceptions import (
 )
 
 if TYPE_CHECKING:
+    from typing import NoReturn
+
     from starlite.types import Logger
     from starlite.types.callable_types import GetLogger
-    from typing_extensions import NoReturn
 
 try:
     from structlog.types import BindableLogger, Processor, WrappedLogger
@@ -64,7 +65,7 @@ default_picologging_handlers: Dict[str, Dict[str, Any]] = {
 
 
 def get_default_handlers() -> Dict[str, Dict[str, Any]]:
-    """Return the default logging handlers for the config
+    """Return the default logging handlers for the config.
 
     Returns:
         A dictionary of logging handlers
@@ -75,7 +76,7 @@ def get_default_handlers() -> Dict[str, Dict[str, Any]]:
 
 
 def get_logger_placeholder(_: str) -> "NoReturn":  # pragma: no cover
-    """Raise an `ImproperlyConfiguredException"""
+    """Raise an `ImproperlyConfiguredException."""
     raise ImproperlyConfiguredException(
         "To use 'app.get_logger', 'request.get_logger' or 'socket.get_logger' pass 'logging_config' to the Starlite constructor"
     )
@@ -140,7 +141,7 @@ class LoggingConfig(BaseLoggingConfig, BaseModel):
     def validate_handlers(  # pylint: disable=no-self-argument
         cls, value: Dict[str, Dict[str, Any]]
     ) -> Dict[str, Dict[str, Any]]:
-        """Ensure that 'queue_listener' is always set
+        """Ensure that 'queue_listener' is always set.
 
         Args:
             value: A dict of route handlers.

--- a/starlite/config/logging.py
+++ b/starlite/config/logging.py
@@ -26,6 +26,7 @@ from starlite.exceptions import (
 if TYPE_CHECKING:
     from starlite.types import Logger
     from starlite.types.callable_types import GetLogger
+    from typing_extensions import NoReturn
 
 try:
     from structlog.types import BindableLogger, Processor, WrappedLogger
@@ -63,21 +64,18 @@ default_picologging_handlers: Dict[str, Dict[str, Any]] = {
 
 
 def get_default_handlers() -> Dict[str, Dict[str, Any]]:
-    """
+    """Return the default logging handlers for the config
 
     Returns:
-        The default handlers for the config.
+        A dictionary of logging handlers
     """
     if find_spec("picologging"):
         return default_picologging_handlers
     return default_handlers
 
 
-def get_logger_placeholder(_: str) -> Any:  # pragma: no cover
-    """
-    Raises:
-        ImproperlyConfiguredException
-    """
+def get_logger_placeholder(_: str) -> "NoReturn":  # pragma: no cover
+    """Raise an `ImproperlyConfiguredException"""
     raise ImproperlyConfiguredException(
         "To use 'app.get_logger', 'request.get_logger' or 'socket.get_logger' pass 'logging_config' to the Starlite constructor"
     )
@@ -142,8 +140,8 @@ class LoggingConfig(BaseLoggingConfig, BaseModel):
     def validate_handlers(  # pylint: disable=no-self-argument
         cls, value: Dict[str, Dict[str, Any]]
     ) -> Dict[str, Dict[str, Any]]:
-        """
-        Ensures that 'queue_listener' is always set
+        """Ensure that 'queue_listener' is always set
+
         Args:
             value: A dict of route handlers.
 
@@ -158,7 +156,7 @@ class LoggingConfig(BaseLoggingConfig, BaseModel):
     def validate_loggers(  # pylint: disable=no-self-argument
         cls, value: Dict[str, Dict[str, Any]]
     ) -> Dict[str, Dict[str, Any]]:
-        """Ensures that the 'starlite' logger is always set.
+        """Ensure that the 'starlite' logger is always set.
 
         Args:
             value: A dict of loggers.
@@ -199,7 +197,7 @@ class LoggingConfig(BaseLoggingConfig, BaseModel):
 
 
 def default_structlog_processors() -> Optional[Iterable[Processor]]:  # pyright: ignore
-    """Sets the default processors for structlog.
+    """Set the default processors for structlog.
 
     Returns:
         An optional list of processors.
@@ -219,7 +217,7 @@ def default_structlog_processors() -> Optional[Iterable[Processor]]:  # pyright:
 
 
 def default_wrapper_class() -> Optional[Type[BindableLogger]]:  # pyright: ignore
-    """Sets the default wrapper class for structlog.
+    """Set the default wrapper class for structlog.
 
     Returns:
         An optional wrapper class.
@@ -234,7 +232,7 @@ def default_wrapper_class() -> Optional[Type[BindableLogger]]:  # pyright: ignor
 
 
 def default_logger_factory() -> Optional[Callable[..., WrappedLogger]]:
-    """Sets the default logger factory for structlog.
+    """Set the default logger factory for structlog.
 
     Returns:
         An optional logger factory.

--- a/starlite/connection/base.py
+++ b/starlite/connection/base.py
@@ -45,6 +45,8 @@ async def empty_send(_: "Message") -> None:  # pragma: no cover
 
 
 class ASGIConnection(Generic[Handler, User, Auth]):
+    """The base ASGI connection container."""
+
     __slots__ = ("scope", "receive", "send", "_base_url", "_url", "_parsed_query", "_headers", "_cookies")
 
     scope: "Scope"
@@ -61,7 +63,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
     """
 
     def __init__(self, scope: "Scope", receive: "Receive" = empty_receive, send: "Send" = empty_send) -> None:
-        """The base ASGI connection container.
+        """Initialize `ASGIConnection`.
 
         Args:
             scope: The ASGI connection scope.
@@ -79,7 +81,8 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def app(self) -> "Starlite":
-        """
+        """Return the `app` for this connection.
+
         Returns:
             The [Starlite][starlite.app.Starlite] application instance
         """
@@ -87,7 +90,8 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def route_handler(self) -> Handler:
-        """
+        """Return the `route_handler` for this connection.
+
         Returns:
             The target route handler instance.
         """
@@ -95,7 +99,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def state(self) -> State:
-        """
+        """Return the `State` of this connection.
 
         Returns:
             A State instance constructed from the scope["state"] value.
@@ -104,7 +108,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def url(self) -> URL:
-        """
+        """Return the URL of this connection's `Scope`.
 
         Returns:
             A URL instance constructed from the request's scope.
@@ -115,7 +119,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def base_url(self) -> URL:
-        """
+        """Return the base URL of this connection's `Scope`.
 
         Returns:
             A URL instance constructed from the request's scope, representing only the base part
@@ -134,7 +138,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def headers(self) -> Headers:
-        """
+        """Return the headers of this connection's `Scope`.
 
         Returns:
             A Headers instance with the request's scope["headers"] value.
@@ -146,7 +150,8 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def query_params(self) -> QueryMultiDict:
-        """
+        """Return the query parameters of this connection's `Scope`.
+
         Returns:
             A normalized dict of query parameters. Multiple values for the same key are returned as a list.
         """
@@ -156,7 +161,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def path_params(self) -> Dict[str, Any]:
-        """
+        """Return the `path_params` of this connection's `Scope`.
 
         Returns:
             A string keyed dictionary of path parameter values.
@@ -165,7 +170,8 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def cookies(self) -> Dict[str, str]:
-        """
+        """Return the `cookies` of this connection's `Scope`.
+
         Returns:
             Returns any cookies stored in the header as a parsed dictionary.
         """
@@ -179,7 +185,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def client(self) -> Optional[Address]:
-        """
+        """Return the `client` data of this connection's `Scope`.
 
         Returns:
             A two tuple of the host name and port number.
@@ -189,7 +195,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def auth(self) -> Auth:
-        """Allows access to auth data.
+        """Return the `auth` data of this connection's `Scope`.
 
         Raises:
             ImproperlyConfiguredException: If 'auth' is not set in scope via an 'AuthMiddleware', raises an exception
@@ -203,7 +209,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def user(self) -> User:
-        """Allows access to user data.
+        """Return the `user` data of this connection's `Scope`.
 
         Raises:
             ImproperlyConfiguredException: If 'user' is not set in scope via an 'AuthMiddleware', raises an exception
@@ -217,7 +223,8 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def session(self) -> Dict[str, Any]:
-        """
+        """Return the session for this connection if a session was previously set in the `Scope`
+
         Returns:
             A dictionary representing the session value - if existing.
 
@@ -232,7 +239,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def logger(self) -> "Logger":
-        """
+        """Return the `Logger` instance for this connection
 
         Returns:
             A 'Logger' instance.
@@ -244,7 +251,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def cache(self) -> "Cache":
-        """
+        """Return the `Cache` for this connection
 
         Returns:
             A 'Cache' instance.
@@ -252,7 +259,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
         return self.app.cache
 
     def set_session(self, value: Union[Dict[str, Any], "BaseModel", "EmptyType"]) -> None:
-        """Helper method to set the session in scope.
+        """Set the session in the connection's `Scope`.
 
         If the [Starlite SessionMiddleware][starlite.middleware.session.SessionMiddleware] is
         enabled, the session will be added to the response as a cookie header.
@@ -266,7 +273,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
         self.scope["session"] = value
 
     def clear_session(self) -> None:
-        """Helper method to remove the session from scope.
+        """Remove the session from the connection's `Scope`.
 
         If the [Starlite SessionMiddleware][starlite.middleware.session.SessionMiddleware] is
         enabled, this will cause the session data to be cleared.
@@ -277,14 +284,15 @@ class ASGIConnection(Generic[Handler, User, Auth]):
         self.scope["session"] = Empty
 
     def url_for(self, name: str, **path_parameters: Dict[str, Any]) -> str:
-        """
+        """Return the url for a given route handler name.
 
         Args:
             name: The 'name' of the request route handler.
             **path_parameters: Values for path parameters in the route
 
         Raises:
-            NoRouteMatchFoundException: If route with 'name' does not exist, path parameters are missing in **path_parameters or have wrong type.
+            NoRouteMatchFoundException: If route with 'name' does not exist, path parameters are missing in
+            **path_parameters or have wrong type.
 
         Returns:
             A string representing the absolute url of the route handler.

--- a/starlite/connection/base.py
+++ b/starlite/connection/base.py
@@ -223,7 +223,8 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def session(self) -> Dict[str, Any]:
-        """Return the session for this connection if a session was previously set in the `Scope`
+        """Return the session for this connection if a session was previously
+        set in the `Scope`
 
         Returns:
             A dictionary representing the session value - if existing.
@@ -239,7 +240,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def logger(self) -> "Logger":
-        """Return the `Logger` instance for this connection
+        """Return the `Logger` instance for this connection.
 
         Returns:
             A 'Logger' instance.
@@ -251,7 +252,7 @@ class ASGIConnection(Generic[Handler, User, Auth]):
 
     @property
     def cache(self) -> "Cache":
-        """Return the `Cache` for this connection
+        """Return the `Cache` for this connection.
 
         Returns:
             A 'Cache' instance.

--- a/starlite/connection/request.py
+++ b/starlite/connection/request.py
@@ -36,6 +36,8 @@ SERVER_PUSH_HEADERS = {
 
 
 class Request(Generic[User, Auth], ASGIConnection["HTTPRouteHandler", User, Auth]):
+    """The Starlite Request class."""
+
     __slots__ = ("_json", "_form", "_body", "_content_type", "is_connected")
 
     scope: "HTTPScope"
@@ -52,14 +54,13 @@ class Request(Generic[User, Auth], ASGIConnection["HTTPRouteHandler", User, Auth
     """
 
     def __init__(self, scope: "Scope", receive: "Receive" = empty_receive, send: "Send" = empty_send) -> None:
-        """The Starlite Request class.
+        """Initialize `Request`.
 
         Args:
             scope: The ASGI connection scope.
             receive: The ASGI receive function.
             send: The ASGI send function.
         """
-
         super().__init__(scope, receive, send)
         self.is_connected: bool = True
         self._body: Any = scope.get("_body", Empty)
@@ -69,7 +70,8 @@ class Request(Generic[User, Auth], ASGIConnection["HTTPRouteHandler", User, Auth
 
     @property
     def method(self) -> "Method":
-        """
+        """Return the request method
+
         Returns:
             The request [Method][starlite.types.Method]
         """
@@ -77,7 +79,7 @@ class Request(Generic[User, Auth], ASGIConnection["HTTPRouteHandler", User, Auth
 
     @property
     def content_type(self) -> Tuple[str, Dict[str, str]]:
-        """Parses the request's 'Content-Type' header, returning the header
+        """Parse the request's 'Content-Type' header, returning the header
         value and any options as a dictionary.
 
         Returns:
@@ -88,7 +90,7 @@ class Request(Generic[User, Auth], ASGIConnection["HTTPRouteHandler", User, Auth
         return cast("Tuple[str, Dict[str, str]]", self._content_type)
 
     async def json(self) -> Any:
-        """Method to retrieve the json request body from the request.
+        """Retrieve the json request body from the request.
 
         Returns:
             An arbitrary value
@@ -129,7 +131,8 @@ class Request(Generic[User, Auth], ASGIConnection["HTTPRouteHandler", User, Auth
         yield b""
 
     async def body(self) -> bytes:
-        """
+        """Return the body of the request
+
         Returns:
             A byte-string representing the body of the request.
         """
@@ -141,14 +144,13 @@ class Request(Generic[User, Auth], ASGIConnection["HTTPRouteHandler", User, Auth
         return cast("bytes", self._body)
 
     async def form(self) -> FormMultiDict:
-        """Method to retrieve form data from the request. If the request is
+        """Retrieve form data from the request. If the request is
         either a 'multipart/form-data' or an 'application/x-www-form-
-        urlencoded', this method will return a FormMultiDict instance populated
-        with the values sent in the request. Otherwise, an empty instance is
-        returned.
+        urlencoded', return a FormMultiDict instance populated
+        with the values sent in the request, otherwise, an empty instance
 
         Returns:
-            A FormMultiDict instance.
+            A FormMultiDict instance
         """
         if self._form is Empty:
             content_type, options = self.content_type

--- a/starlite/connection/request.py
+++ b/starlite/connection/request.py
@@ -70,7 +70,7 @@ class Request(Generic[User, Auth], ASGIConnection["HTTPRouteHandler", User, Auth
 
     @property
     def method(self) -> "Method":
-        """Return the request method
+        """Return the request method.
 
         Returns:
             The request [Method][starlite.types.Method]
@@ -131,7 +131,7 @@ class Request(Generic[User, Auth], ASGIConnection["HTTPRouteHandler", User, Auth
         yield b""
 
     async def body(self) -> bytes:
-        """Return the body of the request
+        """Return the body of the request.
 
         Returns:
             A byte-string representing the body of the request.
@@ -144,10 +144,10 @@ class Request(Generic[User, Auth], ASGIConnection["HTTPRouteHandler", User, Auth
         return cast("bytes", self._body)
 
     async def form(self) -> FormMultiDict:
-        """Retrieve form data from the request. If the request is
-        either a 'multipart/form-data' or an 'application/x-www-form-
-        urlencoded', return a FormMultiDict instance populated
-        with the values sent in the request, otherwise, an empty instance
+        """Retrieve form data from the request. If the request is either a
+        'multipart/form-data' or an 'application/x-www-form- urlencoded',
+        return a FormMultiDict instance populated with the values sent in the
+        request, otherwise, an empty instance.
 
         Returns:
             A FormMultiDict instance

--- a/starlite/connection/websocket.py
+++ b/starlite/connection/websocket.py
@@ -256,11 +256,13 @@ class WebSocket(Generic[User, Auth], ASGIConnection["WebsocketRouteHandler", Use
         await self.send(event)
 
     @overload
-    async def send_text(self, data: bytes, encoding: str = "utf-8") -> None:  # noqa: D102
+    async def send_text(self, data: bytes, encoding: str = "utf-8") -> None:
+        """Overload."""
         ...
 
     @overload
-    async def send_text(self, data: str) -> None:  # noqa: D102
+    async def send_text(self, data: str) -> None:
+        """Overload."""
         ...
 
     async def send_text(self, data: Union[str, bytes], encoding: str = "utf-8") -> None:
@@ -276,11 +278,13 @@ class WebSocket(Generic[User, Auth], ASGIConnection["WebsocketRouteHandler", Use
         await self.send_data(data=data, encoding=encoding)
 
     @overload
-    async def send_bytes(self, data: bytes) -> None:  # noqa: D102
+    async def send_bytes(self, data: bytes) -> None:
+        """Overload."""
         ...
 
     @overload
-    async def send_bytes(self, data: str, encoding: str = "utf-8") -> None:  # noqa: D102
+    async def send_bytes(self, data: str, encoding: str = "utf-8") -> None:
+        """Overload."""
         ...
 
     async def send_bytes(self, data: Union[str, bytes], encoding: str = "utf-8") -> None:

--- a/starlite/connection/websocket.py
+++ b/starlite/connection/websocket.py
@@ -46,10 +46,9 @@ if TYPE_CHECKING:
 DISCONNECT_MESSAGE = "connection is disconnected"
 
 
-class WebSocket(
-    Generic[User, Auth],
-    ASGIConnection["WebsocketRouteHandler", User, Auth],
-):
+class WebSocket(Generic[User, Auth], ASGIConnection["WebsocketRouteHandler", User, Auth]):
+    """The Starlite WebSocket class."""
+
     __slots__ = ("connection_state",)
 
     scope: "WebSocketScope"
@@ -66,7 +65,7 @@ class WebSocket(
     """
 
     def __init__(self, scope: "Scope", receive: "Receive" = empty_receive, send: "Send" = empty_send) -> None:
-        """The Starlite WebSocket class.
+        """Initialize `WebSocket`.
 
         Args:
             scope: The ASGI connection scope.
@@ -77,7 +76,7 @@ class WebSocket(
         self.connection_state: "Literal['init', 'connect', 'receive', 'disconnect']" = "init"
 
     def receive_wrapper(self, receive: "Receive") -> "Receive":
-        """Wraps 'receive' to set 'self.connection_state' and validate events.
+        """Wrap 'receive' to set 'self.connection_state' and validate events.
 
         Args:
             receive: The ASGI receive function.
@@ -101,7 +100,7 @@ class WebSocket(
         return wrapped_receive
 
     def send_wrapper(self, send: "Send") -> "Send":
-        """Wraps 'send' to ensure that state is not disconnected.
+        """Wrap 'send' to ensure that state is not disconnected.
 
         Args:
             send: The ASGI send function.
@@ -122,7 +121,7 @@ class WebSocket(
         subprotocols: Optional[str] = None,
         headers: Optional[Union[Headers, Dict[str, Any], List[Tuple[bytes, bytes]]]] = None,
     ) -> None:
-        """Accepts the incoming connection. This method should be called before
+        """Accept the incoming connection. This method should be called before
         receiving data.
 
         Args:
@@ -150,8 +149,8 @@ class WebSocket(
             await self.send(event)
 
     async def close(self, code: int = WS_1000_NORMAL_CLOSURE, reason: Optional[str] = None) -> None:
-        """
-        Sends an 'websocket.close' event.
+        """Send an 'websocket.close' event.
+
         Args:
             code: Status code.
             reason: Reason for closing the connection
@@ -204,7 +203,7 @@ class WebSocket(
         return event.get("text") or "" if mode == "text" else event.get("bytes") or b""
 
     async def receive_text(self) -> str:
-        """Receives data as text.
+        """Receive data as text.
 
         Returns:
             A string.
@@ -212,7 +211,7 @@ class WebSocket(
         return await self.receive_data(mode="text")
 
     async def receive_bytes(self) -> bytes:
-        """Receives data as bytes.
+        """Receive data as bytes.
 
         Returns:
             A byte-string.
@@ -223,7 +222,7 @@ class WebSocket(
         self,
         mode: "Literal['text', 'binary']" = "text",
     ) -> Any:
-        """Receives data and loads it into JSON using orson.
+        """Receive data and loads it into JSON using orson.
 
         Args:
             mode: Either 'text' or 'binary'.
@@ -237,7 +236,7 @@ class WebSocket(
     async def send_data(
         self, data: Union[str, bytes], mode: "Literal['text', 'binary']" = "text", encoding: str = "utf-8"
     ) -> None:
-        """Sends a 'websocket.send' event.
+        """Send a 'websocket.send' event.
 
         Args:
             data: Data to send.
@@ -257,11 +256,11 @@ class WebSocket(
         await self.send(event)
 
     @overload
-    async def send_text(self, data: bytes, encoding: str = "utf-8") -> None:
+    async def send_text(self, data: bytes, encoding: str = "utf-8") -> None:  # noqa: D102
         ...
 
     @overload
-    async def send_text(self, data: str) -> None:
+    async def send_text(self, data: str) -> None:  # noqa: D102
         ...
 
     async def send_text(self, data: Union[str, bytes], encoding: str = "utf-8") -> None:
@@ -277,15 +276,15 @@ class WebSocket(
         await self.send_data(data=data, encoding=encoding)
 
     @overload
-    async def send_bytes(self, data: bytes) -> None:
+    async def send_bytes(self, data: bytes) -> None:  # noqa: D102
         ...
 
     @overload
-    async def send_bytes(self, data: str, encoding: str = "utf-8") -> None:
+    async def send_bytes(self, data: str, encoding: str = "utf-8") -> None:  # noqa: D102
         ...
 
     async def send_bytes(self, data: Union[str, bytes], encoding: str = "utf-8") -> None:
-        """Sends data using the 'bytes' key of the send event.
+        """Send data using the 'bytes' key of the send event.
 
         Args:
             data: Data to send
@@ -310,6 +309,7 @@ class WebSocket(
             mode: Either 'text' or 'binary'.
             encoding: Encoding to use for binary data.
             serializer: A serializer function.
+
         Returns:
             None
         """

--- a/starlite/controller.py
+++ b/starlite/controller.py
@@ -136,8 +136,9 @@ class Controller:
     """
 
     def __init__(self, owner: "Router") -> None:
-        """The controller init method should only be called by routers as part
-        of controller registration.
+        """Initialize a controller.
+
+        Should only be called by routers as part of controller registration.
 
         Args:
             owner: An instance of 'Router'
@@ -157,7 +158,8 @@ class Controller:
         self.owner = owner
 
     def get_route_handlers(self) -> List["BaseRouteHandler"]:
-        """A getter for the controller's route handlers that sets their owner.
+        """Get a controller's route handlers and set the controller as the
+        handlers' owner.
 
         Returns:
             A list containing a copy of the route handlers defined on the controller

--- a/starlite/controller.py
+++ b/starlite/controller.py
@@ -142,7 +142,6 @@ class Controller:
         Args:
             owner: An instance of 'Router'
         """
-
         # Since functions set on classes are bound, we need replace the bound instance with the class version and wrap
         # it to ensure it does not get bound.
         for key in ("after_request", "after_response", "before_request"):

--- a/starlite/datastructures/background_tasks.py
+++ b/starlite/datastructures/background_tasks.py
@@ -9,8 +9,9 @@ P = ParamSpec("P")
 
 
 class BackgroundTask:
-    """A container for a 'background' task function. Background tasks are
-    called once a Response finishes.
+    """A container for a 'background' task function.
+
+    Background tasks are called once a Response finishes.
     """
 
     __slots__ = ("fn", "args", "kwargs")

--- a/starlite/datastructures/background_tasks.py
+++ b/starlite/datastructures/background_tasks.py
@@ -9,11 +9,15 @@ P = ParamSpec("P")
 
 
 class BackgroundTask:
+    """A container for a 'background' task function. Background tasks are
+    called once a Response finishes.
+    """
+
     __slots__ = ("fn", "args", "kwargs")
 
     def __init__(self, fn: Callable[P, Any], *args: P.args, **kwargs: P.kwargs) -> None:
-        """A container for a 'background' task function. Background tasks are
-        called once a Response finishes.
+        """Initialize `BackgroundTask`.
+
         Args:
             fn: A sync or async function to call as the background task.
             *args: Args to pass to the func.
@@ -24,25 +28,25 @@ class BackgroundTask:
         self.kwargs = kwargs
 
     async def __call__(self) -> None:
-        """Calls the wrapped function with the passed in arguments.
+        """Call the wrapped function with the passed in arguments.
 
         Returns:
-            None.
+            None
         """
         await self.fn(*self.args, **self.kwargs)
 
 
 class BackgroundTasks:
-    __slots__ = (
-        "tasks",
-        "run_in_task_group",
-    )
+    """A container for multiple 'background' task functions.
+
+    Background tasks are called once a Response finishes.
+    """
+
+    __slots__ = ("tasks", "run_in_task_group")
 
     def __init__(self, tasks: Iterable[BackgroundTask], run_in_task_group: bool = False) -> None:
-        """A container for multiple 'background' task functions.
+        """Initialize `BackgroundTasks`.
 
-        Background
-        tasks are called once a Response finishes.
         Args:
             tasks: An iterable of [BackgroundTask][starlite.datastructures.BackgroundTask] instances.
             run_in_task_group: If you set this value to `True` than the tasks will run concurrently, using
@@ -53,7 +57,7 @@ class BackgroundTasks:
         self.run_in_task_group = run_in_task_group
 
     async def __call__(self) -> None:
-        """Calls the wrapped background tasks.
+        """Call the wrapped background tasks.
 
         Returns:
             None

--- a/starlite/datastructures/headers.py
+++ b/starlite/datastructures/headers.py
@@ -34,12 +34,15 @@ def _encode_headers(headers: Iterable[Tuple[str, str]]) -> "RawHeadersList":
 
 
 class Headers(CIMultiDictProxy[str], MultiMixin[str]):
-    def __init__(self, headers: Optional[Union[Mapping[str, str], "RawHeadersList", MultiMapping]] = None) -> None:
-        """An immutable, case-insensitive for HTTP headers.
+    """An immutable, case-insensitive for HTTP headers.
 
-        Notes:
-            - This class inherits from [multidict](https://multidict.aio-
-                libs.org/en/stable/multidict.html#cimultidictproxy).
+    Notes:
+        - This class inherits from [multidict](https://multidict.aio-
+            libs.org/en/stable/multidict.html#cimultidictproxy).
+    """
+
+    def __init__(self, headers: Optional[Union[Mapping[str, str], "RawHeadersList", MultiMapping]] = None) -> None:
+        """Initialize `Headers`.
 
         Args:
             headers: Initial value.
@@ -56,8 +59,8 @@ class Headers(CIMultiDictProxy[str], MultiMixin[str]):
 
     @classmethod
     def from_scope(cls, scope: "HeaderScope") -> "Headers":
-        """
-        Create headers from a send-message.
+        """Create headers from a send-message.
+
         Args:
             scope: The ASGI connection scope.
 
@@ -79,9 +82,12 @@ class Headers(CIMultiDictProxy[str], MultiMixin[str]):
 
 
 class MutableScopeHeaders(MutableMapping):
+    """A case-insensitive, multidict-like structure that can be used to
+    mutate headers within a [Scope][starlite.types.Scope]
+    """
+
     def __init__(self, scope: Optional["HeaderScope"] = None) -> None:
-        """A case-insensitive, multidict-like structure that can be used to
-        mutate headers within a [Scope][starlite.types.Scope].
+        """Initialize `MutableScopeHeaders` from a `HeaderScope`.
 
         Args:
             scope: The ASGI connection scope.
@@ -94,7 +100,7 @@ class MutableScopeHeaders(MutableMapping):
 
     @classmethod
     def from_message(cls, message: "Message") -> "MutableScopeHeaders":
-        """Constructs a header from a message object.
+        """Construct a header from a message object.
 
         Args:
             message: [Message][starlite.types.Message].
@@ -111,7 +117,7 @@ class MutableScopeHeaders(MutableMapping):
         return cls(cast("HeaderScope", message))
 
     def add(self, key: str, value: str) -> None:
-        """Adds a header to the scope.
+        """Add a header to the scope.
 
         Notes:
              - This method keeps duplicates.
@@ -151,7 +157,7 @@ class MutableScopeHeaders(MutableMapping):
         return values
 
     def extend_header_value(self, key: str, value: str) -> None:
-        """Extends a multivalued header.
+        """Extend a multivalued header.
 
         Notes:
             - A multivalues header is a header that can take a comma separated list.
@@ -200,10 +206,11 @@ class MutableScopeHeaders(MutableMapping):
             del self.headers[i]
 
     def __len__(self) -> int:
+        """Return the length of the internally stored headers, including duplicates"""
         return len(self.headers)
 
     def __iter__(self) -> Iterator[str]:
-        """iter over header names including duplicates."""
+        """Create an iterator of header names including duplicates."""
         return iter(h[0].decode("latin-1") for h in self.headers)
 
 
@@ -218,6 +225,7 @@ class Header(BaseModel, ABC):
 
         @classmethod
         def alias_generator(cls, field_name: str) -> str:  # pylint: disable=missing-function-docstring
+            """Generate field-aliases by replacing dashes with underscores in header-names"""
             return field_name.replace("_", "-")
 
     documentation_only: bool = False
@@ -226,7 +234,6 @@ class Header(BaseModel, ABC):
     @abstractmethod
     def _get_header_value(self) -> str:
         """Get the header value as string."""
-
         raise NotImplementedError
 
     @classmethod

--- a/starlite/datastructures/headers.py
+++ b/starlite/datastructures/headers.py
@@ -226,7 +226,7 @@ class Header(BaseModel, ABC):
         extra = Extra.forbid
 
         @classmethod
-        def alias_generator(cls, field_name: str) -> str:  # pylint: disable=missing-function-docstring
+        def alias_generator(cls, field_name: str) -> str:
             """Generate field-aliases by replacing dashes with underscores in
             header-names.
             """

--- a/starlite/datastructures/headers.py
+++ b/starlite/datastructures/headers.py
@@ -82,8 +82,8 @@ class Headers(CIMultiDictProxy[str], MultiMixin[str]):
 
 
 class MutableScopeHeaders(MutableMapping):
-    """A case-insensitive, multidict-like structure that can be used to
-    mutate headers within a [Scope][starlite.types.Scope]
+    """A case-insensitive, multidict-like structure that can be used to mutate
+    headers within a [Scope][starlite.types.Scope]
     """
 
     def __init__(self, scope: Optional["HeaderScope"] = None) -> None:
@@ -206,7 +206,9 @@ class MutableScopeHeaders(MutableMapping):
             del self.headers[i]
 
     def __len__(self) -> int:
-        """Return the length of the internally stored headers, including duplicates"""
+        """Return the length of the internally stored headers, including
+        duplicates.
+        """
         return len(self.headers)
 
     def __iter__(self) -> Iterator[str]:
@@ -225,7 +227,9 @@ class Header(BaseModel, ABC):
 
         @classmethod
         def alias_generator(cls, field_name: str) -> str:  # pylint: disable=missing-function-docstring
-            """Generate field-aliases by replacing dashes with underscores in header-names"""
+            """Generate field-aliases by replacing dashes with underscores in
+            header-names.
+            """
             return field_name.replace("_", "-")
 
     documentation_only: bool = False

--- a/starlite/datastructures/multi_dicts.py
+++ b/starlite/datastructures/multi_dicts.py
@@ -31,7 +31,7 @@ class MultiMixin(Generic[T], MultiMapping[T], ABC):
     """
 
     def dict(self) -> Dict[str, List[Any]]:
-        """
+        """Return the multi-dict as a dict of lists.
 
         Returns:
             A dict of lists
@@ -62,7 +62,15 @@ class MultiMixin(Generic[T], MultiMapping[T], ABC):
 
 
 class MultiDict(BaseMultiDict[T], MultiMixin[T], Generic[T]):
+    """MultiDict, using [MultiDict][multidict.MultiDictProxy]."""
+
     def __init__(self, args: Optional[Union["MultiMapping", Mapping[str, T], Iterable[Tuple[str, T]]]] = None) -> None:
+        """Initialize `MultiDict` from a [MultiMapping][multidict.MultiMapping],
+        `Mapping` or an iterable of tuples.
+
+        Args:
+            args: Mapping-like structure to create the `MultiDict` from
+        """
         super().__init__(args or {})
 
     def immutable(self) -> "ImmutableMultiDict[T]":
@@ -77,9 +85,17 @@ class MultiDict(BaseMultiDict[T], MultiMixin[T], Generic[T]):
 
 
 class ImmutableMultiDict(MultiDictProxy[T], MultiMixin[T], Generic[T]):
+    """Immutable MultiDict, using [MultiDictProxy][multidict.MultiDictProxy]."""
+
     def __init__(
         self, args: Optional[Union["MultiMapping", Mapping[str, Any], Iterable[Tuple[str, Any]]]] = None
     ) -> None:
+        """Initialize `ImmutableMultiDict` from a [MultiMapping][multidict.MultiMapping],
+        `Mapping` or an iterable of tuples.
+
+        Args:
+            args: Mapping-like structure to create the `ImmutableMultiDict` from
+        """
         super().__init__(BaseMultiDict(args or {}))
 
     def mutable_copy(self) -> MultiDict[T]:
@@ -94,6 +110,8 @@ class ImmutableMultiDict(MultiDictProxy[T], MultiMixin[T], Generic[T]):
 
 
 class FormMultiDict(ImmutableMultiDict[Any]):
+    """MultiDict for form data"""
+
     async def close(self) -> None:
         """Closes all files in the multi-dict.
 
@@ -106,9 +124,11 @@ class FormMultiDict(ImmutableMultiDict[Any]):
 
 
 class QueryMultiDict(MultiDict):
+    """MultiDict for URL query parameters"""
+
     @classmethod
     def from_query_string(cls, query_string: str) -> "QueryMultiDict":
-        """Creates a QueryMultiDict from a query string.
+        """Create a `QueryMultiDict` from a query string.
 
         Args:
             query_string: A query string.

--- a/starlite/datastructures/multi_dicts.py
+++ b/starlite/datastructures/multi_dicts.py
@@ -65,8 +65,9 @@ class MultiDict(BaseMultiDict[T], MultiMixin[T], Generic[T]):
     """MultiDict, using [MultiDict][multidict.MultiDictProxy]."""
 
     def __init__(self, args: Optional[Union["MultiMapping", Mapping[str, T], Iterable[Tuple[str, T]]]] = None) -> None:
-        """Initialize `MultiDict` from a [MultiMapping][multidict.MultiMapping],
-        `Mapping` or an iterable of tuples.
+        """Initialize `MultiDict` from a
+        [MultiMapping][multidict.MultiMapping], `Mapping` or an iterable of
+        tuples.
 
         Args:
             args: Mapping-like structure to create the `MultiDict` from
@@ -85,13 +86,16 @@ class MultiDict(BaseMultiDict[T], MultiMixin[T], Generic[T]):
 
 
 class ImmutableMultiDict(MultiDictProxy[T], MultiMixin[T], Generic[T]):
-    """Immutable MultiDict, using [MultiDictProxy][multidict.MultiDictProxy]."""
+    """Immutable MultiDict, using
+    [MultiDictProxy][multidict.MultiDictProxy].
+    """
 
     def __init__(
         self, args: Optional[Union["MultiMapping", Mapping[str, Any], Iterable[Tuple[str, Any]]]] = None
     ) -> None:
-        """Initialize `ImmutableMultiDict` from a [MultiMapping][multidict.MultiMapping],
-        `Mapping` or an iterable of tuples.
+        """Initialize `ImmutableMultiDict` from a
+        [MultiMapping][multidict.MultiMapping], `Mapping` or an iterable of
+        tuples.
 
         Args:
             args: Mapping-like structure to create the `ImmutableMultiDict` from
@@ -110,7 +114,7 @@ class ImmutableMultiDict(MultiDictProxy[T], MultiMixin[T], Generic[T]):
 
 
 class FormMultiDict(ImmutableMultiDict[Any]):
-    """MultiDict for form data"""
+    """MultiDict for form data."""
 
     async def close(self) -> None:
         """Closes all files in the multi-dict.
@@ -124,7 +128,7 @@ class FormMultiDict(ImmutableMultiDict[Any]):
 
 
 class QueryMultiDict(MultiDict):
-    """MultiDict for URL query parameters"""
+    """MultiDict for URL query parameters."""
 
     @classmethod
     def from_query_string(cls, query_string: str) -> "QueryMultiDict":

--- a/starlite/datastructures/multi_dicts.py
+++ b/starlite/datastructures/multi_dicts.py
@@ -65,7 +65,8 @@ class MultiDict(BaseMultiDict[T], MultiMixin[T], Generic[T]):
     """MultiDict, using [MultiDict][multidict.MultiDictProxy]."""
 
     def __init__(self, args: Optional[Union["MultiMapping", Mapping[str, T], Iterable[Tuple[str, T]]]] = None) -> None:
-        """Initialize `MultiDict` from a
+        """Initialize `MultiDict` from a.
+
         [MultiMapping][multidict.MultiMapping], `Mapping` or an iterable of
         tuples.
 
@@ -86,14 +87,16 @@ class MultiDict(BaseMultiDict[T], MultiMixin[T], Generic[T]):
 
 
 class ImmutableMultiDict(MultiDictProxy[T], MultiMixin[T], Generic[T]):
-    """Immutable MultiDict, using
+    """Immutable MultiDict, using.
+
     [MultiDictProxy][multidict.MultiDictProxy].
     """
 
     def __init__(
         self, args: Optional[Union["MultiMapping", Mapping[str, Any], Iterable[Tuple[str, Any]]]] = None
     ) -> None:
-        """Initialize `ImmutableMultiDict` from a
+        """Initialize `ImmutableMultiDict` from a.
+
         [MultiMapping][multidict.MultiMapping], `Mapping` or an iterable of
         tuples.
 

--- a/starlite/datastructures/provide.py
+++ b/starlite/datastructures/provide.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 
 class Provide:
+    """A wrapper class for dependency injection."""
+
     __slots__ = ("dependency", "use_cache", "cache_per_request", "cache_key", "lock", "value", "signature_model")
 
     def __init__(
@@ -23,7 +25,7 @@ class Provide:
         cache_key: Optional[str] = None,
         sync_to_thread: bool = False,
     ) -> None:
-        """A wrapper class used for dependency injection.
+        """Initialize `Provide`
 
         Args:
             dependency: Callable to inject, can be a function, method or class.
@@ -41,7 +43,7 @@ class Provide:
         self.signature_model: Optional["Type[SignatureModel]"] = None
 
     async def __call__(self, **kwargs: Any) -> Any:
-        """Proxies call to 'self.proxy'."""
+        """Proxy a call to 'self.proxy'."""
 
         if self.use_cache and self.value is not Empty:
             return self.value

--- a/starlite/datastructures/response_containers.py
+++ b/starlite/datastructures/response_containers.py
@@ -47,14 +47,15 @@ R = TypeVar("R")
 
 
 class ResponseContainer(ABC, GenericModel, Generic[R]):
+    """Generic response container"""
+
     class Config(BaseConfig):
         arbitrary_types_allowed = True
 
     background: Optional[Union[BackgroundTask, BackgroundTasks]] = None
-    """
-        A [BackgroundTask][starlite.datastructures.BackgroundTask] instance or
-        [BackgroundTasks][starlite.datastructures.BackgroundTasks] to execute after the response is finished.
-        Defaults to None.
+    """A [BackgroundTask][starlite.datastructures.BackgroundTask] instance or
+    [BackgroundTasks][starlite.datastructures.BackgroundTasks] to execute after the response is finished.
+    Defaults to None.
     """
     headers: Dict[str, Any] = {}
     """A string/string dictionary of response headers. Header keys are insensitive. Defaults to None."""
@@ -331,6 +332,7 @@ class Template(ResponseContainer["TemplateResponse"]):
             request: A [Request][starlite.connection.request.Request] instance.
 
         Returns:
+            A dictionary holding the template context
         """
         csrf_token = request.scope.get("_csrf_token", "")
         return {

--- a/starlite/datastructures/response_containers.py
+++ b/starlite/datastructures/response_containers.py
@@ -47,7 +47,7 @@ R = TypeVar("R")
 
 
 class ResponseContainer(ABC, GenericModel, Generic[R]):
-    """Generic response container"""
+    """Generic response container."""
 
     class Config(BaseConfig):
         arbitrary_types_allowed = True

--- a/starlite/datastructures/state.py
+++ b/starlite/datastructures/state.py
@@ -3,8 +3,10 @@ from typing import Any, Dict, Iterator, MutableMapping, Optional
 
 
 class State(MutableMapping[str, Any]):
-    """An object meant to store arbitrary state. It can be accessed using
-    dot notation while exposing dict like functionalities.
+    """An object meant to store arbitrary state.
+
+    It can be accessed using dot notation while exposing dict like
+    functionalities.
     """
 
     __slots__ = ("_state",)
@@ -56,11 +58,14 @@ class State(MutableMapping[str, Any]):
         super().__setattr__("_state", state if state is not None else {})
 
     def __bool__(self) -> bool:
-        """Return a boolean indicating whether the wrapped dict instance has values."""
+        """Return a boolean indicating whether the wrapped dict instance has
+        values.
+        """
         return bool(self._state)
 
     def __getitem__(self, key: str) -> Any:
-        """Get the value for the corresponding key from the wrapped state object using subscription notation
+        """Get the value for the corresponding key from the wrapped state
+        object using subscription notation.
 
         Args:
             key: Key to access.
@@ -74,7 +79,8 @@ class State(MutableMapping[str, Any]):
         return self._state[key]
 
     def __delitem__(self, key: str) -> None:
-        """Delete the value from the key from the wrapped state object using subscription notation
+        """Delete the value from the key from the wrapped state object using
+        subscription notation.
 
         Args:
             key: Key to delete
@@ -88,7 +94,7 @@ class State(MutableMapping[str, Any]):
         del self._state[key]
 
     def __setitem__(self, key: str, value: Any) -> None:
-        """Set an item in the state using subscription notation
+        """Set an item in the state using subscription notation.
 
         Args:
             key: Key to set.
@@ -116,7 +122,7 @@ class State(MutableMapping[str, Any]):
         return len(self._state)
 
     def __setattr__(self, key: str, value: Any) -> None:
-        """Set an item in the state using attribute notation
+        """Set an item in the state using attribute notation.
 
         Args:
             key: Key to set.
@@ -128,7 +134,8 @@ class State(MutableMapping[str, Any]):
         self._state[key] = value
 
     def __getattr__(self, key: str) -> Any:
-        """Get the value for the corresponding key from the wrapped state object using attribute notation
+        """Get the value for the corresponding key from the wrapped state
+        object using attribute notation.
 
         Args:
             key: Key to retrieve
@@ -145,7 +152,8 @@ class State(MutableMapping[str, Any]):
             raise AttributeError(f"State instance has no attribute '{key}'") from e
 
     def __delattr__(self, key: str) -> None:
-        """Delete the value from the key from the wrapped state object using attribute notation
+        """Delete the value from the key from the wrapped state object using
+        attribute notation.
 
         Args:
             key: Key to delete

--- a/starlite/datastructures/state.py
+++ b/starlite/datastructures/state.py
@@ -3,20 +3,21 @@ from typing import Any, Dict, Iterator, MutableMapping, Optional
 
 
 class State(MutableMapping[str, Any]):
+    """An object meant to store arbitrary state. It can be accessed using
+    dot notation while exposing dict like functionalities.
+    """
 
     __slots__ = ("_state",)
 
     _state: Dict[str, Any]
 
     def __init__(self, state: Optional[Dict[str, Any]] = None) -> None:
-        """An object meant to store arbitrary state. It can be accessed using
-        dot notation while exposing dict like functionalities.
+        """Initialize `State` with an optional value.
 
         Args:
              state: An optional string keyed dict for the initial state.
 
         Examples:
-
         ```python
         from starlite import State
 
@@ -55,15 +56,11 @@ class State(MutableMapping[str, Any]):
         super().__setattr__("_state", state if state is not None else {})
 
     def __bool__(self) -> bool:
-        """
-
-        Returns:
-            Boolean indicating whether the wrapped dict instance has values.
-        """
+        """Return a boolean indicating whether the wrapped dict instance has values."""
         return bool(self._state)
 
     def __getitem__(self, key: str) -> Any:
-        """
+        """Get the value for the corresponding key from the wrapped state object using subscription notation
 
         Args:
             key: Key to access.
@@ -77,12 +74,13 @@ class State(MutableMapping[str, Any]):
         return self._state[key]
 
     def __delitem__(self, key: str) -> None:
-        """
+        """Delete the value from the key from the wrapped state object using subscription notation
+
         Args:
-            key: Key to access.
+            key: Key to delete
 
         Raises:
-            KeyError
+            KeyError: if the given attribute is not set.
 
         Returns:
             None
@@ -90,7 +88,7 @@ class State(MutableMapping[str, Any]):
         del self._state[key]
 
     def __setitem__(self, key: str, value: Any) -> None:
-        """
+        """Set an item in the state using subscription notation
 
         Args:
             key: Key to set.
@@ -102,23 +100,23 @@ class State(MutableMapping[str, Any]):
         self._state[key] = value
 
     def __iter__(self) -> Iterator[str]:
-        """
+        """Return an iterator iterating the wrapped state dict.
 
         Returns:
-            An iterator iterating the wrapped state dict.
+            An iterator of strings
         """
         return iter(self._state)
 
     def __len__(self) -> int:
-        """
+        """Return length of the wrapped state dict.
 
         Returns:
-            The length of the wrapped state dict.
+            An integer
         """
         return len(self._state)
 
     def __setattr__(self, key: str, value: Any) -> None:
-        """
+        """Set an item in the state using attribute notation
 
         Args:
             key: Key to set.
@@ -130,7 +128,7 @@ class State(MutableMapping[str, Any]):
         self._state[key] = value
 
     def __getattr__(self, key: str) -> Any:
-        """
+        """Get the value for the corresponding key from the wrapped state object using attribute notation
 
         Args:
             key: Key to retrieve
@@ -139,7 +137,7 @@ class State(MutableMapping[str, Any]):
             AttributeError: if the given attribute is not set.
 
         Returns:
-            Retrieves the value for the corresponding key from the wrapped state object.
+            The retrieved value
         """
         try:
             return self._state[key]
@@ -147,7 +145,7 @@ class State(MutableMapping[str, Any]):
             raise AttributeError(f"State instance has no attribute '{key}'") from e
 
     def __delattr__(self, key: str) -> None:
-        """
+        """Delete the value from the key from the wrapped state object using attribute notation
 
         Args:
             key: Key to delete
@@ -156,7 +154,7 @@ class State(MutableMapping[str, Any]):
             AttributeError: if the given attribute is not set.
 
         Returns:
-            Deletes the value from the key from the wrapped state object.
+            None
         """
         try:
             del self._state[key]
@@ -164,24 +162,24 @@ class State(MutableMapping[str, Any]):
             raise AttributeError(f"State instance has no attribute '{key}'") from e
 
     def __copy__(self) -> "State":
-        """Returns a shallow copy of the given state object.
+        """Return a shallow copy of the given state object.
 
         Customizes how the builtin "copy" function will work.
         """
         return self.__class__(copy(self._state))
 
     def copy(self) -> "State":
-        """
+        """Return a shallow copy of 'self'.
 
         Returns:
-            A shallow copy of 'self'.
+            A `State`
         """
         return copy(self)
 
     def dict(self) -> Dict[str, Any]:
-        """
+        """A shallow copy of the wrapped dict.
 
         Returns:
-            A shallow copy of the wrapped dict.
+            A dict
         """
         return copy(self._state)

--- a/starlite/datastructures/upload_file.py
+++ b/starlite/datastructures/upload_file.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
 
 
 class UploadFile(MultipartUploadFile):
+    """Representation of a file upload, modifying the pydantic schema"""
+
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any], field: Optional["ModelField"]) -> None:
         """Creates a pydantic JSON schema.

--- a/starlite/datastructures/upload_file.py
+++ b/starlite/datastructures/upload_file.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 
 class UploadFile(MultipartUploadFile):
-    """Representation of a file upload, modifying the pydantic schema"""
+    """Representation of a file upload, modifying the pydantic schema."""
 
     @classmethod
     def __modify_schema__(cls, field_schema: Dict[str, Any], field: Optional["ModelField"]) -> None:

--- a/starlite/datastructures/url.py
+++ b/starlite/datastructures/url.py
@@ -38,6 +38,8 @@ def make_absolute_url(path: Union[str, "URL"], base: Union[str, "URL"]) -> str:
 
 
 class URL:
+    """Representation and modification utilities of a URL."""
+
     __slots__ = (
         "_query_params",
         "_url",
@@ -72,10 +74,11 @@ class URL:
     """Hostname if specified"""
 
     def __init__(self, url: Union[str, SplitResult]) -> None:
-        """Representation and modification utilities of a URL.
+        """Initialize `URL` from a string or a [SplitResult][urllib.parse.SplitResult].
 
         Args:
-            url: URL, either as a string or a [SplitResult][urllib.parse.SplitResult] as returned by [urlsplit][urllib.parse.urlsplit]
+            url: URL, either as a string or a [SplitResult][urllib.parse.SplitResult] as
+                returned by [urlsplit][urllib.parse.urlsplit]
         """
         if isinstance(url, str):
             result = urlsplit(url)

--- a/starlite/datastructures/url.py
+++ b/starlite/datastructures/url.py
@@ -74,7 +74,8 @@ class URL:
     """Hostname if specified"""
 
     def __init__(self, url: Union[str, SplitResult]) -> None:
-        """Initialize `URL` from a string or a [SplitResult][urllib.parse.SplitResult].
+        """Initialize `URL` from a string or a
+        [SplitResult][urllib.parse.SplitResult].
 
         Args:
             url: URL, either as a string or a [SplitResult][urllib.parse.SplitResult] as

--- a/starlite/datastructures/url.py
+++ b/starlite/datastructures/url.py
@@ -74,7 +74,8 @@ class URL:
     """Hostname if specified"""
 
     def __init__(self, url: Union[str, SplitResult]) -> None:
-        """Initialize `URL` from a string or a
+        """Initialize `URL` from a string or a.
+
         [SplitResult][urllib.parse.SplitResult].
 
         Args:

--- a/starlite/dto.py
+++ b/starlite/dto.py
@@ -57,6 +57,8 @@ T = TypeVar("T")
 
 
 class DTO(GenericModel, Generic[T]):
+    """Data Transfer Object."""
+
     class Config(BaseConfig):
         arbitrary_types_allowed = True
 
@@ -140,14 +142,17 @@ class DTO(GenericModel, Generic[T]):
 
 
 class DTOFactory:
-    def __init__(self, plugins: Optional[List[PluginProtocol]] = None) -> None:
-        """Create [`DTO`][starlite.dto.DTO] types.
+    """Create [`DTO`][starlite.dto.DTO] type.
 
-         Pydantic models, [`TypedDict`][typing.TypedDict] and dataclasses are natively supported. Other types supported
-         via plugins.
+    Pydantic models, [`TypedDict`][typing.TypedDict] and dataclasses are
+    natively supported. Other types supported  via plugins.
+    """
+
+    def __init__(self, plugins: Optional[List[PluginProtocol]] = None) -> None:
+        """Initialize `DTOFactory`
 
         Args:
-            plugins (list[PluginProtocol] | None): Plugins used to support `DTO` construction from arbitrary types.
+            plugins: Plugins used to support `DTO` construction from arbitrary types.
         """
         self.plugins = plugins or []
 
@@ -159,8 +164,7 @@ class DTOFactory:
         field_mapping: Optional[Dict[str, Union[str, Tuple[str, Any]]]] = None,
         field_definitions: Optional[Dict[str, Tuple[Any, Any]]] = None,
     ) -> Type[DTO[T]]:
-        """
-        Given a supported model class - either pydantic, [`TypedDict`][typing.TypedDict], dataclass or a class supported
+        """Given a supported model class - either pydantic, [`TypedDict`][typing.TypedDict], dataclass or a class supported
         via plugins, create a DTO pydantic model class.
 
         An instance of the factory must first be created, passing any plugins to it.

--- a/starlite/dto.py
+++ b/starlite/dto.py
@@ -243,7 +243,7 @@ class DTOFactory:
     def _get_fields_from_source(
         self, source: Type[T]  # pyright: ignore
     ) -> Tuple[Dict[str, ModelField], Optional[PluginProtocol]]:
-        """Converts a `BaseModel` subclass, [`TypedDict`][typing.TypedDict],
+        """Convert a `BaseModel` subclass, [`TypedDict`][typing.TypedDict],
         `dataclass` or any other type that has a plugin registered into a
         mapping of `str` to `ModelField`.
         """
@@ -272,7 +272,7 @@ class DTOFactory:
         field_mapping: Dict[str, Union[str, Tuple[str, Any]]],
         fields: Dict[str, ModelField],
     ) -> Dict[str, Tuple[Any, Any]]:
-        """Populates `field_definitions`, ignoring fields in `exclude`, and
+        """Populate `field_definitions`, ignoring fields in `exclude`, and
         remapping fields in `field_mapping`.
         """
         for field_name, model_field in fields.items():
@@ -315,7 +315,7 @@ class DTOFactory:
     def _remap_field(
         field_mapping: Dict[str, Union[str, Tuple[str, Any]]], field_name: str, field_type: Any
     ) -> Tuple[str, Any]:
-        """Returns tuple of field name and field type remapped according to
+        """Return tuple of field name and field type remapped according to
         entry in `field_mapping`.
         """
         mapping = field_mapping[field_name]

--- a/starlite/exceptions/base_exceptions.py
+++ b/starlite/exceptions/base_exceptions.py
@@ -2,10 +2,12 @@ from typing import Any
 
 
 class StarLiteException(Exception):
+    """Base exception class from which all Starlite exceptions inherit."""
+
     detail: str
 
     def __init__(self, *args: Any, detail: str = "") -> None:
-        """Base exception class from which all Starlite exceptions inherit.
+        """Initialize `StarLiteException`.
 
         Args:
             *args (Any): args are cast to `str` before passing to `Exception.__init__()`

--- a/starlite/exceptions/http_exceptions.py
+++ b/starlite/exceptions/http_exceptions.py
@@ -15,6 +15,11 @@ from starlite.status_codes import (
 
 
 class HTTPException(StarLiteException):
+    """Base exception for HTTP error responses.
+
+    These exceptions carry information to construct an HTTP response.
+    """
+
     status_code: int = HTTP_500_INTERNAL_SERVER_ERROR
     """Exception status code."""
     detail: str
@@ -32,9 +37,9 @@ class HTTPException(StarLiteException):
         headers: Optional[Dict[str, str]] = None,
         extra: Optional[Union[Dict[str, Any], List[Any]]] = None,
     ) -> None:
-        """Base exception for HTTP error responses.
+        """Initialize `HTTPException`.
 
-        These exceptions carry information to construct an HTTP response.
+        Set `detail` and `args` if not provided.
 
         Args:
             *args: if `detail` kwarg not provided, first arg should be error detail.
@@ -122,8 +127,10 @@ class NoRouteMatchFoundException(InternalServerException):
 
 
 class TemplateNotFoundException(InternalServerException):
+    """Referenced template could not be found."""
+
     def __init__(self, *args: Any, template_name: str) -> None:
-        """Referenced template could not be found.
+        """Initialize `TemplateNotFoundException`.
 
         Args:
             *args (Any): Passed through to `super().__init__()` - should not include `detail`.

--- a/starlite/exceptions/websocket_exceptions.py
+++ b/starlite/exceptions/websocket_exceptions.py
@@ -5,11 +5,13 @@ from starlite.status_codes import WS_1000_NORMAL_CLOSURE
 
 
 class WebSocketException(StarLiteException):
+    """Exception class for websocket related events."""
+
     code: int
     """Exception code. Should be a number in the 4000+ range."""
 
     def __init__(self, *args: Any, detail: str, code: int = 4500) -> None:
-        """Exception class for websocket related events.
+        """Initialize `WebSocketException`.
 
         Args:
             *args: Any exception args.
@@ -21,8 +23,10 @@ class WebSocketException(StarLiteException):
 
 
 class WebSocketDisconnect(WebSocketException):
+    """Exception class for websocket disconnect events."""
+
     def __init__(self, *args: Any, detail: str, code: int = WS_1000_NORMAL_CLOSURE) -> None:
-        """Exception class for websocket disconnect events.
+        """Initialize `WebSocketDisconnect`.
 
         Args:
             *args: Any exception args.

--- a/starlite/handlers/asgi.py
+++ b/starlite/handlers/asgi.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 
 class ASGIRouteHandler(BaseRouteHandler["ASGIRouteHandler"]):
+    """ASGI Route Handler decorator. Use this decorator to decorate ASGI applications."""
+
     __slots__ = ("is_mount", "is_static")
 
     @validate_arguments(config={"arbitrary_types_allowed": True})
@@ -28,14 +30,14 @@ class ASGIRouteHandler(BaseRouteHandler["ASGIRouteHandler"]):
         is_static: bool = False,
         **kwargs: Any,
     ) -> None:
-        """ASGI Route Handler decorator. Use this decorator to decorate ASGI
-        apps.
+        """Initialize `ASGIRouteHandler`.
 
         Args:
             exception_handlers: A dictionary that maps handler functions to status codes and/or exception types.
             guards: A list of [Guard][starlite.types.Guard] callables.
             name: A string identifying the route handler.
-            opt: A string key dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
+            opt: A string key dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or
+                wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             path: A path fragment for the route handler function or a list of path fragments. If not given defaults to '/'
             is_mount: A boolean dictating whether the handler's paths should be regarded as mount paths. Mount path accept
                 any arbitrary paths that begin with the defined prefixed path. For example, a mount with the path `/some-path/`

--- a/starlite/handlers/asgi.py
+++ b/starlite/handlers/asgi.py
@@ -13,7 +13,10 @@ if TYPE_CHECKING:
 
 
 class ASGIRouteHandler(BaseRouteHandler["ASGIRouteHandler"]):
-    """ASGI Route Handler decorator. Use this decorator to decorate ASGI applications."""
+    """ASGI Route Handler decorator.
+
+    Use this decorator to decorate ASGI applications.
+    """
 
     __slots__ = ("is_mount", "is_static")
 

--- a/starlite/handlers/base.py
+++ b/starlite/handlers/base.py
@@ -40,11 +40,13 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound="BaseRouteHandler")
 
 
-class ParameterConfig(BaseConfig):
+class ParameterConfig(BaseConfig):  # noqa: D101
     extra = Extra.allow
 
 
 class BaseRouteHandler(Generic[T]):
+    """Base route handler. Serves as a subclass for all route handlers"""
+
     __slots__ = (
         "_resolved_dependencies",
         "_resolved_guards",
@@ -74,6 +76,19 @@ class BaseRouteHandler(Generic[T]):
         opt: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
+        """Initialize `HTTPRouteHandler`.
+
+        Args:
+            path: A path fragment for the route handler function or a list of path fragments. If not given defaults to '/'
+            dependencies: A string keyed dictionary of dependency [Provider][starlite.datastructures.Provide] instances.
+            exception_handlers: A dictionary that maps handler functions to status codes and/or exception types.
+            guards: A list of [Guard][starlite.types.Guard] callables.
+            middleware: A list of [Middleware][starlite.types.Middleware].
+            name: A string identifying the route handler.
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or
+                wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
+            **kwargs: Any additional kwarg - will be set in the opt dictionary.
+        """
         self._resolved_dependencies: Union[Dict[str, Provide], EmptyType] = Empty
         self._resolved_guards: Union[List[Guard], EmptyType] = Empty
         self._resolved_layered_parameters: Union[Dict[str, "ModelField"], EmptyType] = Empty
@@ -232,9 +247,10 @@ class BaseRouteHandler(Generic[T]):
             raise ImproperlyConfiguredException("Cannot call _validate_handler_function without first setting self.fn")
 
     def __str__(self) -> str:
-        """
+        """Return a unique identifier for the route handler
+
         Returns:
-            A unique identifier for the route handler
+            A string
         """
         target = cast("Any", self.fn)
         if not hasattr(target, "__qualname__"):

--- a/starlite/handlers/base.py
+++ b/starlite/handlers/base.py
@@ -45,7 +45,10 @@ class ParameterConfig(BaseConfig):  # noqa: D101
 
 
 class BaseRouteHandler(Generic[T]):
-    """Base route handler. Serves as a subclass for all route handlers"""
+    """Base route handler.
+
+    Serves as a subclass for all route handlers
+    """
 
     __slots__ = (
         "_resolved_dependencies",
@@ -247,7 +250,7 @@ class BaseRouteHandler(Generic[T]):
             raise ImproperlyConfiguredException("Cannot call _validate_handler_function without first setting self.fn")
 
     def __str__(self) -> str:
-        """Return a unique identifier for the route handler
+        """Return a unique identifier for the route handler.
 
         Returns:
             A string

--- a/starlite/handlers/base.py
+++ b/starlite/handlers/base.py
@@ -40,7 +40,9 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound="BaseRouteHandler")
 
 
-class ParameterConfig(BaseConfig):  # noqa: D101
+class ParameterConfig(BaseConfig):
+    """Base config for `ModelField`"""
+
     extra = Extra.allow
 
 

--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -214,7 +214,7 @@ def _create_data_handler(
 
 
 def _normalize_http_method(http_methods: Union[HttpMethod, Method, List[Union[HttpMethod, Method]]]) -> Set["Method"]:
-    """
+    """Normalize HTTP method(s) into a set of upper-case method names.
 
     Args:
         http_methods: A value for http method.
@@ -234,13 +234,13 @@ def _normalize_http_method(http_methods: Union[HttpMethod, Method, List[Union[Ht
 
 
 def _get_default_status_code(http_methods: Set["Method"]) -> int:
-    """
+    """Return the default status code for a given set of HTTP methods
 
     Args:
-        http_methods: A set of Method strings.
+        http_methods: A set of method strings
 
     Returns:
-        A status code integer.
+        A status code
     """
     if HttpMethod.POST in http_methods:
         return HTTP_201_CREATED
@@ -250,6 +250,10 @@ def _get_default_status_code(http_methods: Set["Method"]) -> int:
 
 
 class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
+    """HTTP Route Decorator. Use this decorator to decorate an HTTP handler
+    with multiple methods.
+    """
+
     __slots__ = (
         "_resolved_after_response",
         "_resolved_before_request",
@@ -325,8 +329,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         tags: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
-        """HTTP Route Decorator. Use this decorator to decorate an HTTP handler
-        with multiple methods.
+        """Initialize `HTTPRouteHandler`.
 
         Args:
             path: A path fragment for the route handler function or a list of path fragments.
@@ -587,7 +590,8 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
     async def to_response(
         self, app: "Starlite", data: Any, plugins: List["PluginProtocol"], request: "Request"
     ) -> "ASGIApp":
-        """
+        """Return a [Response][starlite.Response] from the handler by resolving and
+        calling it.
 
         Args:
             app: The [Starlite][starlite.app.Starlite] app instance
@@ -598,21 +602,21 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
 
         Returns:
             A Response instance
-
         """
         response_handler = self.resolve_response_handler()
         return await response_handler(app=app, data=data, plugins=plugins, request=request)  # type: ignore
 
     @property
     def signature(self) -> Signature:
-        """
+        """Return the signature of `self.fn`.
+
         Returns:
-            The Signature of 'self.fn'.
+            A `Signature`
         """
         return Signature.from_callable(cast("AnyCallable", self.fn))
 
     def _validate_handler_function(self) -> None:
-        """Validates the route handler function once it is set by inspecting
+        """Validate the route handler function once it is set by inspecting
         its return annotations.
         """
         super()._validate_handler_function()
@@ -660,6 +664,10 @@ route = HTTPRouteHandler
 
 
 class get(HTTPRouteHandler):
+    """GET Route Decorator. Use this decorator to decorate an HTTP handler
+    for GET requests.
+    """
+
     @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
@@ -700,8 +708,7 @@ class get(HTTPRouteHandler):
         tags: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
-        """GET Route Decorator. Use this decorator to decorate an HTTP handler
-        for GET requests.
+        """Initialize `get`.
 
         Args:
             path: A path fragment for the route handler function or a list of path fragments.
@@ -724,6 +731,7 @@ class get(HTTPRouteHandler):
             cache_key_builder: A [cache-key builder function][starlite.types.CacheKeyBuilder]. Allows for customization
                 of the cache key if caching is configured on the application level.
             dependencies: A string keyed dictionary of dependency [Provider][starlite.datastructures.Provide] instances.
+            etag: An `etag` header of type [ETag][starlite.datastructures.ETag] that will be added to the response.
             exception_handlers: A dictionary that maps handler functions to status codes and/or exception types.
             guards: A list of [Guard][starlite.types.Guard] callables.
             media_type: A member of the [MediaType][starlite.enums.MediaType] enum or a string with a
@@ -797,6 +805,10 @@ class get(HTTPRouteHandler):
 
 
 class head(HTTPRouteHandler):
+    """HEAD Route Decorator. Use this decorator to decorate an HTTP handler
+    for HEAD requests.
+    """
+
     @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
@@ -837,8 +849,7 @@ class head(HTTPRouteHandler):
         tags: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
-        """HEAD Route Decorator. Use this decorator to decorate an HTTP handler
-        for HEAD requests.
+        """Initialize `head`.
 
         Notes:
             - A response to a head request cannot include a body.
@@ -871,7 +882,8 @@ class head(HTTPRouteHandler):
                 valid IANA Media-Type.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or
+                wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             response_class: A custom subclass of [starlite.response.Response] to be used as route handler's
                 default response.
             response_cookies: A list of [Cookie](starlite.datastructures.Cookie] instances.
@@ -888,7 +900,9 @@ class head(HTTPRouteHandler):
             description: Text used for the route's schema description section.
             include_in_schema: A boolean flag dictating whether  the route handler should be documented in the OpenAPI schema.
             operation_id: An identifier used for the route's schema operationId. Defaults to the __name__ of the wrapped function.
-            raises:  A list of exception classes extending from starlite.HttpException that is used for the OpenAPI documentation. This list should describe all exceptions raised within the route handler's function/method. The Starlite ValidationException will be added automatically for the schema if any validation is involved.
+            raises:  A list of exception classes extending from starlite.HttpException that is used for the OpenAPI documentation.
+                This list should describe all exceptions raised within the route handler's function/method. The Starlite
+                ValidationException will be added automatically for the schema if any validation is involved.
             response_description: Text used for the route's response schema description section.
             security: A list of dictionaries that contain information about which security scheme can be used on the endpoint.
             summary: Text used for the route's schema summary section.
@@ -954,6 +968,10 @@ class head(HTTPRouteHandler):
 
 
 class post(HTTPRouteHandler):
+    """POST Route Decorator. Use this decorator to decorate an HTTP handler
+    for POST requests.
+    """
+
     @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
@@ -994,8 +1012,7 @@ class post(HTTPRouteHandler):
         tags: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
-        """POST Route Decorator. Use this decorator to decorate an HTTP handler
-        for POST requests.
+        """Initialize `post`
 
         Args:
             path: A path fragment for the route handler function or a list of path fragments.
@@ -1025,7 +1042,8 @@ class post(HTTPRouteHandler):
                 valid IANA Media-Type.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or
+                wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             response_class: A custom subclass of [starlite.response.Response] to be used as route handler's
                 default response.
             response_cookies: A list of [Cookie](starlite.datastructures.Cookie] instances.
@@ -1042,7 +1060,9 @@ class post(HTTPRouteHandler):
             description: Text used for the route's schema description section.
             include_in_schema: A boolean flag dictating whether  the route handler should be documented in the OpenAPI schema.
             operation_id: An identifier used for the route's schema operationId. Defaults to the __name__ of the wrapped function.
-            raises:  A list of exception classes extending from starlite.HttpException that is used for the OpenAPI documentation. This list should describe all exceptions raised within the route handler's function/method. The Starlite ValidationException will be added automatically for the schema if any validation is involved.
+            raises:  A list of exception classes extending from starlite.HttpException that is used for the OpenAPI
+                documentation. This list should describe all exceptions raised within the route handler's function/method.
+                The Starlite ValidationException will be added automatically for the schema if any validation is involved.
             response_description: Text used for the route's response schema description section.
             security: A list of dictionaries that contain information about which security scheme can be used on the endpoint.
             summary: Text used for the route's schema summary section.
@@ -1091,6 +1111,10 @@ class post(HTTPRouteHandler):
 
 
 class put(HTTPRouteHandler):
+    """PUT Route Decorator. Use this decorator to decorate an HTTP handler
+    for PUT requests.
+    """
+
     @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
@@ -1131,8 +1155,7 @@ class put(HTTPRouteHandler):
         tags: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
-        """PUT Route Decorator. Use this decorator to decorate an HTTP handler
-        for PUT requests.
+        """Initialize `put`
 
         Args:
             path: A path fragment for the route handler function or a list of path fragments.
@@ -1162,7 +1185,8 @@ class put(HTTPRouteHandler):
                 valid IANA Media-Type.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or
+                wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             response_class: A custom subclass of [starlite.response.Response] to be used as route handler's
                 default response.
             response_cookies: A list of [Cookie](starlite.datastructures.Cookie] instances.
@@ -1230,6 +1254,10 @@ class put(HTTPRouteHandler):
 
 
 class patch(HTTPRouteHandler):
+    """PATCH Route Decorator. Use this decorator to decorate an HTTP
+    handler for PATCH requests.
+    """
+
     @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
@@ -1270,8 +1298,7 @@ class patch(HTTPRouteHandler):
         tags: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
-        """PATCH Route Decorator. Use this decorator to decorate an HTTP
-        handler for PATCH requests.
+        """Initialize `patch`.
 
         Args:
             path: A path fragment for the route handler function or a list of path fragments.
@@ -1301,7 +1328,8 @@ class patch(HTTPRouteHandler):
                 valid IANA Media-Type.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or
+                wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             response_class: A custom subclass of [starlite.response.Response] to be used as route handler's
                 default response.
             response_cookies: A list of [Cookie](starlite.datastructures.Cookie] instances.
@@ -1318,7 +1346,9 @@ class patch(HTTPRouteHandler):
             description: Text used for the route's schema description section.
             include_in_schema: A boolean flag dictating whether  the route handler should be documented in the OpenAPI schema.
             operation_id: An identifier used for the route's schema operationId. Defaults to the __name__ of the wrapped function.
-            raises:  A list of exception classes extending from starlite.HttpException that is used for the OpenAPI documentation. This list should describe all exceptions raised within the route handler's function/method. The Starlite ValidationException will be added automatically for the schema if any validation is involved.
+            raises:  A list of exception classes extending from starlite.HttpException that is used for the OpenAPI documentation.
+                This list should describe all exceptions raised within the route handler's function/method. The Starlite
+                ValidationException will be added automatically for the schema if any validation is involved.
             response_description: Text used for the route's response schema description section.
             security: A list of dictionaries that contain information about which security scheme can be used on the endpoint.
             summary: Text used for the route's schema summary section.
@@ -1367,6 +1397,10 @@ class patch(HTTPRouteHandler):
 
 
 class delete(HTTPRouteHandler):
+    """DELETE Route Decorator. Use this decorator to decorate an HTTP
+    handler for DELETE requests.
+    """
+
     @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
@@ -1407,8 +1441,7 @@ class delete(HTTPRouteHandler):
         tags: Optional[List[str]] = None,
         **kwargs: Any,
     ) -> None:
-        """DELETE Route Decorator. Use this decorator to decorate an HTTP
-        handler for DELETE requests.
+        """Initialize `delete`
 
         Args:
             path: A path fragment for the route handler function or a list of path fragments.
@@ -1438,7 +1471,8 @@ class delete(HTTPRouteHandler):
                 valid IANA Media-Type.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or
+                wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             response_class: A custom subclass of [starlite.response.Response] to be used as route handler's
                 default response.
             response_cookies: A list of [Cookie](starlite.datastructures.Cookie] instances.
@@ -1455,7 +1489,9 @@ class delete(HTTPRouteHandler):
             description: Text used for the route's schema description section.
             include_in_schema: A boolean flag dictating whether  the route handler should be documented in the OpenAPI schema.
             operation_id: An identifier used for the route's schema operationId. Defaults to the __name__ of the wrapped function.
-            raises:  A list of exception classes extending from starlite.HttpException that is used for the OpenAPI documentation. This list should describe all exceptions raised within the route handler's function/method. The Starlite ValidationException will be added automatically for the schema if any validation is involved.
+            raises:  A list of exception classes extending from starlite.HttpException that is used for the OpenAPI documentation.
+                This list should describe all exceptions raised within the route handler's function/method. The Starlite
+                ValidationException will be added automatically for the schema if any validation is involved.
             response_description: Text used for the route's response schema description section.
             security: A list of dictionaries that contain information about which security scheme can be used on the endpoint.
             summary: Text used for the route's schema summary section.

--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -234,7 +234,7 @@ def _normalize_http_method(http_methods: Union[HttpMethod, Method, List[Union[Ht
 
 
 def _get_default_status_code(http_methods: Set["Method"]) -> int:
-    """Return the default status code for a given set of HTTP methods
+    """Return the default status code for a given set of HTTP methods.
 
     Args:
         http_methods: A set of method strings
@@ -250,8 +250,10 @@ def _get_default_status_code(http_methods: Set["Method"]) -> int:
 
 
 class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
-    """HTTP Route Decorator. Use this decorator to decorate an HTTP handler
-    with multiple methods.
+    """HTTP Route Decorator.
+
+    Use this decorator to decorate an HTTP handler with multiple
+    methods.
     """
 
     __slots__ = (
@@ -590,8 +592,8 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
     async def to_response(
         self, app: "Starlite", data: Any, plugins: List["PluginProtocol"], request: "Request"
     ) -> "ASGIApp":
-        """Return a [Response][starlite.Response] from the handler by resolving and
-        calling it.
+        """Return a [Response][starlite.Response] from the handler by resolving
+        and calling it.
 
         Args:
             app: The [Starlite][starlite.app.Starlite] app instance
@@ -616,8 +618,8 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         return Signature.from_callable(cast("AnyCallable", self.fn))
 
     def _validate_handler_function(self) -> None:
-        """Validate the route handler function once it is set by inspecting
-        its return annotations.
+        """Validate the route handler function once it is set by inspecting its
+        return annotations.
         """
         super()._validate_handler_function()
 
@@ -664,8 +666,9 @@ route = HTTPRouteHandler
 
 
 class get(HTTPRouteHandler):
-    """GET Route Decorator. Use this decorator to decorate an HTTP handler
-    for GET requests.
+    """GET Route Decorator.
+
+    Use this decorator to decorate an HTTP handler for GET requests.
     """
 
     @validate_arguments(config={"arbitrary_types_allowed": True})
@@ -805,8 +808,9 @@ class get(HTTPRouteHandler):
 
 
 class head(HTTPRouteHandler):
-    """HEAD Route Decorator. Use this decorator to decorate an HTTP handler
-    for HEAD requests.
+    """HEAD Route Decorator.
+
+    Use this decorator to decorate an HTTP handler for HEAD requests.
     """
 
     @validate_arguments(config={"arbitrary_types_allowed": True})
@@ -968,8 +972,9 @@ class head(HTTPRouteHandler):
 
 
 class post(HTTPRouteHandler):
-    """POST Route Decorator. Use this decorator to decorate an HTTP handler
-    for POST requests.
+    """POST Route Decorator.
+
+    Use this decorator to decorate an HTTP handler for POST requests.
     """
 
     @validate_arguments(config={"arbitrary_types_allowed": True})
@@ -1111,8 +1116,9 @@ class post(HTTPRouteHandler):
 
 
 class put(HTTPRouteHandler):
-    """PUT Route Decorator. Use this decorator to decorate an HTTP handler
-    for PUT requests.
+    """PUT Route Decorator.
+
+    Use this decorator to decorate an HTTP handler for PUT requests.
     """
 
     @validate_arguments(config={"arbitrary_types_allowed": True})
@@ -1254,8 +1260,9 @@ class put(HTTPRouteHandler):
 
 
 class patch(HTTPRouteHandler):
-    """PATCH Route Decorator. Use this decorator to decorate an HTTP
-    handler for PATCH requests.
+    """PATCH Route Decorator.
+
+    Use this decorator to decorate an HTTP handler for PATCH requests.
     """
 
     @validate_arguments(config={"arbitrary_types_allowed": True})
@@ -1397,8 +1404,9 @@ class patch(HTTPRouteHandler):
 
 
 class delete(HTTPRouteHandler):
-    """DELETE Route Decorator. Use this decorator to decorate an HTTP
-    handler for DELETE requests.
+    """DELETE Route Decorator.
+
+    Use this decorator to decorate an HTTP handler for DELETE requests.
     """
 
     @validate_arguments(config={"arbitrary_types_allowed": True})

--- a/starlite/handlers/websocket.py
+++ b/starlite/handlers/websocket.py
@@ -13,8 +13,9 @@ if TYPE_CHECKING:
 
 
 class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):
-    """Websocket route handler decorator. Use this decorator to decorate
-    websocket handler functions.
+    """Websocket route handler decorator.
+
+    Use this decorator to decorate websocket handler functions.
     """
 
     @validate_arguments(config={"arbitrary_types_allowed": True})

--- a/starlite/handlers/websocket.py
+++ b/starlite/handlers/websocket.py
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
 
 
 class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):
+    """Websocket route handler decorator. Use this decorator to decorate
+    websocket handler functions.
+    """
+
     @validate_arguments(config={"arbitrary_types_allowed": True})
     def __init__(
         self,
@@ -26,17 +30,17 @@ class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):
         opt: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> None:
-        """WebSocket Route Handler decorator. Use this decorator to decorate
-        websocket handler functions.
+        """Initialize `WebsocketRouteHandler`
 
         Args:
+            path: A path fragment for the route handler function or a list of path fragments. If not given defaults to '/'
             dependencies: A string keyed dictionary of dependency [Provider][starlite.datastructures.Provide] instances.
             exception_handlers: A dictionary that maps handler functions to status codes and/or exception types.
             guards: A list of [Guard][starlite.types.Guard] callables.
             middleware: A list of [Middleware][starlite.types.Middleware].
             name: A string identifying the route handler.
-            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
-            path: A path fragment for the route handler function or a list of path fragments. If not given defaults to '/'
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or
+                wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """
         super().__init__(

--- a/starlite/kwargs.py
+++ b/starlite/kwargs.py
@@ -88,8 +88,7 @@ def merge_parameter_sets(first: Set[ParameterDefinition], second: Set[ParameterD
 
 
 class KwargsModel:
-    """This class is used to model the required kwargs for a given RouteHandler
-    and its dependencies.
+    """Model required kwargs for a given RouteHandler and its dependencies.
 
     This is done once and is memoized during application bootstrap,
     ensuring minimal runtime overhead.
@@ -121,10 +120,7 @@ class KwargsModel:
         sequence_query_parameter_names: Set[str],
         is_data_optional: bool,
     ) -> None:
-        """This class is used to model the required kwargs for a given
-        RouteHandler and its dependencies.
-
-        This is done once and is memoized during application bootstrap, ensuring minimal runtime overhead.
+        """Initialize `KwargsModel`.
 
         Args:
             expected_cookie_params: Any expected cookie parameter kwargs
@@ -164,8 +160,8 @@ class KwargsModel:
         dependencies: Dict[str, Provide],
         signature_model_fields: Dict[str, ModelField],
     ) -> Tuple[Set[ParameterDefinition], set]:
-        """This function gets parameter_definitions for the construction of
-        KwargsModel instance.
+        """Get parameter_definitions for the construction of KwargsModel
+        instance.
 
         Args:
             path_parameters: Any expected path parameters.
@@ -255,9 +251,9 @@ class KwargsModel:
         path_parameters: Set[str],
         layered_parameters: Dict[str, ModelField],
     ) -> "KwargsModel":
-        """This function pre-determines what parameters are required for a
-        given combination of route + route handler. It is executed during the
-        application bootstrap process.
+        """Pre-determine what parameters are required for a given combination
+        of route + route handler. It is executed during the application
+        bootstrap process.
 
         Args:
             signature_model: A [SignatureModel][starlite.signature.SignatureModel] subclass.
@@ -410,7 +406,7 @@ class KwargsModel:
 
     @staticmethod
     def _collect_params(params: Mapping[str, Any], expected: Set[ParameterDefinition], url: URL) -> Dict[str, Any]:
-        """Collects request params, checking for missing required values."""
+        """Collect request params, checking for missing required values."""
         missing_params = [p.field_alias for p in expected if p.is_required and p.field_alias not in params]
         if missing_params:
             raise ValidationException(f"Missing required parameter(s) {', '.join(missing_params)} for url {url}")
@@ -453,7 +449,7 @@ class KwargsModel:
 
     @classmethod
     def _create_dependency_graph(cls, key: str, dependencies: Dict[str, Provide]) -> Dependency:
-        """Creates a graph like structure of dependencies, with each dependency
+        """Create a graph like structure of dependencies, with each dependency
         including its own dependencies as a list.
         """
         provide = dependencies[key]
@@ -468,7 +464,7 @@ class KwargsModel:
     def _create_parameter_definition(
         allow_none: bool, field_info: FieldInfo, field_name: str, path_parameters: Set[str], is_sequence: bool
     ) -> ParameterDefinition:
-        """Creates a ParameterDefinition for the given pydantic FieldInfo
+        """Create a ParameterDefinition for the given pydantic FieldInfo
         instance and inserts it into the correct parameter set.
         """
         extra = field_info.extra
@@ -503,9 +499,7 @@ class KwargsModel:
         expected_form_data: Optional[Tuple[RequestEncodingType, ModelField]],
         dependency_kwargs_model: "KwargsModel",
     ) -> None:
-        """Validates that the 'data' kwarg is compatible across
-        dependencies.
-        """
+        """Validate that the 'data' kwarg is compatible across dependencies."""
         if (expected_form_data and not dependency_kwargs_model.expected_form_data) or (
             not expected_form_data and dependency_kwargs_model.expected_form_data
         ):
@@ -528,7 +522,7 @@ class KwargsModel:
         model_fields: Dict[str, ModelField],
         layered_parameters: Dict[str, ModelField],
     ) -> None:
-        """Validates that there are no ambiguous kwargs, that is, kwargs
+        """Validate that there are no ambiguous kwargs, that is, kwargs
         declared using the same key in different places.
         """
         dependency_keys = set(dependencies.keys())
@@ -563,14 +557,14 @@ class KwargsModel:
             )
 
     def _sequence_or_scalar_param(self, key: str, value: List[str]) -> Union[str, List[str]]:
-        """Returns the first element of 'value' if we expect it to be a scalar
+        """Return the first element of 'value' if we expect it to be a scalar
         value (appears in self.sequence_query_parameter_names) and it contains
         only a single element.
         """
         return value[0] if key not in self.sequence_query_parameter_names and len(value) == 1 else value
 
     async def _get_request_data(self, request: "Request") -> Any:
-        """Retrieves the data - either json data or form data - from the request"""
+        """Retrieve the data - either json data or form data - from the request"""
         if self.expected_form_data:
             media_type, model_field = self.expected_form_data
             form_data = await request.form()

--- a/starlite/logging/picologging.py
+++ b/starlite/logging/picologging.py
@@ -13,9 +13,12 @@ except ImportError as e:
 
 
 class QueueListenerHandler(QueueHandler):
+    """Configure queue listener and handler to support non-blocking
+    logging configuration.
+    """
+
     def __init__(self, handlers: Optional[List[Any]] = None) -> None:
-        """Configures queue listener and handler to support non-blocking
-        logging configuration.
+        """Initialize `QueueListenerHandler`.
 
         Args:
             handlers: Optional 'ConvertingList'

--- a/starlite/logging/picologging.py
+++ b/starlite/logging/picologging.py
@@ -13,8 +13,8 @@ except ImportError as e:
 
 
 class QueueListenerHandler(QueueHandler):
-    """Configure queue listener and handler to support non-blocking
-    logging configuration.
+    """Configure queue listener and handler to support non-blocking logging
+    configuration.
     """
 
     def __init__(self, handlers: Optional[List[Any]] = None) -> None:

--- a/starlite/logging/standard.py
+++ b/starlite/logging/standard.py
@@ -8,9 +8,12 @@ from starlite.logging.utils import resolve_handlers
 
 
 class QueueListenerHandler(QueueHandler):
+    """Configure queue listener and handler to support non-blocking
+    logging configuration.
+    """
+
     def __init__(self, handlers: Optional[List[Any]] = None) -> None:
-        """Configures queue listener and handler to support non-blocking
-        logging configuration.
+        """Initialize `?QueueListenerHandler`.
 
         Args:
             handlers: Optional 'ConvertingList'

--- a/starlite/logging/standard.py
+++ b/starlite/logging/standard.py
@@ -8,8 +8,8 @@ from starlite.logging.utils import resolve_handlers
 
 
 class QueueListenerHandler(QueueHandler):
-    """Configure queue listener and handler to support non-blocking
-    logging configuration.
+    """Configure queue listener and handler to support non-blocking logging
+    configuration.
     """
 
     def __init__(self, handlers: Optional[List[Any]] = None) -> None:

--- a/starlite/middleware/allowed_hosts.py
+++ b/starlite/middleware/allowed_hosts.py
@@ -12,8 +12,8 @@ if TYPE_CHECKING:
 
 
 class AllowedHostsMiddleware(AbstractMiddleware):
-    """Middleware ensuring the host of a request originated in a
-    trusted host.
+    """Middleware ensuring the host of a request originated in a trusted
+    host.
     """
 
     def __init__(self, app: "ASGIApp", config: "AllowedHostsConfig"):

--- a/starlite/middleware/allowed_hosts.py
+++ b/starlite/middleware/allowed_hosts.py
@@ -12,9 +12,12 @@ if TYPE_CHECKING:
 
 
 class AllowedHostsMiddleware(AbstractMiddleware):
+    """Middleware ensuring the host of a request originated in a
+    trusted host.
+    """
+
     def __init__(self, app: "ASGIApp", config: "AllowedHostsConfig"):
-        """Middleware that ensures the host of a request originated in a
-        trusted host.
+        """Initialize `AllowedHostsMiddleware`.
 
         Args:
             app: The 'next' ASGI app to call.
@@ -43,6 +46,16 @@ class AllowedHostsMiddleware(AbstractMiddleware):
                 self.redirect_domains = re.compile("|".join(sorted(redirect_domains)))
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+        """The middleware's ASGI callable.
+
+        Args:
+            scope: The ASGI connection scope.
+            receive: The ASGI receive function.
+            send: The ASGI send function.
+
+        Returns:
+            None
+        """
         if self.allowed_hosts_regex is None:
             await self.app(scope, receive, send)
             return

--- a/starlite/middleware/authentication.py
+++ b/starlite/middleware/authentication.py
@@ -32,6 +32,11 @@ class AuthenticationResult(BaseModel):
 
 
 class AbstractAuthenticationMiddleware(ABC):
+    """Abstract AuthenticationMiddleware that allows users to
+    create their own AuthenticationMiddleware by extending it and
+    overriding the 'authenticate_request' method.
+    """
+
     scopes: "Scopes" = {ScopeType.HTTP, ScopeType.WEBSOCKET}
     """
     Scopes supported by the middleware.
@@ -43,9 +48,7 @@ class AbstractAuthenticationMiddleware(ABC):
         exclude: Optional[Union[str, List[str]]] = None,
         exclude_from_auth_key: str = "exclude_from_auth",
     ) -> None:
-        """This is an abstract AuthenticationMiddleware that allows users to
-        create their own AuthenticationMiddleware by extending it and
-        overriding the 'authenticate_request' method.
+        """Initialize `AbstractAuthenticationMiddleware`.
 
         Args:
             app: An ASGIApp, this value is the next ASGI handler to call in the middleware stack.
@@ -57,7 +60,8 @@ class AbstractAuthenticationMiddleware(ABC):
         self.exclude = build_exclude_path_pattern(exclude=exclude)
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
-        """
+        """The middleware's ASGI callable.
+
         Args:
             scope: The ASGI connection scope.
             receive: The ASGI receive function.

--- a/starlite/middleware/authentication.py
+++ b/starlite/middleware/authentication.py
@@ -32,9 +32,9 @@ class AuthenticationResult(BaseModel):
 
 
 class AbstractAuthenticationMiddleware(ABC):
-    """Abstract AuthenticationMiddleware that allows users to
-    create their own AuthenticationMiddleware by extending it and
-    overriding the 'authenticate_request' method.
+    """Abstract AuthenticationMiddleware that allows users to create their own
+    AuthenticationMiddleware by extending it and overriding the
+    'authenticate_request' method.
     """
 
     scopes: "Scopes" = {ScopeType.HTTP, ScopeType.WEBSOCKET}

--- a/starlite/middleware/base.py
+++ b/starlite/middleware/base.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class MiddlewareProtocol(Protocol):  # pragma: no cover
+    """Abstract middleware protocol"""
+
     __slots__ = ("app",)
 
     app: "ASGIApp"
@@ -39,6 +41,8 @@ class MiddlewareProtocol(Protocol):  # pragma: no cover
 
 
 class DefineMiddleware:
+    """Container enabling passing *args and **kwargs to Middleware class constructors and factory functions."""
+
     __slots__ = (
         "middleware",
         "args",
@@ -46,8 +50,7 @@ class DefineMiddleware:
     )
 
     def __init__(self, middleware: Callable[..., "ASGIApp"], *args: Any, **kwargs: Any) -> None:
-        """This class is a container that allows passing *args and **kwargs to
-        Middleware class constructors and factory functions.
+        """Initialize `DefineMiddleware`.
 
         Args:
             middleware: A callable that returns an ASGIApp.
@@ -76,6 +79,11 @@ class DefineMiddleware:
 
 
 class AbstractMiddleware:
+    """Abstract middleware providing base functionality common to all middlewares, for
+    dynamically engaging/bypassing the middleware based on paths, `opt`-keys and scope
+    types. When implementing new middleware, this class should be used as a base.
+    """
+
     scopes: "Scopes" = {ScopeType.HTTP, ScopeType.WEBSOCKET}
     exclude: Optional[Union[str, List[str]]] = None
     exclude_opt_key: Optional[str] = None
@@ -87,7 +95,7 @@ class AbstractMiddleware:
         exclude_opt_key: Optional[str] = None,
         scopes: Optional["Scopes"] = None,
     ) -> None:
-        """
+        """Initialize the middleware.
 
         Args:
             app: The 'next' ASGI app to call.

--- a/starlite/middleware/base.py
+++ b/starlite/middleware/base.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class MiddlewareProtocol(Protocol):  # pragma: no cover
-    """Abstract middleware protocol"""
+    """Abstract middleware protocol."""
 
     __slots__ = ("app",)
 
@@ -41,7 +41,9 @@ class MiddlewareProtocol(Protocol):  # pragma: no cover
 
 
 class DefineMiddleware:
-    """Container enabling passing *args and **kwargs to Middleware class constructors and factory functions."""
+    """Container enabling passing *args and **kwargs to Middleware class
+    constructors and factory functions.
+    """
 
     __slots__ = (
         "middleware",
@@ -79,9 +81,12 @@ class DefineMiddleware:
 
 
 class AbstractMiddleware:
-    """Abstract middleware providing base functionality common to all middlewares, for
-    dynamically engaging/bypassing the middleware based on paths, `opt`-keys and scope
-    types. When implementing new middleware, this class should be used as a base.
+    """Abstract middleware providing base functionality common to all
+    middlewares, for dynamically engaging/bypassing the middleware based on
+    paths, `opt`-keys and scope types.
+
+    When implementing new middleware, this class should be used as a
+    base.
     """
 
     scopes: "Scopes" = {ScopeType.HTTP, ScopeType.WEBSOCKET}

--- a/starlite/middleware/compression.py
+++ b/starlite/middleware/compression.py
@@ -28,8 +28,8 @@ if TYPE_CHECKING:
 
 
 class CompressionFacade:
-    """A unified facade offering a uniform interface for different
-    compression libraries
+    """A unified facade offering a uniform interface for different compression
+    libraries.
     """
 
     __slots__ = ("compressor", "buffer", "compression_encoding")
@@ -97,7 +97,8 @@ class CompressionFacade:
 class CompressionMiddleware(AbstractMiddleware):
     """Compression Middleware Wrapper.
 
-    This is a wrapper allowing for generic compression configuration / handler middleware
+    This is a wrapper allowing for generic compression configuration /
+    handler middleware
     """
 
     def __init__(self, app: "ASGIApp", config: "CompressionConfig") -> None:

--- a/starlite/middleware/compression.py
+++ b/starlite/middleware/compression.py
@@ -28,13 +28,16 @@ if TYPE_CHECKING:
 
 
 class CompressionFacade:
+    """A unified facade offering a uniform interface for different
+    compression libraries
+    """
+
     __slots__ = ("compressor", "buffer", "compression_encoding")
 
     compressor: Union["GzipFile", "Compressor"]  # pyright: ignore
 
     def __init__(self, buffer: BytesIO, compression_encoding: CompressionEncoding, config: "CompressionConfig") -> None:
-        """A unified facade class that offers a uniform interface for different
-        compression libraries.
+        """Initialize `CompressionFacade`.
 
         Args:
             buffer: A bytes IO buffer to write the compressed data into.
@@ -92,10 +95,13 @@ class CompressionFacade:
 
 
 class CompressionMiddleware(AbstractMiddleware):
-    def __init__(self, app: "ASGIApp", config: "CompressionConfig") -> None:
-        """Compression Middleware Wrapper.
+    """Compression Middleware Wrapper.
 
-        This is a wrapper allowing for generic compression configuration / handler middleware
+    This is a wrapper allowing for generic compression configuration / handler middleware
+    """
+
+    def __init__(self, app: "ASGIApp", config: "CompressionConfig") -> None:
+        """Initialize `CompressionMiddleware`
 
         Args:
             app: The 'next' ASGI app to call.
@@ -107,6 +113,16 @@ class CompressionMiddleware(AbstractMiddleware):
         self.config = config
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+        """The middleware's ASGI callable.
+
+        Args:
+            scope: The ASGI connection scope.
+            receive: The ASGI receive function.
+            send: The ASGI send function.
+
+        Returns:
+            None
+        """
         accept_encoding = Headers.from_scope(scope).get("accept-encoding", "")
 
         if CompressionEncoding.BROTLI in accept_encoding and self.config.backend == "brotli":

--- a/starlite/middleware/csrf.py
+++ b/starlite/middleware/csrf.py
@@ -33,16 +33,16 @@ CSRF_SECRET_LENGTH = CSRF_SECRET_BYTES * 2
 
 
 class CSRFMiddleware(MiddlewareProtocol):
+    """CSRF Middleware class.
+
+    This Middleware protects against attacks by setting a CSRF cookie
+    with a token and verifying it in request headers.
+    """
+
     scopes: "Scopes" = {ScopeType.HTTP}
 
-    def __init__(
-        self,
-        app: "ASGIApp",
-        config: "CSRFConfig",
-    ) -> None:
-        """CSRF Middleware class.
-
-        This Middleware protects against attacks by setting a CSRF cookie with a token and verifying it in request headers.
+    def __init__(self, app: "ASGIApp", config: "CSRFConfig") -> None:
+        """Initialize `CSRFMiddleware`.
 
         Args:
             app: The 'next' ASGI app to call.

--- a/starlite/middleware/csrf.py
+++ b/starlite/middleware/csrf.py
@@ -53,7 +53,8 @@ class CSRFMiddleware(MiddlewareProtocol):
         self.exclude = build_exclude_path_pattern(exclude=config.exclude)
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
-        """
+        """The middleware's ASGI callable.
+
         Args:
             scope: The ASGI connection scope.
             receive: The ASGI receive function.
@@ -93,7 +94,7 @@ class CSRFMiddleware(MiddlewareProtocol):
             raise PermissionDeniedException("CSRF token verification failed")
 
     def create_send_wrapper(self, send: "Send", token: str, csrf_cookie: Optional[str]) -> "Send":
-        """Wraps 'send' to handle CSRF validation.
+        """Wrap 'send' to handle CSRF validation.
 
         Args:
             token: The CSRF token.
@@ -147,7 +148,7 @@ class CSRFMiddleware(MiddlewareProtocol):
         return token_secret
 
     def _csrf_tokens_match(self, request_csrf_token: Optional[str], cookie_csrf_token: Optional[str]) -> bool:
-        """Takes the CSRF tokens from the request and the cookie and verifies
+        """Take the CSRF tokens from the request and the cookie and verify
         both are valid and identical.
         """
         if not (request_csrf_token and cookie_csrf_token):

--- a/starlite/middleware/csrf.py
+++ b/starlite/middleware/csrf.py
@@ -148,8 +148,8 @@ class CSRFMiddleware(MiddlewareProtocol):
         return token_secret
 
     def _csrf_tokens_match(self, request_csrf_token: Optional[str], cookie_csrf_token: Optional[str]) -> bool:
-        """Take the CSRF tokens from the request and the cookie and verify
-        both are valid and identical.
+        """Take the CSRF tokens from the request and the cookie and verify both
+        are valid and identical.
         """
         if not (request_csrf_token and cookie_csrf_token):
             return False

--- a/starlite/middleware/exceptions/middleware.py
+++ b/starlite/middleware/exceptions/middleware.py
@@ -15,12 +15,15 @@ if TYPE_CHECKING:
 
 
 class ExceptionHandlerMiddleware:
-    def __init__(self, app: "ASGIApp", debug: bool, exception_handlers: "ExceptionHandlersMap") -> None:
-        """This middleware is used to wrap an ASGIApp inside a try catch block
-        and handles any exceptions raised.
+    """This middleware is used to wrap an ASGIApp inside a try catch block and
+    handles any exceptions raised.
 
-        Notes:
-            * It's used in multiple layers of Starlite.
+    Notes:
+        * It's used in multiple layers of Starlite.
+    """
+
+    def __init__(self, app: "ASGIApp", debug: bool, exception_handlers: "ExceptionHandlersMap") -> None:
+        """Initialize `ExceptionHandlerMiddleware`.
 
         Args:
             app: The 'next' ASGI app to call.
@@ -32,7 +35,8 @@ class ExceptionHandlerMiddleware:
         self.debug = debug
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
-        """
+        """The middleware's ASGI-callable.
+
         Args:
             scope: The ASGI connection scope.
             receive: The ASGI receive function.

--- a/starlite/middleware/logging.py
+++ b/starlite/middleware/logging.py
@@ -99,7 +99,6 @@ class LoggingMiddleware(AbstractMiddleware):
 
         Returns:
             None
-
         """
         extracted_data = await self.extract_request_data(request=scope["app"].request_class(scope))
         self.log_message(values=extracted_data)
@@ -124,7 +123,6 @@ class LoggingMiddleware(AbstractMiddleware):
 
         Returns:
             None
-
         """
         message = values.pop("message")
         if self.is_struct_logger:

--- a/starlite/middleware/logging.py
+++ b/starlite/middleware/logging.py
@@ -28,7 +28,7 @@ except ImportError:
 
 
 class LoggingMiddleware(AbstractMiddleware):
-    """Logging middleware"""
+    """Logging middleware."""
 
     __slots__ = ("config", "logger", "request_extractor", "response_extractor", "is_struct_logger")
 

--- a/starlite/middleware/logging.py
+++ b/starlite/middleware/logging.py
@@ -28,12 +28,14 @@ except ImportError:
 
 
 class LoggingMiddleware(AbstractMiddleware):
+    """Logging middleware"""
+
     __slots__ = ("config", "logger", "request_extractor", "response_extractor", "is_struct_logger")
 
     logger: "Logger"
 
     def __init__(self, app: "ASGIApp", config: "LoggingMiddlewareConfig") -> None:
-        """LoggingMiddleware.
+        """Initialize `LoggingMiddleware`.
 
         Args:
             app: The 'next' ASGI app to call.
@@ -70,7 +72,8 @@ class LoggingMiddleware(AbstractMiddleware):
         )
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
-        """
+        """The middleware's ASGI callable.
+
         Args:
             scope: The ASGI connection scope.
             receive: The ASGI receive function.
@@ -89,8 +92,8 @@ class LoggingMiddleware(AbstractMiddleware):
         await self.app(scope, receive, send)
 
     async def log_request(self, scope: "Scope") -> None:
-        """
-        Handles extracting the request data and logging the message.
+        """Extract request data and log the message.
+
         Args:
             scope: The ASGI connection scope.
 
@@ -114,7 +117,7 @@ class LoggingMiddleware(AbstractMiddleware):
         self.log_message(values=extracted_data)
 
     def log_message(self, values: Dict[str, Any]) -> None:
-        """
+        """Log a message.
 
         Args:
             values: Extract values to log.
@@ -131,12 +134,13 @@ class LoggingMiddleware(AbstractMiddleware):
             self.logger.info(f"{message}: " + ", ".join([f"{key}={value}" for key, value in values.items()]))
 
     async def extract_request_data(self, request: "Request") -> Dict[str, Any]:
-        """Creates a dictionary of values for the message.
+        """Create a dictionary of values for the message.
 
         Args:
             request: A [Request][starlite.connection.Request] instance.
+
         Returns:
-            An OrderedDict.
+            An dict.
         """
 
         data: Dict[str, Any] = {"message": self.config.request_log_message}
@@ -154,13 +158,13 @@ class LoggingMiddleware(AbstractMiddleware):
         return data
 
     def extract_response_data(self, scope: "Scope") -> Dict[str, Any]:
-        """
-        Extracts data from the response.
+        """Extract data from the response.
+
         Args:
             scope: The ASGI connection scope.
 
         Returns:
-            An OrderedDict.
+            An dict.
         """
         data: Dict[str, Any] = {"message": self.config.response_log_message}
         serializer = get_serializer_from_scope(scope) or default_serializer
@@ -203,6 +207,8 @@ class LoggingMiddleware(AbstractMiddleware):
 
 
 class LoggingMiddlewareConfig(BaseModel):
+    """Configuration for `LoggingMiddleware`"""
+
     exclude: Optional[Union[str, List[str]]] = None
     """
     List of paths to exclude from logging.
@@ -283,7 +289,6 @@ class LoggingMiddlewareConfig(BaseModel):
         of the application layers.
 
         Examples:
-
             ```python
             from starlite import Starlite, Request, LoggingConfig, get
             from starlite.middleware.logging import LoggingMiddlewareConfig

--- a/starlite/middleware/rate_limit.py
+++ b/starlite/middleware/rate_limit.py
@@ -47,7 +47,7 @@ class CacheObject:
 
 
 class RateLimitMiddleware(AbstractMiddleware):
-    """Rate-limiting middleware"""
+    """Rate-limiting middleware."""
 
     __slots__ = (
         "app",

--- a/starlite/middleware/rate_limit.py
+++ b/starlite/middleware/rate_limit.py
@@ -38,7 +38,7 @@ DURATION_VALUES: Dict[DurationUnit, int] = {"second": 1, "minute": 60, "hour": 3
 
 @dataclass
 class CacheObject:
-    """Representation of a cached object's metadata"""
+    """Representation of a cached object's metadata."""
 
     __slots__ = ("history", "reset")
 
@@ -121,7 +121,7 @@ class RateLimitMiddleware(AbstractMiddleware):
         """
 
         async def send_wrapper(message: "Message") -> None:
-            """Wrapped ASGI `Send` callable
+            """Wrapped ASGI `Send` callable.
 
             Args:
                 message: An ASGI 'Message'
@@ -188,7 +188,8 @@ class RateLimitMiddleware(AbstractMiddleware):
         await self.cache.set(key, dumps(cache_object), expiration=DURATION_VALUES[self.unit])
 
     async def should_check_request(self, request: "Request[Any, Any]") -> bool:
-        """Return a boolean indicating if a request should be checked for rate limiting
+        """Return a boolean indicating if a request should be checked for rate
+        limiting.
 
         Args:
             request: A [Request][starlite.connection.Request] instance.

--- a/starlite/middleware/rate_limit.py
+++ b/starlite/middleware/rate_limit.py
@@ -38,6 +38,8 @@ DURATION_VALUES: Dict[DurationUnit, int] = {"second": 1, "minute": 60, "hour": 3
 
 @dataclass
 class CacheObject:
+    """Representation of a cached object's metadata"""
+
     __slots__ = ("history", "reset")
 
     history: List[int]
@@ -45,6 +47,8 @@ class CacheObject:
 
 
 class RateLimitMiddleware(AbstractMiddleware):
+    """Rate-limiting middleware"""
+
     __slots__ = (
         "app",
         "cache",
@@ -58,7 +62,7 @@ class RateLimitMiddleware(AbstractMiddleware):
     cache: "Cache"
 
     def __init__(self, app: "ASGIApp", config: "RateLimitConfig") -> None:
-        """
+        """Initialize `RateLimitMiddleware`.
 
         Args:
             app: The 'next' ASGI app to call.
@@ -75,7 +79,8 @@ class RateLimitMiddleware(AbstractMiddleware):
         self.unit: DurationUnit = config.rate_limit[0]
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
-        """
+        """The middleware's ASGI callable.
+
         Args:
             scope: The ASGI connection scope.
             receive: The ASGI receive function.
@@ -116,7 +121,7 @@ class RateLimitMiddleware(AbstractMiddleware):
         """
 
         async def send_wrapper(message: "Message") -> None:
-            """
+            """Wrapped ASGI `Send` callable
 
             Args:
                 message: An ASGI 'Message'
@@ -134,7 +139,7 @@ class RateLimitMiddleware(AbstractMiddleware):
         return send_wrapper
 
     def cache_key_from_request(self, request: "Request[Any, Any]") -> str:
-        """
+        """Get a cache-key from a `Request`
 
         Args:
             request: A [Request][starlite.connection.Request] instance.
@@ -183,7 +188,7 @@ class RateLimitMiddleware(AbstractMiddleware):
         await self.cache.set(key, dumps(cache_object), expiration=DURATION_VALUES[self.unit])
 
     async def should_check_request(self, request: "Request[Any, Any]") -> bool:
-        """
+        """Return a boolean indicating if a request should be checked for rate limiting
 
         Args:
             request: A [Request][starlite.connection.Request] instance.
@@ -220,6 +225,8 @@ class RateLimitMiddleware(AbstractMiddleware):
 
 
 class RateLimitConfig(BaseModel):
+    """Configuration for `RateLimitMiddleware`"""
+
     rate_limit: Tuple[DurationUnit, int]
     """A tuple containing a time unit (second, minute, hour, day) and quantity, e.g. ("day", 1) or ("minute", 5)."""
     exclude: Optional[Union[str, List[str]]] = None
@@ -247,7 +254,7 @@ class RateLimitConfig(BaseModel):
 
     @validator("check_throttle_handler")
     def validate_check_throttle_handler(cls, value: Callable) -> Callable:  # pylint: disable=no-self-argument
-        """
+        """Wrap `check_throttle_handler` in an `AsyncCallable`
 
         Args:
             value: A callable.
@@ -263,7 +270,6 @@ class RateLimitConfig(BaseModel):
         of the application layers.
 
         Examples:
-
             ```python
             from starlite import Starlite, Request, get
             from starlite.middleware import RateLimitConfig

--- a/starlite/middleware/session/cookie_backend.py
+++ b/starlite/middleware/session/cookie_backend.py
@@ -32,10 +32,12 @@ AAD = b"additional_authenticated_data="
 
 
 class CookieBackend(BaseSessionBackend["CookieBackendConfig"]):
+    """Cookie backend for SessionMiddleware."""
+
     __slots__ = ("aesgcm", "cookie_re")
 
     def __init__(self, config: "CookieBackendConfig") -> None:
-        """Starlite CookieSessionMiddleware.
+        """Initialize `CookieBackend`.
 
         Args:
             config: SessionCookieConfig instance.

--- a/starlite/middleware/session/file_backend.py
+++ b/starlite/middleware/session/file_backend.py
@@ -9,15 +9,23 @@ from starlite.middleware.session.base import ServerSideBackend, ServerSideSessio
 
 
 class FileStorageMetadataWrapper(NamedTuple):
+    """Metadata of a session file."""
+
     expires: str
     data: str
 
 
 class FileBackend(ServerSideBackend["FileBackendConfig"]):
+    """Session backend to store data in files."""
+
     __slots__ = ("path",)
 
     def __init__(self, config: "FileBackendConfig") -> None:
-        """Session backend to store data in files."""
+        """Initialize `FileBackend`
+
+        Args:
+            config: A `FileBackendConfig`
+        """
         super().__init__(config=config)
         self.path = Path(config.storage_path)
 
@@ -108,6 +116,8 @@ class FileBackend(ServerSideBackend["FileBackendConfig"]):
 
 
 class FileBackendConfig(ServerSideSessionConfig):
+    """Backend configuration for `FileBackend`"""
+
     _backend_class: Type[FileBackend] = FileBackend
     storage_path: PathLike
     """Disk path under which to store session files."""

--- a/starlite/middleware/session/memcached_backend.py
+++ b/starlite/middleware/session/memcached_backend.py
@@ -6,10 +6,15 @@ from starlite.middleware.session.base import ServerSideBackend, ServerSideSessio
 
 
 class MemcachedBackend(ServerSideBackend["MemcachedBackendConfig"]):
+    """Session backend to store data in memcached."""
+
     __slots__ = ("memcached",)
 
     def __init__(self, config: "MemcachedBackendConfig") -> None:
-        """Session backend to store data in memcached.
+        """Initialize `MemcachedBackend`
+
+        Args:
+            config: A `MemcachedBackendConfig` instance
 
         Notes:
             - Requires `aiomcache`. Install with `pip install starlite[memcached]`
@@ -84,6 +89,8 @@ class MemcachedBackend(ServerSideBackend["MemcachedBackendConfig"]):
 
 
 class MemcachedBackendConfig(ServerSideSessionConfig):
+    """Configuration for `MemcachedBackend`"""
+
     _backend_class: Type[MemcachedBackend] = MemcachedBackend
     memcached: MemcacheClient
     """An `aiomcache.Client` instance"""

--- a/starlite/middleware/session/memory_backend.py
+++ b/starlite/middleware/session/memory_backend.py
@@ -5,11 +5,16 @@ from starlite.middleware.session.base import ServerSideBackend, ServerSideSessio
 
 
 class MemoryBackend(ServerSideBackend["MemoryBackendConfig"]):
+    """Session backend to store data in memory."""
+
     __slots__ = ()
     _cache = SimpleCacheBackend()
 
     def __init__(self, config: "MemoryBackendConfig") -> None:
-        """Session backend to store data in memory.
+        """Initialize `MemoryBackend`.
+
+        Args:
+            config: An instance of `MemoryBackendConfig`
 
         Warning:
             This should not be used in production and serves mainly as a dummy backend
@@ -66,4 +71,6 @@ class MemoryBackend(ServerSideBackend["MemoryBackendConfig"]):
 
 
 class MemoryBackendConfig(ServerSideSessionConfig):
+    """Configuration for `MemoryBackend`"""
+
     _backend_class: Type[MemoryBackend] = MemoryBackend

--- a/starlite/middleware/session/redis_backend.py
+++ b/starlite/middleware/session/redis_backend.py
@@ -6,10 +6,12 @@ from starlite.middleware.session.base import ServerSideBackend, ServerSideSessio
 
 
 class RedisBackend(ServerSideBackend["RedisBackendConfig"]):
+    """Session backend to store data in redis."""
+
     __slots__ = ("redis",)
 
     def __init__(self, config: "RedisBackendConfig") -> None:
-        """Session backend to store data in redis.
+        """Initialize `RedisBackend`.
 
         Notes:
             - Requires `redis`. Install with `pip install starlite[redis]`
@@ -74,6 +76,8 @@ class RedisBackend(ServerSideBackend["RedisBackendConfig"]):
 
 
 class RedisBackendConfig(ServerSideSessionConfig):
+    """Configuration for `RedisBackend`"""
+
     _backend_class: Type[RedisBackend] = RedisBackend
     redis: Redis
     """`redis.asyncio.Redis` instance"""

--- a/starlite/middleware/session/sqlalchemy_backend.py
+++ b/starlite/middleware/session/sqlalchemy_backend.py
@@ -87,15 +87,21 @@ def register_session_model(base: Union[registry, Any], model: Type[SessionModelT
 
 
 class BaseSQLAlchemyBackend(Generic[AnySASessionT], ServerSideBackend["SQLAlchemyBackendConfig"], ABC):
+    """Session backend to store data in a database with SQLAlchemy. Works with
+    both sync and async engines.
+
+    Notes:
+        - Requires `sqlalchemy` which needs to be installed separately, and a configured
+        [SQLAlchemyPlugin][starlite.plugins.sql_alchemy.SQLAlchemyPlugin].
+    """
+
     __slots__ = ("_model", "_session_maker")
 
     def __init__(self, config: "SQLAlchemyBackendConfig") -> None:
-        """Session backend to store data in a database with SQLAlchemy. Works
-        with both sync and async engines.
+        """Initialize `BaseSQLAlchemyBackend`.
 
-        Notes:
-            - Requires `sqlalchemy` which needs to be installed separately, and a configured
-            [SQLAlchemyPlugin][starlite.plugins.sql_alchemy.SQLAlchemyPlugin].
+        Args:
+            config: An instance of `SQLAlchemyBackendConfig`
         """
         super().__init__(config=config)
         self._model = config.model
@@ -116,6 +122,8 @@ class BaseSQLAlchemyBackend(Generic[AnySASessionT], ServerSideBackend["SQLAlchem
 
 
 class AsyncSQLAlchemyBackend(BaseSQLAlchemyBackend[AsyncSASession]):
+    """Asynchronous SQLAlchemy backend."""
+
     async def _get_session_obj(self, *, sa_session: AsyncSASession, session_id: str) -> Optional[SessionModelMixin]:
         result = await sa_session.scalars(self._select_session_obj(session_id))
         return result.one_or_none()
@@ -198,6 +206,8 @@ class AsyncSQLAlchemyBackend(BaseSQLAlchemyBackend[AsyncSASession]):
 
 
 class SQLAlchemyBackend(BaseSQLAlchemyBackend[SASession]):
+    """Synchronous SQLAlchemy backend."""
+
     def _get_session_obj(self, *, sa_session: SASession, session_id: str) -> Optional[SessionModelMixin]:
         return sa_session.scalars(self._select_session_obj(session_id)).one_or_none()
 
@@ -296,6 +306,8 @@ class SQLAlchemyBackend(BaseSQLAlchemyBackend[SASession]):
 
 
 class SQLAlchemyBackendConfig(ServerSideSessionConfig):
+    """Configuration for `SQLAlchemyBackend` and `AsyncSQLAlchemyBackend`"""
+
     model: Type[SessionModelMixin]
     plugin: SQLAlchemyPlugin
 

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -134,15 +134,17 @@ class OpenAPIController(Controller):
 
     @property
     def favicon(self) -> str:
-        """
+        """A favicon `<link>` tag, if applicable.
+
         Returns:
-            A link tag if self.favicon_url is not empty, otherwise returns a placeholder meta tag.
+            A `<link>` tag if self.favicon_url is not empty, otherwise returns a placeholder meta tag.
         """
         return f"<link rel='icon' type='image/x-icon' href='{self.favicon_url}'>" if self.favicon_url else "<meta/>"
 
     @property
     def render_methods_map(self) -> Dict["Literal['redoc', 'swagger', 'elements']", Callable[[Request], str]]:
-        """
+        """Map render method names to render methods.
+
         Returns:
             A mapping of string keys to render methods.
         """
@@ -158,7 +160,7 @@ class OpenAPIController(Controller):
         include_in_schema=False,
     )
     def retrieve_schema_yaml(self, request: Request) -> Response:
-        """Returns the OpenAPI schema as YAML with an
+        """Return the OpenAPI schema as YAML with an
         'application/vnd.oai.openapi' Content-Type header.
 
         Args:
@@ -177,7 +179,7 @@ class OpenAPIController(Controller):
 
     @get(path="/openapi.json", media_type=OpenAPIMediaType.OPENAPI_JSON, include_in_schema=False)
     def retrieve_schema_json(self, request: Request) -> Response:
-        """Returns the OpenAPI schema as JSON with an
+        """Return the OpenAPI schema as JSON with an
         'application/vnd.oai.openapi+json' Content-Type header.
 
         Args:

--- a/starlite/openapi/enums.py
+++ b/starlite/openapi/enums.py
@@ -30,6 +30,8 @@ class OpenAPIFormat(str, Enum):
 
 
 class OpenAPIType(str, Enum):
+    """An OopenAPI type."""
+
     ARRAY = "array"
     BOOLEAN = "boolean"
     INTEGER = "integer"

--- a/starlite/openapi/parameters.py
+++ b/starlite/openapi/parameters.py
@@ -44,6 +44,11 @@ class ParameterCollection:
     """
 
     def __init__(self, route_handler: "BaseRouteHandler") -> None:
+        """Initialize `ParameterCollection`.
+
+        Args:
+            route_handler: Associated route handler
+        """
         self.route_handler = route_handler
         self._parameters: Dict[str, Parameter] = {}
 

--- a/starlite/openapi/responses.py
+++ b/starlite/openapi/responses.py
@@ -34,8 +34,8 @@ if TYPE_CHECKING:
 
 
 def create_cookie_schema(cookie: "Cookie") -> Schema:
-    """
-    Given a Cookie instance, return its corresponding OpenAPI schema
+    """Given a Cookie instance, return its corresponding OpenAPI schema.
+
     Args:
         cookie: Cookie
 

--- a/starlite/openapi/schema.py
+++ b/starlite/openapi/schema.py
@@ -229,9 +229,7 @@ def create_examples_for_field(field: ModelField) -> List[Example]:
 def create_schema(
     field: ModelField, generate_examples: bool, plugins: List["PluginProtocol"], ignore_optional: bool = False
 ) -> Schema:
-    """
-    Create a Schema model for a given ModelField and if needed - recursively traverse its sub_fields as well.
-    """
+    """Create a Schema model for a given ModelField and if needed - recursively traverse its sub_fields as well."""
 
     if is_optional(field) and not ignore_optional:
         non_optional_schema = create_schema(

--- a/starlite/params.py
+++ b/starlite/params.py
@@ -35,7 +35,7 @@ def Parameter(
     max_length: Optional[int] = None,
     regex: Optional[str] = None
 ) -> Any:
-    """Creates a pydantic `FieldInfo` instance with an extra kwargs, used for
+    """Create a pydantic `FieldInfo` instance with an extra kwargs, used for
     both parameter parsing and OpenAPI schema generation.
 
     Args:
@@ -129,7 +129,7 @@ def Body(
     max_length: Optional[int] = None,
     regex: Optional[str] = None
 ) -> Any:
-    """Creates a pydantic `FieldInfo` instance with an extra kwargs, used for
+    """Create a pydantic `FieldInfo` instance with an extra kwargs, used for
     both parameter parsing and OpenAPI schema generation.
 
     Args:
@@ -194,7 +194,7 @@ def Body(
 
 @validate_arguments(config={"arbitrary_types_allowed": True})
 def Dependency(*, default: Any = Undefined, skip_validation: bool = False) -> Any:
-    """Creates a pydantic `FieldInfo` instance with an extra kwargs, used for
+    """Create a pydantic `FieldInfo` instance with an extra kwargs, used for
     both parameter parsing and OpenAPI schema generation.
 
     Args:

--- a/starlite/parsers.py
+++ b/starlite/parsers.py
@@ -21,7 +21,7 @@ _false_values = {"False", "false"}
 
 
 def parse_form_data(media_type: "RequestEncodingType", form_data: "FormMultiDict", field: "ModelField") -> Any:
-    """Transforms the multidict into a regular dict, try to load json on all
+    """Transform the multidict into a regular dict, try to load json on all
     non-file values.
 
     Supports lists.
@@ -47,7 +47,7 @@ def parse_form_data(media_type: "RequestEncodingType", form_data: "FormMultiDict
 
 
 def parse_cookie_string(cookie_string: str) -> Dict[str, str]:
-    """Parses a cookie string into a dictionary of values.
+    """Parse a cookie string into a dictionary of values.
 
     Args:
         cookie_string: A cookie string.

--- a/starlite/parsers.py
+++ b/starlite/parsers.py
@@ -47,8 +47,8 @@ def parse_form_data(media_type: "RequestEncodingType", form_data: "FormMultiDict
 
 
 def parse_cookie_string(cookie_string: str) -> Dict[str, str]:
-    """
-    Parses a cookie string into a dictionary of values.
+    """Parses a cookie string into a dictionary of values.
+
     Args:
         cookie_string: A cookie string.
 

--- a/starlite/plugins/base.py
+++ b/starlite/plugins/base.py
@@ -24,6 +24,8 @@ ModelT = TypeVar("ModelT")
 
 @runtime_checkable
 class PluginProtocol(Protocol[ModelT]):  # pragma: no cover
+    """Base plugin protocol to be inherited when implementing plugins."""
+
     __slots__ = ()
 
     def on_app_init(self, app: "Starlite") -> None:
@@ -165,6 +167,8 @@ def get_plugin_for_value(value: Any, plugins: List[PluginProtocol]) -> Optional[
 
 
 class PluginMapping(NamedTuple):
+    """Named tuple, mapping plugins > models."""
+
     plugin: PluginProtocol
     model_class: Any
 

--- a/starlite/plugins/sql_alchemy/config.py
+++ b/starlite/plugins/sql_alchemy/config.py
@@ -65,15 +65,15 @@ def serializer(value: Any) -> str:
 
 
 async def default_before_send_handler(message: "Message", _: "State", scope: "Scope") -> None:
-    """
-    Handles closing and cleaning up sessions before sending.
+    """Handle closing and cleaning up sessions before sending.
+
     Args:
-        message:
-        _:
-        scope:
+        message: ASGI-`Message`
+        _: A `State` (not used)
+        scope: An ASGI-`Scope`
 
     Returns:
-
+        None
     """
     session = cast("Optional[Union[Session, AsyncSession]]", scope.get(SESSION_SCOPE_KEY))
     if session and message["type"] in SESSION_TERMINUS_ASGI_EVENTS:
@@ -85,6 +85,8 @@ async def default_before_send_handler(message: "Message", _: "State", scope: "Sc
 
 
 class SQLAlchemySessionConfig(BaseModel):
+    """Configuration for a SQLAlchemy-Session."""
+
     class Config(BaseConfig):
         arbitrary_types_allowed = True
 
@@ -228,13 +230,13 @@ class SQLAlchemyConfig(BaseModel):
     def validate_before_send_handler(  # pylint: disable=no-self-argument
         cls, value: BeforeMessageSendHookHandler
     ) -> Any:
-        """
+        """Wrap `before_send_handler` in an `AsyncCallable`
 
         Args:
             value: A before send handler callable.
 
         Returns:
-            The handler wrapped in AsyncCallable.
+            An `AsyncCallable`
         """
         return AsyncCallable(value)  # type: ignore[arg-type]
 
@@ -264,7 +266,7 @@ class SQLAlchemyConfig(BaseModel):
 
     @property
     def engine_config_dict(self) -> Dict[str, Any]:
-        """
+        """Return the engine configuration as a dict.
 
         Returns:
             A string keyed dict of config kwargs for the SQLAlchemy 'create_engine' function.
@@ -278,7 +280,7 @@ class SQLAlchemyConfig(BaseModel):
 
     @property
     def engine(self) -> Union["Engine", "FutureEngine", "AsyncEngine"]:
-        """
+        """Return an engine. If none exists yet, create one.
 
         Returns:
             Getter that returns the engine instance used by the plugin.
@@ -294,7 +296,7 @@ class SQLAlchemyConfig(BaseModel):
 
     @property
     def session_maker(self) -> sessionmaker:
-        """
+        """Get a sessionmaker. If none exists yet, create one.
 
         Returns:
             Getter that returns the session_maker instance used by the plugin.
@@ -310,7 +312,7 @@ class SQLAlchemyConfig(BaseModel):
         return cast("sessionmaker", self.session_maker_instance)
 
     def create_db_session_dependency(self, state: "State", scope: "Scope") -> Union[Session, AsyncSession]:
-        """
+        """Create a session instance.
 
         Args:
             state: The 'application.state' instance.

--- a/starlite/plugins/sql_alchemy/plugin.py
+++ b/starlite/plugins/sql_alchemy/plugin.py
@@ -46,10 +46,12 @@ if TYPE_CHECKING:
 
 
 class SQLAlchemyPlugin(PluginProtocol[DeclarativeMeta]):
+    """A Plugin for SQLAlchemy."""
+
     __slots__ = ("_model_namespace_map", "_config")
 
     def __init__(self, config: Optional["SQLAlchemyConfig"] = None) -> None:
-        """A Plugin for SQLAlchemy.
+        """Initialize `SQLAlchemyPlugin`.
 
         Support (de)serialization and OpenAPI generation for SQLAlchemy
         ORM types.

--- a/starlite/plugins/sql_alchemy/types.py
+++ b/starlite/plugins/sql_alchemy/types.py
@@ -14,6 +14,8 @@ SQLAlchemyBinaryType = Union["BINARY", "VARBINARY", "LargeBinary"]
 
 @runtime_checkable
 class SessionMakerTypeProtocol(Protocol):
+    """Protocol for a sessionmaker."""
+
     def __init__(
         self,
         bind: "Optional[Union[AsyncEngine, Engine, Connection]]",
@@ -23,13 +25,18 @@ class SessionMakerTypeProtocol(Protocol):
         info: Dict[Any, Any],
         **kwargs: Any,
     ) -> None:
+        """Initialize the sessionmaker."""
         ...
 
     def __call__(self) -> "Union[Session, AsyncSession]":
+        """Return a session instance."""
         ...
 
 
 @runtime_checkable
 class SessionMakerInstanceProtocol(Protocol):
+    """Protocol for a sessionmaker instance."""
+
     def __call__(self) -> "Union[Session, AsyncSession]":
+        """Return a session instance."""
         ...

--- a/starlite/response/base.py
+++ b/starlite/response/base.py
@@ -43,6 +43,10 @@ T = TypeVar("T")
 
 
 class Response(Generic[T]):
+    """Base Starlite HTTP response class, used as the basis for all other
+    response classes.
+    """
+
     __slots__ = (
         "status_code",
         "media_type",
@@ -67,8 +71,7 @@ class Response(Generic[T]):
         encoding: str = "utf-8",
         is_head_response: bool = False,
     ) -> None:
-        """This is the base Starlite HTTP response class, used as the basis for
-        all other response classes.
+        """Initialize the response.
 
         Args:
             content: A value for the response body that will be rendered into bytes string.
@@ -193,8 +196,8 @@ class Response(Generic[T]):
         return default_serializer(value)
 
     def render(self, content: Any) -> bytes:
-        """
-        Handles the rendering of content T into a bytes string.
+        """Handle the rendering of content T into a bytes string.
+
         Args:
             content: A value for the response body that will be rendered into bytes string.
 
@@ -229,7 +232,7 @@ class Response(Generic[T]):
 
     @property
     def content_length(self) -> Optional[int]:
-        """
+        """Content length of the response if applicable.
 
         Returns:
             The content length of the body (e.g. for use in a "Content-Length" header).
@@ -241,7 +244,8 @@ class Response(Generic[T]):
 
     @property
     def encoded_headers(self) -> List[Tuple[bytes, bytes]]:
-        """
+        """Encoded response headers as a list of tuples of bytes.
+
         Notes:
             - A 'Content-Length' header will be added if appropriate and not provided by the user.
 
@@ -274,8 +278,9 @@ class Response(Generic[T]):
             await self.background()
 
     async def start_response(self, send: "Send") -> None:
-        """
-        Emits the start event of the response. This event includes the headers and status codes.
+        """Emit the start event of the response. This event includes the
+        headers and status codes.
+
         Args:
             send: The ASGI send function.
 
@@ -291,7 +296,7 @@ class Response(Generic[T]):
         await send(event)
 
     async def send_body(self, send: "Send", receive: "Receive") -> None:  # pylint: disable=unused-argument
-        """Emits the response body.
+        """Emit the response body.
 
         Args:
             send: The ASGI send function.

--- a/starlite/response/file.py
+++ b/starlite/response/file.py
@@ -37,8 +37,8 @@ ONE_MEGA_BYTE: int = 1024 * 1024
 async def async_file_iterator(
     file_path: "PathType", chunk_size: int, adapter: "FileSystemAdapter"
 ) -> AsyncGenerator[bytes, None]:
-    """
-    A generator function that asynchronously reads a file and yields its chunks.
+    """Return an async that asynchronously reads a file and yields its chunks.
+
     Args:
         file_path: A path to a file.
         chunk_size: The chunk file to use.
@@ -66,6 +66,8 @@ def create_etag_for_file(path: "PathType", modified_time: float, file_size: int)
 
 
 class FileResponse(StreamingResponse):
+    """A response, streaming a file as response body."""
+
     __slots__ = (
         "chunk_size",
         "content_disposition_type",
@@ -154,7 +156,7 @@ class FileResponse(StreamingResponse):
 
     @property
     def content_disposition(self) -> str:
-        """
+        """Content disposition.
 
         Returns:
             A value for the 'Content-Disposition' header.
@@ -167,7 +169,7 @@ class FileResponse(StreamingResponse):
 
     @property
     def content_length(self) -> Optional[int]:
-        """
+        """Content length of the response if applicable.
 
         Returns:
             Returns the value of 'self.stat_result.st_size' to populate the 'Content-Length' header.
@@ -177,6 +179,15 @@ class FileResponse(StreamingResponse):
         return 0
 
     async def start_response(self, send: "Send") -> None:
+        """Emit the start event of the response. This event includes the
+        headers and status codes.
+
+        Args:
+            send: The ASGI send function.
+
+        Returns:
+            None
+        """
         try:
             fs_info = self.file_info = cast(
                 "FileInfo", (await self.file_info if iscoroutine(self.file_info) else self.file_info)

--- a/starlite/response/redirect.py
+++ b/starlite/response/redirect.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 
 
 class RedirectResponse(Response[Any]):
+    """A redirect response."""
+
     def __init__(
         self,
         url: str,
@@ -25,7 +27,7 @@ class RedirectResponse(Response[Any]):
         cookies: Optional["ResponseCookies"] = None,
         encoding: str = "utf-8",
     ) -> None:
-        """This class is used to send redirect responses.
+        """Initialize the response.
 
         Args:
             url: A url to redirect to.
@@ -34,6 +36,7 @@ class RedirectResponse(Response[Any]):
             headers: A string keyed dictionary of response headers. Header keys are insensitive.
             cookies: A list of [Cookie][starlite.datastructures.Cookie] instances to be set under the response 'Set-Cookie' header.
             encoding: The encoding to be used for the response headers.
+
         Raises:
             [ImproperlyConfiguredException][starlite.exceptions.ImproperlyConfiguredException]: If status code is not a redirect status code.
         """

--- a/starlite/response/streaming.py
+++ b/starlite/response/streaming.py
@@ -25,6 +25,10 @@ if TYPE_CHECKING:
 
 
 class StreamingResponse(Response[StreamType[Union[str, bytes]]]):
+    """An HTTP response that streams the response data as a series of ASGI
+    'http.response.body' events.
+    """
+
     __slots__ = ("iterator",)
 
     def __init__(
@@ -39,8 +43,7 @@ class StreamingResponse(Response[StreamType[Union[str, bytes]]]):
         encoding: str = "utf-8",
         is_head_response: bool = False,
     ):
-        """This class is an HTTP response that streams the response data as a
-        series of ASGI 'http.response.body' events.
+        """Initialize the response.
 
         Args:
             content: A sync or async iterator or iterable.
@@ -69,8 +72,7 @@ class StreamingResponse(Response[StreamType[Union[str, bytes]]]):
         )
 
     async def _listen_for_disconnect(self, cancel_scope: "CancelScope", receive: "Receive") -> None:
-        """
-        Listens for a cancellation message, and if received - calls cancel on the cancel scope.
+        """Listens for a cancellation message, and if received - calls cancel on the cancel scope.
 
         Args:
             cancel_scope: A task group cancel scope instance.

--- a/starlite/response/template.py
+++ b/starlite/response/template.py
@@ -11,6 +11,10 @@ if TYPE_CHECKING:
 
 
 class TemplateResponse(Response[bytes]):
+    """Template-based response, rendering a given template into a bytes
+    string.
+    """
+
     def __init__(
         self,
         template_name: str,
@@ -23,7 +27,7 @@ class TemplateResponse(Response[bytes]):
         cookies: Optional["ResponseCookies"] = None,
         encoding: str = "utf-8",
     ) -> None:
-        """Handles the rendering of a given template into a bytes string.
+        """Handle the rendering of a given template into a bytes string.
 
         Args:
             template_name: Path-like name for the template to be rendered, e.g. "index.html".
@@ -35,6 +39,7 @@ class TemplateResponse(Response[bytes]):
                 Defaults to None.
             headers: A string keyed dictionary of response headers. Header keys are insensitive.
             cookies: A list of [Cookie][starlite.datastructures.Cookie] instances to be set under the response 'Set-Cookie' header.
+            encoding: Content encoding
         """
         template = template_engine.get_template(template_name)
         super().__init__(

--- a/starlite/router.py
+++ b/starlite/router.py
@@ -43,6 +43,12 @@ if TYPE_CHECKING:
 
 
 class Router:
+    """The Starlite Router class.
+
+    A Router instance is used to group controller, routers and route
+    handler functions under a shared path fragment
+    """
+
     __slots__ = (
         "after_request",
         "before_request",
@@ -88,9 +94,7 @@ class Router:
         security: Optional[List[SecurityRequirement]] = None,
         tags: Optional[List[str]] = None,
     ) -> None:
-        """The Starlite Router class.
-
-        A Router instance is used to group controller, routers and route handler functions under a shared path fragment.
+        """Initialize a `Router`.
 
         Args:
             after_request: A sync or async function executed before a [Request][starlite.connection.Request] is passed
@@ -110,7 +114,8 @@ class Router:
             exception_handlers: A dictionary that maps handler functions to status codes and/or exception types.
             guards: A list of [Guard][starlite.types.Guard] callables.
             middleware: A list of [Middleware][starlite.types.Middleware].
-            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
+            opt: A string keyed dictionary of arbitrary values that can be accessed in [Guards][starlite.types.Guard] or
+                wherever you have access to [Request][starlite.connection.request.Request] or [ASGI Scope][starlite.types.Scope].
             parameters: A mapping of [Parameter][starlite.params.Parameter] definitions available to all
                 application paths.
             path: A path fragment that is prefixed to all route handlers, controllers and other routers associated
@@ -203,7 +208,9 @@ class Router:
 
     @property
     def route_handler_method_map(self) -> Dict[str, RouteHandlerMapItem]:
-        """
+        """Map route paths to [RouteHandlerMapItem][starlite.types.internal_typ
+        es.RouteHandlerMapItem]
+
         Returns:
              A dictionary mapping paths to route handlers
         """

--- a/starlite/router.py
+++ b/starlite/router.py
@@ -229,7 +229,7 @@ class Router:
         cls,
         value: Union[Controller, BaseRouteHandler, "Router"],
     ) -> ItemsView[str, RouteHandlerMapItem]:
-        """Maps route handlers to HTTP methods."""
+        """Map route handlers to HTTP methods."""
         if isinstance(value, Router):
             return value.route_handler_method_map.items()
         if isinstance(value, BaseRouteHandler):
@@ -239,9 +239,7 @@ class Router:
 
     @staticmethod
     def _map_route_handlers_for_base_route_handler(value: BaseRouteHandler) -> ItemsView[str, RouteHandlerMapItem]:
-        """Maps route handlers to HTTP methods for an input
-        BaseRouteHandler.
-        """
+        """Map route handlers to HTTP methods for an input BaseRouteHandler."""
         value_ = copy(value)
         handlers_map: Dict[str, RouteHandlerMapItem] = {}
         for path in value_.paths:
@@ -253,7 +251,7 @@ class Router:
 
     @classmethod
     def _map_route_handlers_for_controller(cls, value: Controller) -> ItemsView[str, RouteHandlerMapItem]:
-        """Maps route handlers to HTTP methods for an input Controller."""
+        """Map route handlers to HTTP methods for an input Controller."""
         handlers_map: Dict[str, RouteHandlerMapItem] = {}
         for route_handler in value.get_route_handlers():
             for handler_path in route_handler.paths:
@@ -268,7 +266,7 @@ class Router:
     def _create_http_handler_item(
         handlers_map: Dict[str, RouteHandlerMapItem], route_handler: HTTPRouteHandler, path: str
     ) -> RouteHandlerMapItem:
-        """Creates a dict of HTTP method to route handler for a single
+        """Create a dict of HTTP method to route handler for a single
         controller path.
         """
         handler_item: Optional[RouteHandlerMapItem] = handlers_map.get(path)
@@ -281,9 +279,7 @@ class Router:
     def _validate_registration_value(
         self, value: ControllerRouterHandler
     ) -> Union[Controller, BaseRouteHandler, "Router"]:
-        """Validates that the value passed to the register method is
-        supported.
-        """
+        """Ensure values passed to the register method are supported."""
         if is_class_and_subclass(value, Controller):
             return value(owner=self)
         if not isinstance(value, (Router, BaseRouteHandler)):

--- a/starlite/routes/asgi.py
+++ b/starlite/routes/asgi.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 
 class ASGIRoute(BaseRoute):
+    """An ASGI route, handling a single `ASGIRouteHandler`"""
+
     __slots__ = ("route_handler",)
 
     def __init__(
@@ -20,7 +22,7 @@ class ASGIRoute(BaseRoute):
         path: str,
         route_handler: "ASGIRouteHandler",
     ) -> None:
-        """This class handles a single ASGI Route.
+        """Initialize the route.
 
         Args:
             path: The path for the route.

--- a/starlite/routes/base.py
+++ b/starlite/routes/base.py
@@ -6,8 +6,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
 from uuid import UUID
 
-from typing_extensions import TypedDict
-
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.kwargs import KwargsModel
 from starlite.signature import get_signature_model
@@ -35,12 +33,12 @@ param_type_map = {
 }
 
 
-class RouteHandlerIndex(TypedDict):
-    name: str
-    handler: "BaseRouteHandler"
-
-
 class BaseRoute(ABC):
+    """Base Route class used by Starlite.
+
+    It's an abstract class meant to be extended.
+    """
+
     __slots__ = (
         "app",
         "handler_names",
@@ -60,14 +58,13 @@ class BaseRoute(ABC):
         scope_type: "ScopeType",
         methods: Optional[List["Method"]] = None,
     ) -> None:
-        """This is the base Route class used by Starlite. It's an abstract
-        class meant to be extended.
+        """Initialize the route.
 
         Args:
-            handler_names:
-            path:
-            scope_type:
-            methods:
+            handler_names: Names of the associated handlers
+            path: Base path of the route
+            scope_type: Type of the ASGI scope
+            methods: Supported methods
         """
         self.path, self.path_format, self.path_components = self._parse_path(path)
         self.path_parameters: List[PathParameterDefinition] = [

--- a/starlite/routes/http.py
+++ b/starlite/routes/http.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
 
 
 class HTTPRoute(BaseRoute):
+    """An HTTP route, capable of handling multiple `HTTPRouteHandler`s."""
+
     __slots__ = (
         "route_handler_map",
         "route_handlers",
@@ -42,7 +44,7 @@ class HTTPRoute(BaseRoute):
         path: str,
         route_handlers: List["HTTPRouteHandler"],
     ) -> None:
-        """This class handles a multiple HTTP Routes.
+        """Initialize `HTTPRoute`.
 
         Args:
             path: The path for the route.

--- a/starlite/routes/websocket.py
+++ b/starlite/routes/websocket.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 
 
 class WebSocketRoute(BaseRoute):
+    """A websocket route, handling a single `WebsocketRouteHandler`"""
+
     __slots__ = (
         "route_handler",
         "handler_parameter_model",
@@ -33,7 +35,7 @@ class WebSocketRoute(BaseRoute):
         path: str,
         route_handler: "WebsocketRouteHandler",
     ) -> None:
-        """This class handles a single Websocket Route.
+        """Initialize the route.
 
         Args:
             path: The path for the route.

--- a/starlite/signature.py
+++ b/starlite/signature.py
@@ -161,11 +161,8 @@ class SignatureParameter:
 
     @property
     def default_defined(self) -> bool:
-        """`True` if `self.default` is not one of the undefined sentinel types.
-
-        Returns
-        -------
-        bool
+        """Return a boolean, indicating if `self.default` is not one of the
+        undefined sentinel types.
         """
         return self.default not in UNDEFINED_SENTINELS
 
@@ -297,9 +294,9 @@ class SignatureModelFactory:
 
     @property
     def signature_parameters(self) -> Generator[SignatureParameter, None, None]:
-        """Iterable of `SignatureModel` instances, that represent the
-        parameters of the function signature that should be included in the
-        `SignatureModel` type.
+        """Create a generator of `SignatureParameters` to be included in the
+        `SignatureModel` by iterating over the parameters of the function
+        signature.
 
         Returns:
             Generator[SignatureParameter, None, None]
@@ -321,7 +318,7 @@ class SignatureModelFactory:
         return parameter.name in SKIP_VALIDATION_NAMES or should_skip_dependency_validation(parameter.default)
 
     def create_signature_model(self) -> Type[SignatureModel]:
-        """Constructs a `SignatureModel` type that represents the signature of
+        """Construct a `SignatureModel` type that represents the signature of
         `self.fn`
 
         Returns:
@@ -357,9 +354,7 @@ class SignatureModelFactory:
 
 
 def get_signature_model(value: Any) -> Type[SignatureModel]:
-    """Helper function to retrieve and validate the signature model from a
-    provider or handler.
-    """
+    """Retrieve and validate the signature model from a provider or handler."""
     try:
         return cast("Type[SignatureModel]", value.signature_model)
     except AttributeError as e:  # pragma: no cover

--- a/starlite/signature.py
+++ b/starlite/signature.py
@@ -45,6 +45,8 @@ SKIP_VALIDATION_NAMES = {"request", "socket", "state", "scope"}
 
 
 class SignatureModel(BaseModel):
+    """Pydantic model representing a signature."""
+
     class Config(BaseConfig):
         arbitrary_types_allowed = True
 
@@ -87,14 +89,12 @@ class SignatureModel(BaseModel):
 
         If both parameter and dependency values are invalid, we raise the client error first.
 
-        Parameters
-        ----------
-        connection : Request | WebSocket
-        exc : ValidationError
+        Args:
+            connection: A Request or WebSocket
+            exc: A ValidationError
 
-        Returns
-        -------
-        ValidationException | InternalServerException
+        Returns:
+            A ValidationException or InternalServerException
         """
         server_errors: List["ErrorDict"] = []
         client_errors: List["ErrorDict"] = []
@@ -127,14 +127,6 @@ class SignatureModel(BaseModel):
 class SignatureParameter:
     """Represents the parameters of a callable for purpose of signature model
     generation.
-
-    Parameters
-    ----------
-    fn_name : str
-        Name of function.
-    parameter_name : str
-        Name of parameter.
-    parameter : inspect.Parameter
     """
 
     __slots__ = (
@@ -150,6 +142,13 @@ class SignatureParameter:
     optional: bool
 
     def __init__(self, fn_name: str, parameter_name: str, parameter: Parameter) -> None:
+        """Initialize SignatureParameter.
+
+        Args:
+            fn_name: Name of function.
+            parameter_name: Name of parameter.
+            parameter: inspect.Parameter
+        """
         if parameter.annotation is Signature.empty:
             raise ImproperlyConfiguredException(
                 f"Kwarg {parameter_name} of {fn_name} does not have a type annotation. If it "
@@ -177,25 +176,14 @@ class SignatureModelFactory:
 
     Instance available at `SignatureModel.factory`.
 
-    Parameters
-    ----------
-    fn : AnyCallable
-    plugins : list[PluginProtocol]
-    dependency_names : Set[str]
-
     The following attributes are populated after the `model()` method has been called to generate
     the `SignatureModel` subclass.
 
-    Attributes
-    ----------
-    field_plugin_mappings : dict[str, PluginMapping]
-        Maps parameter name, to `PluginMapping` where a plugin has been applied.
-    field_definitions : dict[str, Tuple[Any, Any]
-        Maps parameter name to the `(<type>, <default>)` tuple passed to `pydantic.create_model()`.
-    defaults : dict[str, Any]
-        Maps parameter name to default value, if one defined.
-    dependency_name_set : set[str]
-        The names of all known dependency parameters.
+    Attributes:
+        field_plugin_mappings: Maps parameter name, to `PluginMapping` where a plugin has been applied.
+        field_definitions:  Maps parameter name to the `(<type>, <default>)` tuple passed to `pydantic.create_model()`.
+        defaults: Maps parameter name to default value, if one defined.
+        dependency_name_set: The names of all known dependency parameters.
     """
 
     __slots__ = (
@@ -209,6 +197,13 @@ class SignatureModelFactory:
     )
 
     def __init__(self, fn: "AnyCallable", plugins: List["PluginProtocol"], dependency_names: Set[str]) -> None:
+        """Initialise `SignatureModelFactory`
+
+        Args:
+            fn: A callable
+            plugins: A list of plugins
+            dependency_names: Dependency names
+        """
         if fn is None:
             raise ImproperlyConfiguredException("Parameter `fn` to `SignatureModelFactory` cannot be `None`.")
         self.signature = Signature.from_callable(fn)
@@ -225,13 +220,11 @@ class SignatureModelFactory:
         defined without a default value, and it hasn't been provided to the
         handler.
 
-        Parameters
-        ----------
-        parameter : SignatureParameter
+        Args:
+            parameter  SignatureParameter
 
-        Raises
-        ------
-        `ImproperlyConfiguredException`
+        Raises:
+            `ImproperlyConfiguredException`
         """
         if parameter.optional:
             return
@@ -250,9 +243,8 @@ class SignatureModelFactory:
         """Add parameter name of dependencies declared using `Dependency()`
         function to the set of all dependency names.
 
-        Parameters
-        ----------
-        parameter : SignatureParameter
+        Args:
+            parameter: SignatureParameter
         """
         if is_dependency_field(parameter.default):
             self.dependency_name_set.add(parameter.name)
@@ -261,9 +253,8 @@ class SignatureModelFactory:
         """If `parameter` has defined default, map it to the parameter name in
         `self.defaults`.
 
-        Parameters
-        ----------
-        parameter : SignatureParameter
+        Args:
+            parameter: SignatureParameter
         """
         if parameter.default_defined:
             self.defaults[parameter.name] = parameter.default
@@ -272,14 +263,12 @@ class SignatureModelFactory:
         """Use plugin declared for parameter annotation type to generate a
         pydantic model.
 
-        Parameters
-        ----------
-        parameter : SignatureParameter
-        plugin : PluginProtocol
+        Args:
+            parameter:  SignatureParameter
+            plugin: PluginProtocol
 
-        Returns
-        -------
-        Any
+        Returns:
+            A pydantic model to be used as a type
         """
         type_args = get_args(parameter.annotation)
         type_value = type_args[0] if type_args else parameter.annotation
@@ -294,13 +283,11 @@ class SignatureModelFactory:
         """Construct an `(<annotation>, <default>)` tuple, appropriate for
         `pydantic.create_model()`.
 
-        Parameters
-        ----------
-        parameter : SignatureParameter
+        Args:
+            parameter: SignatureParameter
 
-        Returns
-        -------
-        tuple[Any, Any]
+        Returns:
+            tuple[Any, Any]
         """
         if parameter.default_defined:
             return parameter.annotation, parameter.default
@@ -314,9 +301,8 @@ class SignatureModelFactory:
         parameters of the function signature that should be included in the
         `SignatureModel` type.
 
-        Returns
-        -------
-        Generator[SignatureParameter, None, None]
+        Returns:
+            Generator[SignatureParameter, None, None]
         """
         for name, parameter in filter(lambda x: x[0] not in SKIP_NAMES, self.signature.parameters.items()):
             yield SignatureParameter(self.fn_name, name, parameter)
@@ -338,9 +324,8 @@ class SignatureModelFactory:
         """Constructs a `SignatureModel` type that represents the signature of
         `self.fn`
 
-        Returns
-        -------
-        type[SignatureModel]
+        Returns:
+            type[SignatureModel]
         """
         try:
             for parameter in self.signature_parameters:

--- a/starlite/static_files/base.py
+++ b/starlite/static_files/base.py
@@ -16,10 +16,12 @@ if TYPE_CHECKING:
 
 
 class StaticFiles:
+    """ASGI callable serving static files from a `FileSystemProtocol`"""
+
     __slots__ = ("is_html_mode", "directories", "adapter")
 
     def __init__(self, is_html_mode: bool, directories: List["PathType"], file_system: "FileSystemProtocol") -> None:
-        """This class is an ASGI App that handles file sending.
+        """Initialize the application.
 
         Args:
             is_html_mode: Flag dictating whether serving html. If true, the default file will be 'index.html'.
@@ -55,6 +57,16 @@ class StaticFiles:
         return None, None
 
     async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+        """ASGI callable.
+
+        Args:
+            scope: ASGI scope
+            receive: ASGI `receive` callable
+            send: ASGI `send` callable
+
+        Returns:
+            None
+        """
         if scope["type"] != ScopeType.HTTP or scope["method"] not in {"GET", "HEAD"}:
             raise MethodNotAllowedException()
 

--- a/starlite/status_codes.py
+++ b/starlite/status_codes.py
@@ -1,4 +1,4 @@
-"""This file includes code adapted from
+"""Includes code adapted from
 https://github.com/encode/starlette/blob/master/starlette/status.py.
 
 Copyright © 2018, [Encode OSS Ltd](https://www.encode.io/).

--- a/starlite/template/base.py
+++ b/starlite/template/base.py
@@ -8,6 +8,8 @@ if TYPE_CHECKING:
 
 
 class TemplateContext(TypedDict):
+    """Dictionary representing a template context."""
+
     request: "Request[Any, Any]"
     csrf_input: str
 
@@ -89,9 +91,11 @@ T_co = TypeVar("T_co", bound=TemplateProtocol, covariant=True)
 
 @runtime_checkable
 class TemplateEngineProtocol(Protocol[T_co]):  # pragma: no cover
+    """Protocol for template engines."""
+
     @validate_arguments
     def __init__(self, directory: Union[DirectoryPath, List[DirectoryPath]]) -> None:
-        """Protocol for a templating engine.
+        """Initialize the template engine with a directory.
 
         Args:
             directory: Direct path or list of directory paths from which to serve templates.
@@ -99,8 +103,7 @@ class TemplateEngineProtocol(Protocol[T_co]):  # pragma: no cover
         ...
 
     def get_template(self, template_name: str) -> T_co:
-        """
-        Retrieves a template by matching its name (dotted path) with files in the directory or directories provided.
+        """Retrieve a template by matching its name (dotted path) with files in the directory or directories provided.
         Args:
             template_name: A dotted path
 
@@ -113,7 +116,7 @@ class TemplateEngineProtocol(Protocol[T_co]):  # pragma: no cover
         ...
 
     def register_template_callable(self, key: str, template_callable: Callable[[Dict[str, Any]], Any]) -> None:
-        """Registers a callable on the template engine.
+        """Register a callable on the template engine.
 
         Args:
             key: The callable key, i.e. the value to use inside the template to call the callable.

--- a/starlite/template/jinja.py
+++ b/starlite/template/jinja.py
@@ -37,8 +37,7 @@ class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate"]):
         self.register_template_callable(key="url_for", template_callable=url_for)  # type: ignore
 
     def get_template(self, template_name: str) -> "JinjaTemplate":
-        """
-        Retrieves a template by matching its name (dotted path) with files in the directory or directories provided.
+        """Retrieve a template by matching its name (dotted path) with files in the directory or directories provided.
         Args:
             template_name: A dotted path
 
@@ -54,7 +53,7 @@ class JinjaTemplateEngine(TemplateEngineProtocol["JinjaTemplate"]):
             raise TemplateNotFoundException(template_name=template_name) from exc
 
     def register_template_callable(self, key: str, template_callable: Callable[[Dict[str, Any]], Any]) -> None:
-        """Registers a callable on the template engine.
+        """Register a callable on the template engine.
 
         Args:
             key: The callable key, i.e. the value to use inside the template to call the callable.

--- a/starlite/template/mako.py
+++ b/starlite/template/mako.py
@@ -23,14 +23,31 @@ if TYPE_CHECKING:
 
 
 class MakoTemplate(TemplateProtocol):
+    """Mako template, implementing `TemplateProtocol`"""
+
     def __init__(
         self, template: "_MakoTemplate", template_callables: List[Tuple[str, Callable[[Dict[str, Any]], Any]]]
     ):
+        """Initialize a template.
+
+        Args:
+            template: Base `MakoTemplate` used by the underlying mako-engine
+            template_callables: List of callables passed to the template
+        """
         super().__init__()
         self.template = template
         self.template_callables = template_callables
 
     def render(self, *args: Any, **kwargs: Any) -> str:
+        """Render a template.
+
+        Args:
+            args: Positional arguments passed to the engines `render` function
+            kwargs: Keyword arguments passed to the engines `render` function
+
+        Returns:
+            Rendered template as a string
+        """
         for callable_key, template_callable in self.template_callables:
             kwargs_copy = {**kwargs}
             kwargs[callable_key] = partial(template_callable, kwargs_copy)
@@ -39,8 +56,10 @@ class MakoTemplate(TemplateProtocol):
 
 
 class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate]):
+    """Mako based TemplateEngine."""
+
     def __init__(self, directory: Union["DirectoryPath", List["DirectoryPath"]]) -> None:
-        """Mako based TemplateEngine.
+        """Initialize template engine.
 
         Args:
             directory: Direct path or list of directory paths from which to serve templates.
@@ -53,8 +72,7 @@ class MakoTemplateEngine(TemplateEngineProtocol[MakoTemplate]):
         self.register_template_callable(key="url_for", template_callable=url_for)  # type: ignore
 
     def get_template(self, template_name: str) -> MakoTemplate:
-        """
-        Retrieves a template by matching its name (dotted path) with files in the directory or directories provided.
+        """Retrieve a template by matching its name (dotted path) with files in the directory or directories provided.
         Args:
             template_name: A dotted path
 

--- a/starlite/testing/create_test_client.py
+++ b/starlite/testing/create_test_client.py
@@ -79,7 +79,7 @@ def create_test_client(
     template_config: Optional["TemplateConfig"] = None,
     websocket_class: Optional[Type["WebSocket"]] = None,
 ) -> TestClient["Starlite"]:
-    """Creates a Starlite app instance and initializes it.
+    """Create a Starlite app instance and initializes it.
 
     [TestClient][starlite.testing.TestClient] with it.
 
@@ -88,7 +88,6 @@ def create_test_client(
             handled correctly.
 
     Examples:
-
         ```python
         from starlite import get, create_test_client
 

--- a/starlite/testing/request_factory.py
+++ b/starlite/testing/request_factory.py
@@ -38,6 +38,8 @@ default_app = Starlite(route_handlers=[_default_route_handler])
 
 
 class RequestFactory:
+    """Factory to create [Request][starlite.connection.Request] instances."""
+
     def __init__(
         self,
         app: Starlite = default_app,
@@ -46,8 +48,7 @@ class RequestFactory:
         root_path: str = "",
         scheme: str = "http",
     ) -> None:
-        """A factory object to create [Request][starlite.connection.Request]
-        instances.
+        """Initialize `RequestFactory`
 
         Args:
              app: An instance of [Starlite][starlite.app.Starlite] to set as `request.scope["app"]`.
@@ -57,7 +58,6 @@ class RequestFactory:
              scheme: Scheme for the server.
 
         Examples:
-
         ```python
         from starlite import RequestEncodingType, Starlite
         from starlite.testing import RequestFactory
@@ -171,7 +171,6 @@ class RequestFactory:
             cookies: A string representing the cookie header or a list of "Cookie" instances.
                 This value can include multiple cookies.
         """
-
         if not cookies:
             return
 
@@ -197,7 +196,6 @@ class RequestFactory:
         Returns:
             A list of encoded headers that can be passed to the request scope.
         """
-
         headers = headers or {}
         self._create_cookie_header(headers, cookies)
         return [
@@ -247,7 +245,6 @@ class RequestFactory:
         Returns:
             A [Request][starlite.connection.Request] instance
         """
-
         scope = self._create_scope(
             path=path,
             http_method=http_method,
@@ -313,7 +310,6 @@ class RequestFactory:
         Returns:
             A [Request][starlite.connection.Request] instance
         """
-
         scope = self._create_scope(
             path=path,
             http_method=HttpMethod.GET,
@@ -368,7 +364,6 @@ class RequestFactory:
         Returns:
             A [Request][starlite.connection.Request] instance
         """
-
         return self._create_request_with_data(
             auth=auth,
             cookies=cookies,
@@ -424,7 +419,6 @@ class RequestFactory:
         Returns:
             A [Request][starlite.connection.Request] instance
         """
-
         return self._create_request_with_data(
             auth=auth,
             cookies=cookies,
@@ -480,7 +474,6 @@ class RequestFactory:
         Returns:
             A [Request][starlite.connection.Request] instance
         """
-
         return self._create_request_with_data(
             auth=auth,
             cookies=cookies,
@@ -531,7 +524,6 @@ class RequestFactory:
         Returns:
             A [Request][starlite.connection.Request] instance
         """
-
         scope = self._create_scope(
             path=path,
             http_method=HttpMethod.DELETE,

--- a/starlite/types/asgi_types.py
+++ b/starlite/types/asgi_types.py
@@ -59,15 +59,21 @@ ScopeSession = Optional[Union["EmptyType", Dict[str, Any], "BaseModel"]]
 
 
 class ASGIVersion(TypedDict):
+    """ASGI spec version."""
+
     spec_version: str
     version: Literal["3.0"]
 
 
 class HeaderScope(TypedDict):
+    """Base class for ASGI-scopes that supports headers."""
+
     headers: "RawHeadersList"
 
 
 class BaseScope(HeaderScope):
+    """Base ASGI-scope."""
+
     app: "Starlite"
     asgi: ASGIVersion
     auth: Any
@@ -88,112 +94,156 @@ class BaseScope(HeaderScope):
 
 
 class HTTPScope(BaseScope):
+    """HTTP-ASGI-scope."""
+
     method: "Method"
     type: Literal[ScopeType.HTTP]
 
 
 class WebSocketScope(BaseScope):
+    """WebSocket-ASGI-scope."""
+
     subprotocols: List[str]
     type: Literal[ScopeType.WEBSOCKET]
 
 
 class LifeSpanScope(TypedDict):
+    """Lifespan-ASGI-scope."""
+
     app: "Starlite"
     asgi: ASGIVersion
     type: Literal["lifespan"]
 
 
 class HTTPRequestEvent(TypedDict):
+    """ASGI `http.request` event."""
+
     type: Literal["http.request"]
     body: bytes
     more_body: bool
 
 
 class HTTPResponseStartEvent(HeaderScope):
+    """ASGI `http.response.start` event."""
+
     type: Literal["http.response.start"]
     status: int
 
 
 class HTTPResponseBodyEvent(TypedDict):
+    """ASGI `http.response.body` event."""
+
     type: Literal["http.response.body"]
     body: bytes
     more_body: bool
 
 
 class HTTPServerPushEvent(HeaderScope):
+    """ASGI `http.response.push` event."""
+
     type: Literal["http.response.push"]
     path: str
 
 
 class HTTPDisconnectEvent(TypedDict):
+    """ASGI `http.disconnect` event."""
+
     type: Literal["http.disconnect"]
 
 
 class WebSocketConnectEvent(TypedDict):
+    """ASGI `websocket.connect` event."""
+
     type: Literal["websocket.connect"]
 
 
 class WebSocketAcceptEvent(HeaderScope):
+    """ASGI `websocket.accept` event."""
+
     type: Literal["websocket.accept"]
     subprotocol: Optional[str]
 
 
 class WebSocketReceiveEvent(TypedDict):
+    """ASGI `websocket.receive` event."""
+
     type: Literal["websocket.receive"]
     bytes: Optional[bytes]
     text: Optional[str]
 
 
 class WebSocketSendEvent(TypedDict):
+    """ASGI `websocket.send` event."""
+
     type: Literal["websocket.send"]
     bytes: Optional[bytes]
     text: Optional[str]
 
 
 class WebSocketResponseStartEvent(HeaderScope):
+    """ASGI `websocket.http.response.start` event."""
+
     type: Literal["websocket.http.response.start"]
     status: int
 
 
 class WebSocketResponseBodyEvent(TypedDict):
+    """ASGI `websocket.http.response.body` event."""
+
     type: Literal["websocket.http.response.body"]
     body: bytes
     more_body: bool
 
 
 class WebSocketDisconnectEvent(TypedDict):
+    """ASGI `websocket.disconnect` event."""
+
     type: Literal["websocket.disconnect"]
     code: int
 
 
 class WebSocketCloseEvent(TypedDict):
+    """ASGI `websocket.close` event."""
+
     type: Literal["websocket.close"]
     code: int
     reason: Optional[str]
 
 
 class LifeSpanStartupEvent(TypedDict):
+    """ASGI `lifespan.startup` event."""
+
     type: Literal["lifespan.startup"]
 
 
 class LifeSpanShutdownEvent(TypedDict):
+    """ASGI `lifespan.shutdown` event."""
+
     type: Literal["lifespan.shutdown"]
 
 
 class LifeSpanStartupCompleteEvent(TypedDict):
+    """ASGI `lifespan.startup.complete` event."""
+
     type: Literal["lifespan.startup.complete"]
 
 
 class LifeSpanStartupFailedEvent(TypedDict):
+    """ASGI `lifespan.startup.failed` event."""
+
     type: Literal["lifespan.startup.failed"]
     message: str
 
 
 class LifeSpanShutdownCompleteEvent(TypedDict):
+    """ASGI `lifespan.shutdown.complete` event."""
+
     type: Literal["lifespan.shutdown.complete"]
 
 
 class LifeSpanShutdownFailedEvent(TypedDict):
+    """ASGI `lifespan.shutdown.failed` event."""
+
     type: Literal["lifespan.shutdown.failed"]
     message: str
 

--- a/starlite/types/file_types.py
+++ b/starlite/types/file_types.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
 
 class FileInfo(TypedDict):
+    """File information gathered from a file system."""
+
     created: float
     """Created time stamp, equal to 'stat_result.st_ctime'."""
     destination: NotRequired[Optional[bytes]]
@@ -44,7 +46,7 @@ class FileSystemProtocol(Protocol):
     """
 
     def info(self, path: "PathType", **kwargs: Any) -> Union[FileInfo, Awaitable[FileInfo]]:
-        """Retrieves information about a given file path.
+        """Retrieve information about a given file path.
 
         Args:
             path: A file path.
@@ -62,7 +64,7 @@ class FileSystemProtocol(Protocol):
         mode: "OpenBinaryMode",
         buffering: int = -1,
     ) -> Union[IO[bytes], Awaitable["AsyncFile[bytes]"]]:
-        """Returns a file-like object from the filesystem.
+        """Return a file-like object from the filesystem.
 
         Notes:
             - The return value must function correctly in a context `with` block.
@@ -81,7 +83,7 @@ class FileSystemProtocol(Protocol):
         mode: "OpenTextMode",
         buffering: int = -1,
     ) -> Union[IO[str], Awaitable["AsyncFile[str]"]]:
-        """Returns a file-like object from the filesystem.
+        """Return a file-like object from the filesystem.
 
         Notes:
             - The return value must function correctly in a context `with` block.
@@ -99,7 +101,7 @@ class FileSystemProtocol(Protocol):
         mode: str,
         buffering: int = -1,
     ) -> Union[IO[AnyStr], Awaitable["AsyncFile[AnyStr]"]]:
-        """Returns a file-like object from the filesystem.
+        """Return a file-like object from the filesystem.
 
         Notes:
             - The return value must function correctly in a context `with` block.

--- a/starlite/types/internal_types.py
+++ b/starlite/types/internal_types.py
@@ -30,6 +30,8 @@ RouteHandlerMapItem = Union[WebsocketRouteHandler, ASGIRouteHandler, Dict[Method
 
 
 class PathParameterDefinition(NamedTuple):
+    """Path parameter tuple."""
+
     name: str
     full: str
     type: Type

--- a/starlite/types/partial.py
+++ b/starlite/types/partial.py
@@ -64,7 +64,6 @@ class Partial(Generic[T]):
         Returns:
             A pydantic model, [`TypedDict`][typing.TypedDict], or dataclass.
         """
-
         if item not in cls._models:
             if is_class_and_subclass(item, BaseModel):
                 cls._create_partial_pydantic_model(item=item)

--- a/starlite/types/protocols.py
+++ b/starlite/types/protocols.py
@@ -4,8 +4,10 @@ from typing_extensions import Protocol
 
 
 class Logger(Protocol):  # pragma: no cover
+    """Logger protocol."""
+
     def debug(self, event: str, *args: Any, **kwargs: Any) -> Any:
-        """Outputs a log message at 'DEBUG' level.
+        """Output a log message at 'DEBUG' level.
 
         Args:
              event: Log message.
@@ -14,7 +16,7 @@ class Logger(Protocol):  # pragma: no cover
         """
 
     def info(self, event: str, *args: Any, **kwargs: Any) -> Any:
-        """Outputs a log message at 'INFO' level.
+        """Output a log message at 'INFO' level.
 
         Args:
              event: Log message.
@@ -23,7 +25,7 @@ class Logger(Protocol):  # pragma: no cover
         """
 
     def warning(self, event: str, *args: Any, **kwargs: Any) -> Any:
-        """Outputs a log message at 'WARNING' level.
+        """Output a log message at 'WARNING' level.
 
         Args:
              event: Log message.
@@ -32,7 +34,7 @@ class Logger(Protocol):  # pragma: no cover
         """
 
     def warn(self, event: str, *args: Any, **kwargs: Any) -> Any:
-        """Outputs a log message at 'WARN' level.
+        """Output a log message at 'WARN' level.
 
         Args:
              event: Log message.
@@ -41,7 +43,7 @@ class Logger(Protocol):  # pragma: no cover
         """
 
     def error(self, event: str, *args: Any, **kwargs: Any) -> Any:
-        """Outputs a log message at 'ERROR' level.
+        """Output a log message at 'ERROR' level.
 
         Args:
              event: Log message.
@@ -50,7 +52,7 @@ class Logger(Protocol):  # pragma: no cover
         """
 
     def fatal(self, event: str, *args: Any, **kwargs: Any) -> Any:
-        """Outputs a log message at 'FATAL' level.
+        """Output a log message at 'FATAL' level.
 
         Args:
              event: Log message.
@@ -59,7 +61,7 @@ class Logger(Protocol):  # pragma: no cover
         """
 
     def exception(self, event: str, *args: Any, **kwargs: Any) -> Any:
-        """Logs a message with level 'ERROR' on this logger. The arguments are
+        """Log a message with level 'ERROR' on this logger. The arguments are
         interpreted as for debug(). Exception info is added to the logging
         message.
 
@@ -70,7 +72,7 @@ class Logger(Protocol):  # pragma: no cover
         """
 
     def critical(self, event: str, *args: Any, **kwargs: Any) -> Any:
-        """Outputs a log message at 'INFO' level.
+        """Output a log message at 'INFO' level.
 
         Args:
              event: Log message.

--- a/starlite/utils/exception.py
+++ b/starlite/utils/exception.py
@@ -45,6 +45,8 @@ def get_exception_handler(exception_handlers: "ExceptionHandlersMap", exc: Excep
 
 
 class ExceptionResponseContent(BaseModel):
+    """Represent the contents of an exception-response."""
+
     status_code: int
     """Exception status code."""
     detail: str

--- a/starlite/utils/extractors.py
+++ b/starlite/utils/extractors.py
@@ -25,16 +25,15 @@ if TYPE_CHECKING:
 
 
 def obfuscate(values: Dict[str, Any], fields_to_obfuscate: Set[str]) -> Dict[str, Any]:
-    """
+    """Obfuscate values in a dictionary, replacing values with `******`
+
     Args:
         values: A dictionary of strings
         fields_to_obfuscate: keys to obfuscate
 
     Returns:
         A dictionary with obfuscated strings
-
     """
-
     for key in values:
         if key.lower() in fields_to_obfuscate:
             values[key] = "*****"
@@ -49,6 +48,8 @@ ResponseExtractorField = Literal["status_code", "headers", "body", "cookies"]
 
 
 class ExtractedRequestData(TypedDict, total=False):
+    """Dictionary representing extracted request data."""
+
     body: Coroutine
     client: Tuple[str, int]
     content_type: Tuple[str, Dict[str, str]]
@@ -62,6 +63,12 @@ class ExtractedRequestData(TypedDict, total=False):
 
 
 class ConnectionDataExtractor:
+    """Utility class to extract data from an.
+
+    [ASGIConnection][starlite.connection.ASGIConnection],
+    [Request][starlite.connection.Request] or [WebSocket][starlite.connection.WebSocket] instance.
+    """
+
     __slots__ = (
         "connection_extractors",
         "request_extractors",
@@ -88,11 +95,7 @@ class ConnectionDataExtractor:
         parse_body: bool = False,
         parse_query: bool = False,
     ):
-        """A utility class that extracts data from an.
-
-        [ASGIConnection][starlite.connection.ASGIConnection],
-
-        [Request][starlite.connection.Request] or [WebSocket][starlite.connection.WebSocket] instance.
+        """Initialize `ConnectionDataExtractor`
 
         Args:
             extract_body: Whether to extract body, (for requests only).
@@ -138,17 +141,17 @@ class ConnectionDataExtractor:
             self.request_extractors["body"] = self.extract_body
 
     def __call__(self, connection: "ASGIConnection[Any, Any, Any]") -> ExtractedRequestData:
-        """Extracts data from the connection, returning a dictionary of values.
+        """Extract data from the connection, returning a dictionary of values.
 
         Notes:
             - The value for 'body' - if present - is an unresolved Coroutine and as such should be awaited by the receiver.
+
         Args:
             connection: An ASGI connection or its subclasses.
 
         Returns:
             A string keyed dictionary of extracted values.
         """
-
         extractors = (
             {**self.connection_extractors, **self.request_extractors}  # type: ignore
             if isinstance(connection, Request)
@@ -158,7 +161,7 @@ class ConnectionDataExtractor:
 
     @staticmethod
     def extract_scheme(connection: "ASGIConnection[Any, Any, Any]") -> str:
-        """
+        """Extract the scheme from an `ASGIConnection`
 
         Args:
             connection: An [ASGIConnection][starlite.connection.ASGIConnection] instance.
@@ -170,7 +173,7 @@ class ConnectionDataExtractor:
 
     @staticmethod
     def extract_client(connection: "ASGIConnection[Any, Any, Any]") -> Tuple[str, int]:
-        """
+        """Extract the client from an `ASGIConnection`
 
         Args:
             connection: An [ASGIConnection][starlite.connection.ASGIConnection] instance.
@@ -182,7 +185,7 @@ class ConnectionDataExtractor:
 
     @staticmethod
     def extract_path(connection: "ASGIConnection[Any, Any, Any]") -> str:
-        """
+        """Extract the path from an `ASGIConnection`
 
         Args:
             connection: An [ASGIConnection][starlite.connection.ASGIConnection] instance.
@@ -193,7 +196,7 @@ class ConnectionDataExtractor:
         return connection.scope["path"]
 
     def extract_headers(self, connection: "ASGIConnection[Any, Any, Any]") -> Dict[str, str]:
-        """
+        """Extract headers from an `ASGIConnection`
 
         Args:
             connection: An [ASGIConnection][starlite.connection.ASGIConnection] instance.
@@ -205,7 +208,7 @@ class ConnectionDataExtractor:
         return obfuscate(headers, self.obfuscate_headers) if self.obfuscate_headers else headers
 
     def extract_cookies(self, connection: "ASGIConnection[Any, Any, Any]") -> Dict[str, str]:
-        """
+        """Extract cookies from an `ASGIConnection`
 
         Args:
             connection: An [ASGIConnection][starlite.connection.ASGIConnection] instance.
@@ -216,7 +219,7 @@ class ConnectionDataExtractor:
         return obfuscate(connection.cookies, self.obfuscate_cookies) if self.obfuscate_cookies else connection.cookies
 
     def extract_query(self, connection: "ASGIConnection[Any, Any, Any]") -> Any:
-        """
+        """Extract query from an `ASGIConnection`
 
         Args:
             connection: An [ASGIConnection][starlite.connection.ASGIConnection] instance.
@@ -228,7 +231,7 @@ class ConnectionDataExtractor:
 
     @staticmethod
     def extract_path_params(connection: "ASGIConnection[Any, Any, Any]") -> Dict[str, Any]:
-        """
+        """Extract the path parameters from an `ASGIConnection`
 
         Args:
             connection: An [ASGIConnection][starlite.connection.ASGIConnection] instance.
@@ -240,7 +243,7 @@ class ConnectionDataExtractor:
 
     @staticmethod
     def extract_method(request: "Request[Any, Any]") -> "Method":
-        """
+        """Extract the method from an `ASGIConnection`
 
         Args:
             request: A [Request][starlite.connection.Request] instance.
@@ -252,7 +255,7 @@ class ConnectionDataExtractor:
 
     @staticmethod
     def extract_content_type(request: "Request[Any, Any]") -> Tuple[str, Dict[str, str]]:
-        """
+        """Extract the content-type from an `ASGIConnection`
 
         Args:
             request: A [Request][starlite.connection.Request] instance.
@@ -263,7 +266,7 @@ class ConnectionDataExtractor:
         return request.content_type
 
     async def extract_body(self, request: "Request[Any, Any]") -> Any:
-        """
+        """Extract the body from an `ASGIConnection`
 
         Args:
             request: A [Request][starlite.connection.Request] instance.
@@ -287,6 +290,8 @@ class ConnectionDataExtractor:
 
 
 class ExtractedResponseData(TypedDict, total=False):
+    """Dictionary representing extracted response data."""
+
     body: bytes
     status_code: int
     headers: Dict[str, str]
@@ -294,6 +299,8 @@ class ExtractedResponseData(TypedDict, total=False):
 
 
 class ResponseDataExtractor:
+    """Utility class to extract data from a `Message`"""
+
     __slots__ = ("extractors", "parse_headers", "obfuscate_headers", "obfuscate_cookies")
 
     def __init__(
@@ -305,7 +312,7 @@ class ResponseDataExtractor:
         obfuscate_cookies: Optional[Set[str]] = None,
         obfuscate_headers: Optional[Set[str]] = None,
     ):
-        """A utility class that extracts data from response messages.
+        """Initialize `ResponseDataExtractor` with options.
 
         Args:
             extract_body: Whether to extract the body.
@@ -330,12 +337,13 @@ class ResponseDataExtractor:
             self.extractors["cookies"] = self.extract_cookies
 
     def __call__(self, messages: Tuple["HTTPResponseStartEvent", "HTTPResponseBodyEvent"]) -> ExtractedResponseData:
-        """Extracts data from the response, returning a dictionary of values.
+        """Extract data from the response, returning a dictionary of values.
 
         Args:
             messages: A tuple containing
                 [HTTPResponseStartEvent][starlite.types.asgi_types.HTTPResponseStartEvent]
                 and [HTTPResponseBodyEvent][starlite.types.asgi_types.HTTPResponseBodyEvent].
+
         Returns:
             A string keyed dictionary of extracted values.
         """
@@ -343,12 +351,13 @@ class ResponseDataExtractor:
 
     @staticmethod
     def extract_response_body(messages: Tuple["HTTPResponseStartEvent", "HTTPResponseBodyEvent"]) -> bytes:
-        """
+        """Extract the response ody from a `Message`
 
         Args:
             messages: A tuple containing
                 [HTTPResponseStartEvent][starlite.types.asgi_types.HTTPResponseStartEvent]
                 and [HTTPResponseBodyEvent][starlite.types.asgi_types.HTTPResponseBodyEvent].
+
         Returns:
             The Response's body as a byte-string.
         """
@@ -356,24 +365,26 @@ class ResponseDataExtractor:
 
     @staticmethod
     def extract_status_code(messages: Tuple["HTTPResponseStartEvent", "HTTPResponseBodyEvent"]) -> int:
-        """
+        """Extract a status code from a `Message`
 
         Args:
             messages: A tuple containing
                 [HTTPResponseStartEvent][starlite.types.asgi_types.HTTPResponseStartEvent]
                 and [HTTPResponseBodyEvent][starlite.types.asgi_types.HTTPResponseBodyEvent].
+
         Returns:
             The Response's status-code.
         """
         return messages[0]["status"]
 
     def extract_headers(self, messages: Tuple["HTTPResponseStartEvent", "HTTPResponseBodyEvent"]) -> Dict[str, str]:
-        """
+        """Extract headers from a `Message`
 
         Args:
             messages: A tuple containing
                 [HTTPResponseStartEvent][starlite.types.asgi_types.HTTPResponseStartEvent]
                 and [HTTPResponseBodyEvent][starlite.types.asgi_types.HTTPResponseBodyEvent].
+
         Returns:
             The Response's headers dict.
         """
@@ -391,7 +402,7 @@ class ResponseDataExtractor:
         )
 
     def extract_cookies(self, messages: Tuple["HTTPResponseStartEvent", "HTTPResponseBodyEvent"]) -> Dict[str, str]:
-        """
+        """Extract cookies from a `Message`
 
         Args:
             messages: A tuple containing

--- a/starlite/utils/extractors.py
+++ b/starlite/utils/extractors.py
@@ -351,7 +351,7 @@ class ResponseDataExtractor:
 
     @staticmethod
     def extract_response_body(messages: Tuple["HTTPResponseStartEvent", "HTTPResponseBodyEvent"]) -> bytes:
-        """Extract the response ody from a `Message`
+        """Extract the response body from a `Message`
 
         Args:
             messages: A tuple containing

--- a/starlite/utils/file.py
+++ b/starlite/utils/file.py
@@ -18,8 +18,10 @@ if TYPE_CHECKING:
 
 
 class BaseLocalFileSystem(FileSystemProtocol):
+    """Base class for a local file system."""
+
     async def info(self, path: "PathType", **kwargs: Any) -> "FileInfo":  # pylint: disable=W0236
-        """Retrieves information about a given file path.
+        """Retrieve information about a given file path.
 
         Args:
             path: A file path.
@@ -51,9 +53,10 @@ class BaseLocalFileSystem(FileSystemProtocol):
 
 
 class FileSystemAdapter:
+    """Wrapper around a `FileSystemProtocol`, normalising its interface."""
+
     def __init__(self, file_system: "FileSystemProtocol"):
-        """This class is a wrapper around a file_system, normalizing
-        interaction with it.
+        """Initialize an adapter from a given `file_system`
 
         Args:
             file_system: A filesystem class adhering to the [FileSystemProtocol][starlite.types.FileSystemProtocol]

--- a/starlite/utils/helpers.py
+++ b/starlite/utils/helpers.py
@@ -6,15 +6,14 @@ T = TypeVar("T")
 
 
 def get_name(value: Any) -> str:
-    """Helper to get the '__name__' dunder of a value.
+    """Get the `__name__` of an object.
 
     Args:
-        value: An arbitrary value.
+        value: An arbitrary object.
 
     Returns:
         A name string.
     """
-
     if hasattr(value, "__name__"):
         return cast("str", value.__name__)
     return type(value).__name__

--- a/starlite/utils/model.py
+++ b/starlite/utils/model.py
@@ -9,7 +9,9 @@ if TYPE_CHECKING:
     from starlite.types.builtin_types import DataclassClassOrInstance, TypedDictClass
 
 
-class Config(BaseConfig):  # noqa: D101
+class Config(BaseConfig):
+    """Base config for models."""
+
     arbitrary_types_allowed = True
 
 

--- a/starlite/utils/model.py
+++ b/starlite/utils/model.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from starlite.types.builtin_types import DataclassClassOrInstance, TypedDictClass
 
 
-class Config(BaseConfig):
+class Config(BaseConfig):  # noqa: D101
     arbitrary_types_allowed = True
 
 
@@ -25,10 +25,9 @@ _type_model_map: Dict[Type[Any], Type[BaseModel]] = {}
 
 
 def convert_dataclass_to_model(dataclass_or_instance: "DataclassClassOrInstance") -> Type[BaseModel]:
-    """Converts a dataclass or dataclass instance to a pydantic model and
-    memoizes the result.
+    """Convert a dataclass or dataclass instance to a pydantic model and
+    memoize the result.
     """
-
     if not isinstance(dataclass_or_instance, type):
         dataclass = type(dataclass_or_instance)
     else:

--- a/starlite/utils/scope.py
+++ b/starlite/utils/scope.py
@@ -5,15 +5,14 @@ if TYPE_CHECKING:
 
 
 def get_serializer_from_scope(scope: "Scope") -> Optional["Serializer"]:
-    """
-    Utility that returns a serializer given a scope object.
+    """Returns a serializer given a scope object.
+
     Args:
         scope: The ASGI connection scope.
 
     Returns:
         A serializer function
     """
-
     route_handler = scope["route_handler"]
     if hasattr(route_handler, "resolve_response_class"):
         return route_handler.resolve_response_class().serializer  # type: ignore

--- a/starlite/utils/serialization.py
+++ b/starlite/utils/serialization.py
@@ -5,7 +5,8 @@ from pydantic import BaseModel, SecretStr
 
 
 def default_serializer(value: Any) -> Any:
-    """
+    """Return the default serializer for a given object based on its type.
+
     Args:
         value: A value to serialize
     Returns:

--- a/starlite/utils/sync.py
+++ b/starlite/utils/sync.py
@@ -41,16 +41,16 @@ def is_async_callable(value: Callable[P, T]) -> TypeGuard[Callable[P, Awaitable[
 
 
 class AsyncCallable(Generic[P, T]):
+    """Wrap a callable into an asynchronous callable."""
+
     __slots__ = ("args", "kwargs", "wrapped_callable", "is_method", "num_expected_args")
 
     def __init__(self, fn: Callable[P, T]) -> None:
-        """Utility class that wraps a callable and ensures it can be called as
-        an async function.
+        """Initialize the wrapper from any callable.
 
         Args:
             fn: Callable to wrap - can be any sync or async callable.
         """
-
         self.is_method = ismethod(fn) or (callable(fn) and ismethod(fn.__call__))  # type: ignore
         self.num_expected_args = len(getfullargspec(fn).args) - (1 if self.is_method else 0)
         self.wrapped_callable = Ref[Callable](fn if is_async_callable(fn) else async_partial(fn))  # pyright: ignore
@@ -69,8 +69,8 @@ class AsyncCallable(Generic[P, T]):
 
 
 def as_async_callable_list(value: Union[Callable, List[Callable]]) -> List[AsyncCallable]:
-    """
-    Helper function to handle wrapping values in AsyncCallables
+    """Wrap callables in `AsyncCallable`s.
+
     Args:
         value: A callable or list of callables.
 
@@ -101,6 +101,8 @@ def async_partial(fn: Callable) -> Callable:
 
 
 class AsyncIteratorWrapper(Generic[T]):
+    """Asynchronous generator, wrapping an iterable or iterator."""
+
     __slots__ = ("iterator", "generator")
 
     def __init__(self, iterator: Union[Iterator[T], Iterable[T]]) -> None:


### PR DESCRIPTION
Part of #776 and makes sure all docstrings pass basic `pydocstyle` tests with the google convention. It also adds `pydocstyle` to pre-commit. 

I will further improve docstrings in a future PR and add some more strict rules. This PR is big enough as is.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
