### PR TITLE
Support iterable headers in the scope/message

### DIFF
--- a/starlite/datastructures/headers.py
+++ b/starlite/datastructures/headers.py
@@ -183,7 +183,7 @@ class MutableScopeHeaders(MutableMapping):
         """
         existing = self.get(key)
         if existing is not None:
-            value = ", ".join([*existing.split(","), value])
+            value = ",".join([*existing.split(","), value])
         self[key] = value
 
     def __getitem__(self, key: str) -> str:

--- a/starlite/testing/test_client/websocket_test_session.py
+++ b/starlite/testing/test_client/websocket_test_session.py
@@ -76,7 +76,9 @@ class WebSocketTestSession:
             if message["type"] == "websocket.accept":
                 headers = message.get("headers", [])
                 if headers:
-                    self.scope["headers"].extend(headers)
+                    headers_list = list(self.scope["headers"])
+                    headers_list.extend(headers)
+                    self.scope["headers"] = headers_list
                 subprotocols = cast("Optional[str]", message.get("subprotocols"))
                 if subprotocols:
                     self.scope["subprotocols"].append(subprotocols)

--- a/starlite/types/asgi_types.py
+++ b/starlite/types/asgi_types.py
@@ -35,6 +35,7 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
+    Iterable,
     List,
     Literal,
     Optional,
@@ -68,7 +69,7 @@ class ASGIVersion(TypedDict):
 class HeaderScope(TypedDict):
     """Base class for ASGI-scopes that supports headers."""
 
-    headers: "RawHeadersList"
+    headers: "RawHeaders"
 
 
 class BaseScope(HeaderScope):
@@ -288,4 +289,5 @@ Scope = Union[HTTPScope, WebSocketScope]
 Receive = Callable[..., Awaitable[Union[HTTPReceiveMessage, WebSocketReceiveMessage]]]
 Send = Callable[[Message], Awaitable[None]]
 ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+RawHeaders = Iterable[Tuple[bytes, bytes]]
 RawHeadersList = List[Tuple[bytes, bytes]]

--- a/tests/datastructures/test_headers.py
+++ b/tests/datastructures/test_headers.py
@@ -143,14 +143,14 @@ def test_mutable_scope_headers_extend_header_value(
     raw_headers: "RawHeadersList", mutable_headers: MutableScopeHeaders
 ) -> None:
     mutable_headers.extend_header_value("foo", "baz")
-    assert raw_headers == [(b"foo", b"bar, baz")]
+    assert raw_headers == [(b"foo", b"bar,baz")]
 
 
 def test_mutable_scope_headers_from_tuple_extend_header_value(
     raw_headers_tuple: "RawHeaders", mutable_headers_from_tuple: MutableScopeHeaders
 ) -> None:
     mutable_headers_from_tuple.extend_header_value("foo", "baz")
-    assert list(raw_headers_tuple) == [(b"foo", b"bar, baz")]
+    assert list(raw_headers_tuple) == [(b"foo", b"bar,baz")]
 
 
 def test_mutable_scope_headers_extend_header_value_new_header(

--- a/tests/datastructures/test_headers.py
+++ b/tests/datastructures/test_headers.py
@@ -14,7 +14,7 @@ from starlite.exceptions import ImproperlyConfiguredException
 from starlite.types.asgi_types import HTTPResponseBodyEvent, HTTPResponseStartEvent
 
 if TYPE_CHECKING:
-    from starlite.types.asgi_types import RawHeadersList
+    from starlite.types.asgi_types import RawHeaders, RawHeadersList
 
 
 @pytest.fixture
@@ -23,8 +23,18 @@ def raw_headers() -> "RawHeadersList":
 
 
 @pytest.fixture
+def raw_headers_tuple() -> "RawHeaders":
+    return [(b"foo", b"bar")]
+
+
+@pytest.fixture
 def mutable_headers(raw_headers: "RawHeadersList") -> MutableScopeHeaders:
     return MutableScopeHeaders({"headers": raw_headers})
+
+
+@pytest.fixture
+def mutable_headers_from_tuple(raw_headers_tuple: "RawHeaders") -> MutableScopeHeaders:
+    return MutableScopeHeaders({"headers": raw_headers_tuple})
 
 
 @pytest.fixture(params=[True, False])
@@ -43,9 +53,19 @@ def test_headers_from_raw_list() -> None:
     assert headers.getall("foo") == ["bar", "baz"]
 
 
-def test_headers_from_scope(raw_headers: "RawHeadersList") -> None:
+def test_headers_from_raw_tuple() -> None:
+    headers = Headers(((b"foo", b"bar"), (b"foo", b"baz")))
+    assert headers.getall("foo") == ["bar", "baz"]
+
+
+def test_headers_from_scope() -> None:
     headers = Headers.from_scope(
         HTTPResponseStartEvent(type="http.response.start", status=200, headers=[(b"foo", b"bar"), (b"foo", b"baz")])
+    )
+    assert headers.getall("foo") == ["bar", "baz"]
+
+    headers = Headers.from_scope(
+        HTTPResponseStartEvent(type="http.response.start", status=200, headers=((b"foo", b"bar"), (b"foo", b"baz")))
     )
     assert headers.getall("foo") == ["bar", "baz"]
 
@@ -56,11 +76,22 @@ def test_headers_to_header_list() -> None:
     assert headers.to_header_list() == raw
 
 
-def test_mutable_scope_headers_from_message(raw_headers: "RawHeadersList") -> None:
+def test_headers_tuple_to_header_list() -> None:
+    raw = ((b"foo", b"bar"), (b"foo", b"baz"))
+    headers = Headers(raw)
+    assert headers.to_header_list() == list(raw)
+
+
+def test_mutable_scope_headers_from_message(raw_headers: "RawHeadersList", raw_headers_tuple: "RawHeaders") -> None:
     headers = MutableScopeHeaders.from_message(
         HTTPResponseStartEvent(type="http.response.start", status=200, headers=raw_headers)
     )
     assert headers.headers == raw_headers
+
+    headers = MutableScopeHeaders.from_message(
+        HTTPResponseStartEvent(type="http.response.start", status=200, headers=raw_headers_tuple)
+    )
+    assert headers.headers == list(raw_headers_tuple)
 
 
 def test_mutable_scope_headers_from_message_invalid_type() -> None:
@@ -75,16 +106,27 @@ def test_mutable_scope_headers_add(
     assert raw_headers == [(b"foo", b"bar"), (b"foo", b"baz")]
 
 
+def test_mutable_scope_headers_from_tuple_add(
+    raw_headers_tuple: "RawHeaders", mutable_headers_from_tuple: MutableScopeHeaders, existing_headers_key: str
+) -> None:
+    mutable_headers_from_tuple.add(existing_headers_key, "baz")
+    assert list(raw_headers_tuple) == [(b"foo", b"bar"), (b"foo", b"baz")]
+
+
 def test_mutable_scope_headers_getall_singular_value(
-    raw_headers: "RawHeadersList", mutable_headers: MutableScopeHeaders, existing_headers_key: str
+    mutable_headers: MutableScopeHeaders, mutable_headers_from_tuple: MutableScopeHeaders, existing_headers_key: str
 ) -> None:
     assert mutable_headers.getall(existing_headers_key) == ["bar"]
+    assert mutable_headers_from_tuple.getall(existing_headers_key) == ["bar"]
 
 
 def test_mutable_scope_headers_getall_multi_value(
-    raw_headers: "RawHeadersList", mutable_headers: MutableScopeHeaders, existing_headers_key: str
+    mutable_headers: MutableScopeHeaders, mutable_headers_from_tuple: MutableScopeHeaders, existing_headers_key: str
 ) -> None:
     mutable_headers.add(existing_headers_key, "baz")
+    assert mutable_headers.getall("foo") == ["bar", "baz"]
+
+    mutable_headers_from_tuple.add(existing_headers_key, "baz")
     assert mutable_headers.getall("foo") == ["bar", "baz"]
 
 
@@ -104,11 +146,25 @@ def test_mutable_scope_headers_extend_header_value(
     assert raw_headers == [(b"foo", b"bar, baz")]
 
 
+def test_mutable_scope_headers_from_tuple_extend_header_value(
+    raw_headers_tuple: "RawHeaders", mutable_headers_from_tuple: MutableScopeHeaders
+) -> None:
+    mutable_headers_from_tuple.extend_header_value("foo", "baz")
+    assert list(raw_headers_tuple) == [(b"foo", b"bar, baz")]
+
+
 def test_mutable_scope_headers_extend_header_value_new_header(
     raw_headers: "RawHeadersList", mutable_headers: MutableScopeHeaders
 ) -> None:
     mutable_headers.extend_header_value("bar", "baz")
     assert raw_headers == [(b"foo", b"bar"), (b"bar", b"baz")]
+
+
+def test_mutable_scope_headers_from_tuple_extend_header_value_new_header(
+    raw_headers_tuple: "RawHeaders", mutable_headers_from_tuple: MutableScopeHeaders
+) -> None:
+    mutable_headers_from_tuple.extend_header_value("bar", "baz")
+    assert list(raw_headers_tuple) == [(b"foo", b"bar"), (b"bar", b"baz")]
 
 
 def test_mutable_scope_headers_getitem(mutable_headers: MutableScopeHeaders, existing_headers_key: str) -> None:
@@ -125,6 +181,13 @@ def test_mutable_scope_headers_setitem_existing_key(
 ) -> None:
     mutable_headers[existing_headers_key] = "baz"
     assert raw_headers == [(b"foo", b"baz")]
+
+
+def test_mutable_scope_headers_from_tuple_setitem_existing_key(
+    raw_headers_tuple: "RawHeaders", mutable_headers_from_tuple: MutableScopeHeaders, existing_headers_key: str
+) -> None:
+    mutable_headers_from_tuple[existing_headers_key] = "baz"
+    assert list(raw_headers_tuple) == [(b"foo", b"baz")]
 
 
 def test_mutable_scope_headers_setitem_new_key(


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

Our code assumed that `headers` in `scope` and `message` will be `List[Tuple[byte, byte]]` while the [spec says](https://asgi.readthedocs.io/en/latest/specs/www.html#http-connection-scope) it should be an `iterable`. asgiref typing follows the spec - https://github.com/django/asgiref/blob/main/asgiref/typing.py#L62 so we should do the same.
In this PR I change typing and make sure we can process not only lists but iterables.

Tests use a tuple as alternative because judging by the source of dozens of ASGI apps people either throw a list or a tuple.

This PR closes #813 