### PR TITLE
Rework dependencies

### DIFF
--- a/docs/usage/6-dependency-injection/3-the-provide-class.md
+++ b/docs/usage/6-dependency-injection/3-the-provide-class.md
@@ -30,31 +30,4 @@ See the [API Reference][starlite.datastructures.Provide] for full details on the
     If `Provide.use_cache` is true, the return value of the function will be memoized the first time it is called and
     then will be used. There is no sophisticated comparison of kwargs, LRU implementation etc. so you should be careful
     when you choose to use this option.
-
-
-```python
-from starlite import Provide, get
-from random import randint
-
-
-def cached_dependency() -> int:
-    return randint(1, 10)
-
-
-def dependent(first: int) -> int:
-    return first
-
-
-@get(
-    "/some-path",
-    dependencies={
-        "first": Provide(
-            cached_dependency,
-        ),
-        "second": Provide(dependent),
-    },
-)
-def my_handler(first: int, second: int) -> None:
-    assert first == second
-    ...
-```
+    Note that dependencies will only be called once per request, even with `Provide.use_cache` set to false.

--- a/starlite/datastructures/provide.py
+++ b/starlite/datastructures/provide.py
@@ -17,7 +17,6 @@ class Provide:
     __slots__ = (
         "dependency",
         "use_cache",
-        "lock",
         "value",
         "signature_model",
         "sync_to_thread",

--- a/starlite/routes/http.py
+++ b/starlite/routes/http.py
@@ -13,7 +13,6 @@ from starlite.routes.base import BaseRoute
 from starlite.status_codes import HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST
 
 if TYPE_CHECKING:
-
     from starlite.kwargs import KwargsModel
     from starlite.types import ASGIApp, HTTPScope, Method, Receive, Scope, Send
 
@@ -175,10 +174,7 @@ class HTTPRoute(BaseRoute):
             if "data" in kwargs:
                 kwargs["data"] = await kwargs["data"]
 
-            for dependency in parameter_model.expected_dependencies:
-                kwargs[dependency.key] = await parameter_model.resolve_dependency(
-                    dependency=dependency, connection=request, **kwargs
-                )
+            await parameter_model.resolve_dependencies(request, kwargs)
 
             parsed_kwargs = route_handler.signature_model.parse_values_from_connection_kwargs(connection=request, **kwargs)  # type: ignore
 

--- a/starlite/routes/websocket.py
+++ b/starlite/routes/websocket.py
@@ -73,8 +73,5 @@ class WebSocketRoute(BaseRoute):
 
         signature_model = get_signature_model(self.route_handler)
         kwargs = self.handler_parameter_model.to_kwargs(connection=websocket)
-        for dependency in self.handler_parameter_model.expected_dependencies:
-            kwargs[dependency.key] = await self.handler_parameter_model.resolve_dependency(
-                dependency=dependency, connection=websocket, **kwargs
-            )
+        await self.handler_parameter_model.resolve_dependencies(websocket, kwargs)
         return signature_model.parse_values_from_connection_kwargs(connection=websocket, **kwargs)

--- a/tests/dependency_injection/test_request_local_caching.py
+++ b/tests/dependency_injection/test_request_local_caching.py
@@ -1,0 +1,34 @@
+from starlite import Provide, create_test_client, get
+from starlite.status_codes import HTTP_200_OK
+
+
+def test_caching_per_request() -> None:
+    value = 1
+
+    def first_dependency() -> int:
+        nonlocal value
+        tmp = value
+        value += 1
+        return tmp  # noqa: R504
+
+    def second_dependency(first: int) -> int:
+        return first + 5
+
+    @get()
+    def route(first: int, second: int) -> int:
+        return first + second
+
+    with create_test_client(
+        route,
+        dependencies={
+            "first": Provide(first_dependency),
+            "second": Provide(second_dependency),
+        },
+    ) as client:
+        response = client.get("/")
+        assert response.status_code == HTTP_200_OK
+        assert response.content == b"7"  # 1 + 1 + 5
+
+        response2 = client.get("/")
+        assert response2.status_code == HTTP_200_OK
+        assert response2.content == b"9"  # 2 + 2 + 5

--- a/tests/kwargs/test_dependency_batches.py
+++ b/tests/kwargs/test_dependency_batches.py
@@ -1,0 +1,58 @@
+from typing import List, Set
+
+import pytest
+
+from starlite import Provide
+from starlite.kwargs import Dependency, create_dependency_batches
+
+
+def dummy() -> None:
+    pass
+
+
+DEPENDENCY_A = Dependency("A", Provide(dummy), [])
+DEPENDENCY_B = Dependency("B", Provide(dummy), [])
+DEPENDENCY_C1 = Dependency("C1", Provide(dummy), [])
+DEPENDENCY_C2 = Dependency("C2", Provide(dummy), [DEPENDENCY_C1])
+DEPENDENCY_ALL_EXCEPT_A = Dependency("D", Provide(dummy), [DEPENDENCY_B, DEPENDENCY_C1, DEPENDENCY_C2])
+
+
+@pytest.mark.parametrize(
+    "dependency_tree,expected_batches",
+    [
+        (set(), []),
+        ({DEPENDENCY_A}, [{DEPENDENCY_A}]),
+        (
+            {DEPENDENCY_A, DEPENDENCY_B},
+            [
+                {DEPENDENCY_A, DEPENDENCY_B},
+            ],
+        ),
+        (
+            {DEPENDENCY_C1, DEPENDENCY_C2},
+            [
+                {DEPENDENCY_C1},
+                {DEPENDENCY_C2},
+            ],
+        ),
+        (
+            {DEPENDENCY_A, DEPENDENCY_B, DEPENDENCY_C1, DEPENDENCY_C2, DEPENDENCY_ALL_EXCEPT_A},
+            [
+                {DEPENDENCY_A, DEPENDENCY_B, DEPENDENCY_C1},
+                {DEPENDENCY_C2},
+                {DEPENDENCY_ALL_EXCEPT_A},
+            ],
+        ),
+        (
+            {DEPENDENCY_ALL_EXCEPT_A},
+            [
+                {DEPENDENCY_B, DEPENDENCY_C1},
+                {DEPENDENCY_C2},
+                {DEPENDENCY_ALL_EXCEPT_A},
+            ],
+        ),
+    ],
+)
+def test_dependency_batches(dependency_tree: Set[Dependency], expected_batches: List[Set[Dependency]]) -> None:
+    calculated_batches = create_dependency_batches(dependency_tree)
+    assert calculated_batches == expected_batches


### PR DESCRIPTION
Dependencies currently have two problems:
1. They are resolved sequentially
2. They may be resolved multiple times within a single request

In order to solve the first without introducing locks, the resolution algorithm was changed to:
1. Recursively getting a list of all dependencies, with their required sub-dependencies
2. Creating a sequence of dependency batches. The dependencies per batch can run concurrently, but depend on values from the previous batches. Each batch is created by:
  a. Getting all unaccounted for dependencies without remaining sub-dependencies
  b. Removing those dependencies from the list of overall dependencies
  c. Removing them from the remaining sub-dependencies of the other dependencies

This way the following dependency graph will be split into these batches: `(A, B, C), (D, E), (F)`
```
┌─F─┐
│   │
▼   │
D   │   E
│   │   │
▼   ▼   ▼
A   B   C
```
This is done once when the KwargsModel is created. When actually resolving the dependencies, we only need to iterate over the batches and resolve the the dependencies without checking for sub-dependencies. In order to avoid unnecessary overhead we only create the task group when there is more than one dependency per batch.

This also solves the second problem, all dependencies are only called once per request. If in the above graph F were to also require A or C, nothing would change. If E were to require D, it would only move to F's batch.

# PR Checklist

- [X] Have you followed the guidelines in `CONTRIBUTING.md`?
- [X] Have you got 100% test coverage on new code?
- [X] Have you updated the prose documentation?
- [X] Have you updated the reference documentation?
