### PR TITLE
Allow subclasses of `State`

### DIFF
--- a/docs/reference/config/0-app-config.md
+++ b/docs/reference/config/0-app-config.md
@@ -37,6 +37,7 @@
             - response_headers
             - route_handlers
             - security
+            - state_class
             - static_files_config
             - tags
             - template_config

--- a/examples/using_application_state.py
+++ b/examples/using_application_state.py
@@ -9,7 +9,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def set_state_on_startup(state: State) -> None:
+class AppState(State):
+    value: str
+
+
+def set_state_on_startup(state: AppState) -> None:
     """Startup and shutdown hooks can receive `State` as a keyword arg."""
     state.value = "abc123"
 
@@ -25,7 +29,7 @@ def middleware_factory(*, app: "ASGIApp") -> "ASGIApp":
     return my_middleware
 
 
-def my_dependency(state: State) -> Any:
+def my_dependency(state: AppState) -> Any:
     """Dependencies can receive state via injection."""
     logger.info("state value in dependency: %s", state.value)
 
@@ -37,4 +41,4 @@ def get_handler(state: State, request: Request, dep: Any) -> None:  # pylint: di
     logger.info("state value in handler from `Request`: %s", request.app.state.value)
 
 
-starlite = Starlite(route_handlers=[get_handler], on_startup=[set_state_on_startup], debug=True)
+starlite = Starlite(route_handlers=[get_handler], on_startup=[set_state_on_startup], state_class=AppState, debug=True)

--- a/starlite/config/app.py
+++ b/starlite/config/app.py
@@ -23,6 +23,7 @@ from starlite.types import (
     ResponseHeadersMap,
     ResponseType,
     SingleOrList,
+    StateType,
 )
 
 from . import AllowedHostsConfig
