### PR TITLE
refixing the mobile navbar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,8 +39,8 @@ extra_css:
   - css/typo.css
   - css/color.css
 nav:
+  - index.md
   - Starlite:
-    - Intro: index.md
     - benchmarks.md
     - governance.md
     - contributing.md


### PR DESCRIPTION
The issue #420 mentioned that needing to press the back arrow to access top top level menu on mobile wasn't the wanted behavior. It's been fixed by #433 but reintroduced by #866 

Not sure if you want to keep Starlite or go back to Overview  since it forces to pulls out the index (Intro in the navbar)
