### PR TITLE
Fix #899 - Generator based dependencies with cached responses

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -173,7 +173,7 @@ repos:
             types-redis,
           ]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.281
+    rev: v1.1.282
     hooks:
       - id: pyright
         additional_dependencies:

--- a/starlite/datastructures/provide.py
+++ b/starlite/datastructures/provide.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from inspect import Traceback
 
     from starlite.signature import SignatureModel
-    from starlite.types import AnyCallable, AnyGenerator, ASGIApp, Receive, Scope, Send
+    from starlite.types import AnyCallable, AnyGenerator
 
 
 class Provide:
@@ -154,22 +154,6 @@ class DependencyCleanupGroup:
         async with create_task_group() as task_group:
             for generator in self._generators:
                 task_group.start_soon(self._wrap_next(generator))
-
-    def wrap_asgi(self, app: "ASGIApp") -> "ASGIApp":
-        """Wrap an ASGI callable such that all generators will be called before it.
-
-        Args:
-            app: An ASGI callable
-
-        Returns:
-            An ASGI callable
-        """
-
-        async def wrapped(scope: "Scope", receive: "Receive", send: "Send") -> None:
-            await self.cleanup()
-            await app(scope, receive, send)
-
-        return wrapped
 
     async def __aenter__(self) -> None:
         """Support the async contextmanager protocol to allow for easier catching and throwing of exceptions into the

--- a/starlite/routes/http.py
+++ b/starlite/routes/http.py
@@ -163,10 +163,11 @@ class HTTPRoute(BaseRoute):
                 plugins=request.app.plugins,
                 request=request,
             )
-        if cleanup_group:
-            return cleanup_group.wrap_asgi(response)
 
-        return response
+        if cleanup_group:
+            await cleanup_group.cleanup()
+
+        return response  # noqa: R504
 
     @staticmethod
     async def _get_response_data(

--- a/tests/kwargs/test_generator_dependencies.py
+++ b/tests/kwargs/test_generator_dependencies.py
@@ -54,8 +54,10 @@ def async_generator_dependency(
     return dependency
 
 
+@pytest.mark.parametrize("cache", [False, True])
 @pytest.mark.parametrize("dependency_fixture", ["generator_dependency", "async_generator_dependency"])
 def test_generator_dependency(
+    cache: bool,
     request: FixtureRequest,
     dependency_fixture: str,
     cleanup_mock: MagicMock,
@@ -64,7 +66,7 @@ def test_generator_dependency(
 ) -> None:
     dependency = request.getfixturevalue(dependency_fixture)
 
-    @get("/", dependencies={"dep": Provide(dependency)})
+    @get("/", dependencies={"dep": Provide(dependency)}, cache=cache)
     def handler(dep: str) -> Dict[str, str]:
         return {"value": dep}
 


### PR DESCRIPTION
Fix #899 by not wrapping the response but instead calling the cleanup after all response processing is done. This maintains the current order of execution.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
