### PR TITLE
Fix path to example files in the docs

### DIFF
--- a/docs/usage/5-responses/4-response-headers.md
+++ b/docs/usage/5-responses/4-response-headers.md
@@ -5,7 +5,7 @@ available on all layers of the app - individual route handlers, controllers, rou
 itself:
 
 ```py
---8<-- "examples/responses/response_headers.py"
+--8<-- "examples/responses/response_headers_1.py"
 ```
 
 In the above example the response returned from `my_route_handler` will have headers set from each layer of the

--- a/docs/usage/5-responses/5-response-cookies.md
+++ b/docs/usage/5-responses/5-response-cookies.md
@@ -5,7 +5,7 @@ available on all layers of the app - individual route handlers, controllers, rou
 itself:
 
 ```py
---8<-- "examples/response_cookies_1.py"
+--8<-- "examples/responses/response_cookies_1.py"
 ```
 
 In the above example, the response returned by `my_route_handler` will have cookies set by each layer of the
@@ -24,7 +24,7 @@ You can easily override cookies declared in higher levels by re-declaring a cook
 e.g.:
 
 ```py
---8<-- "examples/responses/response_cookies.py"
+--8<-- "examples/responses/response_cookies_2.py"
 ```
 
 Of the two declarations of `my-cookie` only the route handler one will be used, because its lower level:
@@ -50,7 +50,7 @@ We can simply return a response instance directly from the route handler and set
 as you see fit, e.g.:
 
 ```py
---8<-- "examples/response_cookies_3.py"
+--8<-- "examples/responses/response_cookies_3.py"
 ```
 
 In the above we use the `response_cookies` kwarg to pass the `key` and `description` parameters for the `Random-Header`
@@ -65,7 +65,7 @@ the handler on different layers of the application as explained in the pertinent
 the cookies on the corresponding layer:
 
 ```py
---8<-- "examples/response_cookies_4.py"
+--8<-- "examples/responses/response_cookies_4.py"
 ```
 
 In the above we set the cookie using an `after_request_handler` function on the router level. Because the
@@ -76,5 +76,5 @@ required. For example, lets say we have a router level cookie being set and a lo
 different value range:
 
 ```py
---8<-- "examples/response_cookies_5.py"
+--8<-- "examples/responses/response_cookies_5.py"
 ```


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

In the recent docs update (#798) some paths contained typos so at the moment our docs look like this
![image](https://user-images.githubusercontent.com/153191/204734548-e9b3dbe5-6d11-4951-ad9c-986cfb3b0441.png)

Here I simply fix typos