### PR TITLE
Minor docs update

### DIFF
--- a/docs/usage/0-the-starlite-app/2-using-application-state.md
+++ b/docs/usage/0-the-starlite-app/2-using-application-state.md
@@ -33,7 +33,7 @@ Starlite constructor:
 
 !!! note
     The `initial_state` can be a dictionary, an instance of [`ImmutableState`][starlite.datastructures.ImmutableState]
-    or [`tate`][starlite.datastructures.ImmutableState], or a list of tuples containing key/value pairs.
+    or [`State`][starlite.datastructures.State], or a list of tuples containing key/value pairs.
 
 !!! important
     Any value passed to `initial_state` will be deep copied - to prevent mutation from outside the application context.

--- a/docs/usage/1-routing/0-routing.md
+++ b/docs/usage/1-routing/0-routing.md
@@ -1,7 +1,6 @@
 # Routing
 
-Although Starlite builds on the Starlette ASGI toolkit as a basis, it does not use the Starlette routing system,
-which uses regex matching, and instead it implements its own solution that is based on the concept of a
+Starlite implements its routing solution that is based on the concept of a
 [radix tree](https://en.wikipedia.org/wiki/Radix_tree) or `trie`.
 
 ## Why Radix Based Routing?


### PR DESCRIPTION
Following changes to documentation
- Removes a reference to Starlette in the ["Routing" section](https://starlite-api.github.io/starlite/usage/1-routing/0-routing/) as Starlite is no longer dependant on Starlette.
- Fixes a typo and links to the correct class in ["Note" section](https://starlite-api.github.io/starlite/usage/0-the-starlite-app/2-using-application-state/)

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