@@ -198,6 +199,10 @@ class AppConfig(BaseModel):
     """
     A list of dictionaries that will be added to the schema of all route handlers in the application. See
     [SecurityRequirement][pydantic_openapi_schema.v3_1_0.security_requirement.SecurityRequirement] for details.
+    """
+    state_class: Optional[StateType]
+    """
+    A custom subclass of [starlite.datastructures.State] to be used as the app's default state.
     """
     static_files_config: SingleOrList[StaticFilesConfig]
     """

--- a/starlite/types/__init__.py
+++ b/starlite/types/__init__.py
@@ -76,6 +76,7 @@ from .internal_types import (
     ResponseType,
     RouteHandlerMapItem,
     RouteHandlerType,
+    StateType,
 )
 from .partial import Partial
 from .protocols import Logger
@@ -156,6 +157,7 @@ __all__ = (
     "Send",
     "Serializer",
     "SingleOrList",
+    "StateType",
     "SyncOrAsyncUnion",
     "WebSocketAcceptEvent",
     "WebSocketCloseEvent",

--- a/starlite/types/callable_types.py
+++ b/starlite/types/callable_types.py
@@ -22,8 +22,9 @@ else:
     Logger = Any
 
 _ExceptionT = TypeVar("_ExceptionT", bound=Exception)
+_StateT = TypeVar("_StateT", bound=State)
 
-AfterExceptionHookHandler = Callable[[Exception, Scope, State], SyncOrAsyncUnion[None]]
+AfterExceptionHookHandler = Callable[[Exception, Scope, _StateT], SyncOrAsyncUnion[None]]
 AfterRequestHookHandler = Union[
     Callable[[ASGIApp], SyncOrAsyncUnion[ASGIApp]], Callable[[Response], SyncOrAsyncUnion[Response]]
 ]
@@ -31,7 +32,7 @@ AfterResponseHookHandler = Callable[[Request], SyncOrAsyncUnion[None]]
 AsyncAnyCallable = Callable[..., Awaitable[Any]]
 AnyCallable = Callable[..., Any]
 BeforeMessageSendHookHandler = Union[
-    Callable[[Message, State, Scope], SyncOrAsyncUnion[None]], Callable[[Message, State], SyncOrAsyncUnion[None]]
+    Callable[[Message, _StateT, Scope], SyncOrAsyncUnion[None]], Callable[[Message, _StateT], SyncOrAsyncUnion[None]]
 ]
 BeforeRequestHookHandler = Callable[[Request], Union[Any, Awaitable[Any]]]
 CacheKeyBuilder = Callable[[Request], str]
@@ -40,7 +41,7 @@ Guard = Union[
     Callable[[Request, HTTPRouteHandler], SyncOrAsyncUnion[None]],
     Callable[[WebSocket, WebsocketRouteHandler], SyncOrAsyncUnion[None]],
 ]
-LifeSpanHandler = Union[Callable[[], SyncOrAsyncUnion[Any]], Callable[[State], SyncOrAsyncUnion[Any]]]
+LifeSpanHandler = Union[Callable[[], SyncOrAsyncUnion[Any]], Callable[[_StateT], SyncOrAsyncUnion[Any]]]
 LifeSpanHookHandler = Callable[[StarliteType], SyncOrAsyncUnion[None]]
 OnAppInitHandler = Callable[[AppConfig], AppConfig]
 Serializer = Callable[[Any], Any]

--- a/starlite/types/internal_types.py
+++ b/starlite/types/internal_types.py
@@ -5,6 +5,7 @@ from starlite.types import Method
 if TYPE_CHECKING:
     from starlite.app import Starlite  # noqa: TC004
     from starlite.controller import Controller  # noqa: TC004
+    from starlite.datastructures import State  # noqa: TC004
     from starlite.handlers.asgi import ASGIRouteHandler  # noqa: TC004
     from starlite.handlers.http import HTTPRouteHandler  # noqa: TC004
     from starlite.handlers.websocket import WebsocketRouteHandler  # noqa: TC004
@@ -18,6 +19,7 @@ else:
     Response = Any
     Controller = Any
     Router = Any
+    State = Any
 
 ReservedKwargs = Literal["request", "socket", "headers", "query", "cookies", "state", "data"]
 StarliteType = Starlite
@@ -25,6 +27,7 @@ RouteHandlerType = Union[HTTPRouteHandler, WebsocketRouteHandler, ASGIRouteHandl
 ResponseType = Type[Response]
 ControllerRouterHandler = Union[Type[Controller], RouteHandlerType, Router, Callable[..., Any]]
 RouteHandlerMapItem = Union[WebsocketRouteHandler, ASGIRouteHandler, Dict[Method, HTTPRouteHandler]]
+StateType = Type[State]
 
 
 class PathParameterDefinition(NamedTuple):

--- a/tests/app/test_app_config.py
+++ b/tests/app/test_app_config.py
@@ -44,6 +44,7 @@ def app_config_object() -> AppConfig:
         response_headers={},
         route_handlers=[],
         security=[],
+        state_class=None,
         static_files_config=[],
         tags=[],
         template_config=None,

--- a/tests/datastructures/test_state.py
+++ b/tests/datastructures/test_state.py
@@ -1,5 +1,6 @@
 import pytest
 
+from starlite.app import Starlite
 from starlite.datastructures import State
 
 
@@ -43,3 +44,19 @@ def test_state_copy() -> None:
     copy = state.copy()
     del state.key
     assert copy.key
+
+
+def test_state_subclass() -> None:
+    class CustomState(State):
+        called: bool
+        msg: str
+
+    def startup(state: CustomState) -> None:
+        assert type(state) is not State
+        assert isinstance(state, State)
+
+    Starlite(
+        on_startup=[startup],
+        route_handlers=[],
+        state_class=CustomState,
+    )


### PR DESCRIPTION
Allow subclasses of `State`

* Add optional `state_class` argument to `starlite.app.Starlite` and `starlite.config.AppConfig` which allows the user to pass a custom subclass of `starlite.datastructures.State` to be used by the Starlite.

* Add `_StateT` TypeVar to `starlite/types/callable_types.py` and `starlite/plugins/sql_alchemy/config.py` to keep type checking happy when subclasses of State are used.

* Update `examples/using_application_state.py` to use a typed subclass of State.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
