### PR TITLE
feat: make SignatureModel inherit error_msg_templates

### DIFF
--- a/starlite/signature.py
+++ b/starlite/signature.py
@@ -355,7 +355,10 @@ class SignatureModelFactory:
                 self.field_definitions[parameter.name] = self.create_field_definition_from_parameter(parameter)
 
                 if is_class_and_subclass(parameter.annotation, BaseModel):
-                    error_msg_templates = getattr(parameter.annotation.Config, "error_msg_templates", {})
+                    error_msg_templates = {
+                        **error_msg_templates,
+                        **getattr(parameter.annotation.Config, "error_msg_templates", {}),
+                    }
 
             signature_model = SignatureModel.create_with_error_msg_templates(error_msg_templates or {})
             model: Type[SignatureModel] = create_model(


### PR DESCRIPTION
Make `SignatureModel` inherit `error_msg_templates` from parameter annotation.

Since pydantic does not support nested error messages, starlite users can not leverage error message templates because every parameter becomes a field of `SignatureModel`. 

This PR makes pydantic's `error_msg_template` work. But if there is duplicate `error_msg_templates` key then last parameter's `error_msg_template` will be used.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

