### PR TITLE
Fix #841 - Change `middleware.session.sqlalchemy_backend.SessionModelMixin.data` to LargeBinary.

### DIFF
--- a/starlite/middleware/session/sqlalchemy_backend.py
+++ b/starlite/middleware/session/sqlalchemy_backend.py
@@ -31,7 +31,7 @@ class SessionModelMixin:
     """Mixin for session storage."""
 
     session_id: Mapped[str] = sa.Column(sa.String, nullable=False, unique=True, index=True)  # pyright: ignore
-    data: Mapped[bytes] = sa.Column(sa.BLOB, nullable=False)  # pyright: ignore
+    data: Mapped[bytes] = sa.Column(sa.LargeBinary, nullable=False)  # pyright: ignore
     expires: Mapped[datetime] = sa.Column(sa.DateTime, nullable=False)  # pyright: ignore
 
     @hybrid_property


### PR DESCRIPTION
The previously used `BLOB` did not render correctly for a database drivers. `LargeBinary` renders as the appropriate binary column type for each driver.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
