### PR TITLE
Fix #840 - Always commit changes properly after deleting session data

### DIFF
--- a/starlite/middleware/session/sqlalchemy_backend.py
+++ b/starlite/middleware/session/sqlalchemy_backend.py
@@ -199,6 +199,7 @@ class AsyncSQLAlchemyBackend(BaseSQLAlchemyBackend[AsyncSASession]):
         """
         async with self._create_sa_session() as sa_session:
             await sa_session.execute(sa.delete(self._model).where(self._model.expired))
+            await sa_session.commit()
 
 
 class SQLAlchemyBackend(BaseSQLAlchemyBackend[SASession]):
@@ -290,6 +291,7 @@ class SQLAlchemyBackend(BaseSQLAlchemyBackend[SASession]):
     def _delete_expired_sync(self) -> None:
         sa_session = self._create_sa_session()
         sa_session.execute(sa.delete(self._model).where(self._model.expired))
+        sa_session.commit()
 
     async def delete_expired(self) -> None:
         """Delete all expired session from the database.


### PR DESCRIPTION
Fixes #840

Some deletion methods didn't `commit()` properly, which lead to changes sometimes not being persisted.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
