### PR TITLE
fix: parsing of sequence query for nested dependency.

### DIFF
--- a/starlite/kwargs.py
+++ b/starlite/kwargs.py
@@ -379,9 +379,7 @@ class KwargsModel:
         expected_header_parameters = {p for p in param_definitions if p.param_type == ParamType.HEADER}
         expected_cookie_parameters = {p for p in param_definitions if p.param_type == ParamType.COOKIE}
         expected_query_parameters = {p for p in param_definitions if p.param_type == ParamType.QUERY}
-        sequence_query_parameter_names = {
-            p.field_alias for p in param_definitions if p.param_type == ParamType.QUERY and p.is_sequence
-        }
+        sequence_query_parameter_names = {p.field_alias for p in expected_query_parameters if p.is_sequence}
 
         expected_form_data = None
         data_model_field = signature_model.__fields__.get("data")
@@ -418,6 +416,7 @@ class KwargsModel:
                     dependency_kwargs_model=dependency_kwargs_model,
                 )
             expected_reserved_kwargs.update(dependency_kwargs_model.expected_reserved_kwargs)
+            sequence_query_parameter_names.update(dependency_kwargs_model.sequence_query_parameter_names)
 
         return KwargsModel(
             expected_form_data=expected_form_data,  # pyright: ignore


### PR DESCRIPTION
Updates `sequence_query_parameter_names` of the kwargs model with the values of same from dependencies.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
