### PR TITLE
fix: make SessionAuth openapi_schema use backend_config.key

### DIFF
--- a/starlite/security/session_auth/auth.py
+++ b/starlite/security/session_auth/auth.py
@@ -82,7 +82,7 @@ class SessionAuth(Generic[UserType], AbstractSecurityConfig[UserType, Dict[str, 
             securitySchemes={
                 "sessionCookie": SecurityScheme(
                     type="apiKey",
-                    name="Set-Cookie",
+                    name=self.session_backend_config.key,
                     security_scheme_in="cookie",
                     description="Session cookie authentication.",
                 )

--- a/tests/security/test_security.py
+++ b/tests/security/test_security.py
@@ -72,7 +72,7 @@ def test_abstract_security_config_registers_route_handlers() -> None:
                     "sessionCookie": {
                         "type": "apiKey",
                         "description": "Session cookie authentication.",
-                        "name": "Set-Cookie",
+                        "name": "session",
                         "security_scheme_in": "cookie",
                     }
                 }
@@ -101,7 +101,7 @@ def test_abstract_security_config_registers_route_handlers() -> None:
                     "sessionCookie": {
                         "type": "apiKey",
                         "description": "Session cookie authentication.",
-                        "name": "Set-Cookie",
+                        "name": "session",
                         "security_scheme_in": "cookie",
                     },
                 }
@@ -127,7 +127,7 @@ def test_abstract_security_config_registers_route_handlers() -> None:
                     "sessionCookie": {
                         "type": "apiKey",
                         "description": "Session cookie authentication.",
-                        "name": "Set-Cookie",
+                        "name": "session",
                         "security_scheme_in": "cookie",
                     },
                     "app": {"type": "http", "description": "test.", "name": "test", "security_scheme_in": "cookie"},

--- a/tests/security/test_session_auth.py
+++ b/tests/security/test_session_auth.py
@@ -67,9 +67,10 @@ def test_authentication() -> None:
 
 
 def test_session_auth_openapi() -> None:
+    backend_config = MemoryBackendConfig()
     session_auth = SessionAuth[Any](
         retrieve_user_handler=retrieve_user_handler,
-        session_backend_config=MemoryBackendConfig(),
+        session_backend_config=backend_config,
     )
     app = Starlite(route_handlers=[], on_app_init=[session_auth.on_app_init])
     assert app.openapi_schema.dict(exclude_none=True) == {  # type: ignore
@@ -82,7 +83,7 @@ def test_session_auth_openapi() -> None:
                 "sessionCookie": {
                     "type": "apiKey",
                     "description": "Session cookie authentication.",
-                    "name": "Set-Cookie",
+                    "name": backend_config.key,
                     "security_scheme_in": "cookie",
                 }
             }


### PR DESCRIPTION
When SessionAuth is implemented in project open api security scheme cookie key is generated as `Set-Cookie`. 

This PR makes cookie name as user-defined cookie key.

<details>
<summary>Starlite 1.45.1 samples</summary>

>  Swagger
> <img width="230" alt="Swagger" src="https://user-images.githubusercontent.com/16171942/207762768-a8a81767-bb51-463c-bb79-d4d411b1ffde.png">

> Redoc
> <img width="262" alt="스크린샷 2022-12-15 오후 12 03 14" src="https://user-images.githubusercontent.com/16171942/207762709-52b17b7b-2297-45c4-abf9-bc7d5f506c76.png">

> Element 
> <img width="782" alt="스크린샷 2022-12-15 오후 12 02 40" src="https://user-images.githubusercontent.com/16171942/207762732-5e0ba8cc-2c51-458d-b1b8-a37321f8b8fd.png">

</details>

<details>
<summary>Current PR sample</summary>

>  Swagger
> <img width="258" alt="Swagger" src="https://user-images.githubusercontent.com/16171942/207763350-2c45c3b4-ff46-4e62-85f1-e73be27d1b3e.png">


> Redoc
> <img width="347" alt="Redoc" src="https://user-images.githubusercontent.com/16171942/207763368-53284642-4af9-4e12-b54b-09aae93b77d6.png">



> Element 
> <img width="839" alt="Element" src="https://user-images.githubusercontent.com/16171942/207763384-25d8600e-cfac-444f-b05e-0ebb2fc3915e.png">

</details>


# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
