### PR TITLE
Fix issue with OpenAPI Controller and ASGI root_path

### DIFF
--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -139,10 +139,13 @@ class OpenAPIController(Controller):
         if not request.app.openapi_config:  # pragma: no cover
             raise ImproperlyConfiguredException("Starlite has not been instantiated with an OpenAPIConfig")
 
-        request_path = set(filter(None, request.url.path.split("/")))
+        asgi_root_path = set(filter(None, request.scope.get("root_path", "").split("/")))
+        full_request_path = set(filter(None, request.url.path.split("/")))
+        request_path = full_request_path.difference(asgi_root_path)
         root_path = set(filter(None, self.path.split("/")))
 
         config = request.app.openapi_config
+
         if request_path == root_path and config.root_schema_site in config.enabled_endpoints:
             return True
 

--- a/tests/openapi/test_controller.py
+++ b/tests/openapi/test_controller.py
@@ -1,3 +1,7 @@
+from typing import List
+
+import pytest
+
 from starlite import OpenAPIConfig
 from starlite.app import DEFAULT_OPENAPI_CONFIG
 from starlite.enums import MediaType
@@ -5,6 +9,8 @@ from starlite.openapi.controller import OpenAPIController
 from starlite.status_codes import HTTP_200_OK, HTTP_404_NOT_FOUND
 from starlite.testing import create_test_client
 from tests.openapi.utils import PersonController, PetController
+
+root_paths: List[str] = ["", "/part1", "/part1/part2"]
 
 
 def test_default_redoc_cdn_urls() -> None:
@@ -117,29 +123,41 @@ def test_openapi_stoplight_elements_offline() -> None:
         assert OfflineOpenAPIController.stoplight_elements_js_url in response.text
 
 
-def test_openapi_root() -> None:
-    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+@pytest.mark.parametrize("root_path", root_paths)
+def test_openapi_root(root_path: str) -> None:
+    with create_test_client(
+        [PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
+    ) as client:
         response = client.get("/schema")
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"].startswith(MediaType.HTML.value)
 
 
-def test_openapi_redoc() -> None:
-    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+@pytest.mark.parametrize("root_path", root_paths)
+def test_openapi_redoc(root_path: str) -> None:
+    with create_test_client(
+        [PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
+    ) as client:
         response = client.get("/schema/redoc")
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"].startswith(MediaType.HTML.value)
 
 
-def test_openapi_swagger() -> None:
-    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+@pytest.mark.parametrize("root_path", root_paths)
+def test_openapi_swagger(root_path: str) -> None:
+    with create_test_client(
+        [PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
+    ) as client:
         response = client.get("/schema/swagger")
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"].startswith(MediaType.HTML.value)
 
 
-def test_openapi_stoplight_elements() -> None:
-    with create_test_client([PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG) as client:
+@pytest.mark.parametrize("root_path", root_paths)
+def test_openapi_stoplight_elements(root_path: str) -> None:
+    with create_test_client(
+        [PersonController, PetController], openapi_config=DEFAULT_OPENAPI_CONFIG, root_path=root_path
+    ) as client:
         response = client.get("/schema/elements/")
         assert response.status_code == HTTP_200_OK
         assert response.headers["content-type"].startswith(MediaType.HTML.value)


### PR DESCRIPTION
# PR Checklist

- [X] Have you followed the guidelines in `CONTRIBUTING.md`?
- [X] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

I was testing a _Starlite_ app with _uvicorn_'s _--root-path_ option, and found (what appears to be) a bug.

`OpenAPIController` compares `request.url.path` to the path given by the client to determine if the request is asking for something openapi-related but `request.url.path` can have an ASGI _root_path_ prepended to it if it is given. This was causing all openapi routes to throw a 404.

I think I found an elegant solution to address this issue.

Cheers!
Kyle