### PR TITLE
fix TestClient handling of escapted ampersands in query params

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
         args: [--config=./pyproject.toml]

--- a/starlite/testing/test_client/transport.py
+++ b/starlite/testing/test_client/transport.py
@@ -106,7 +106,7 @@ class TestClientTransport(BaseTransport):
         netloc = unquote(request.url.netloc.decode(encoding="ascii"))
         path = request.url.path
         raw_path = request.url.raw_path
-        query = unquote(request.url.query.decode(encoding="ascii"))
+        query = request.url.query.decode(encoding="ascii")
         default_port = 433 if scheme in {"https", "wss"} else 80
 
         if ":" in netloc:


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
