### PR TITLE
Autorun examples 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -176,7 +176,7 @@ repos:
     rev: v1.1.283
     hooks:
       - id: pyright
-        exclude: "test_apps"
+        exclude: "test_apps|tools"
         additional_dependencies:
           [
             aiomcache,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,67 @@ Please follow the next guidelines when adding a new example:
 ```
 ````
 
+#### Automatically execute examples
+
+Our docs include an mkdocs hook that can automatically run requests against example apps
+and include their result in the documentation page when its being built. This only requires 2 steps:
+
+1. Create an example file with an `app` object in it, which is an instance of `Starlite`
+2. Add a comment in the form of `# run: /hello` to the example file
+
+When building the docs (or serving them locally), a process serving the `app` instance 
+will be launched, and the requests specified in the comments will be run against it. The
+comments will be stripped from the result, and the output of the `curl` invocation inserted
+after the example code-block.
+
+The `# run: ` syntax is nothing special; Everything after the colon will be passed to
+the `curl` command that's being invoked. The URL is being built automatically, so the
+specified path can just be a path relative to the app.
+
+In practice, this looks like the following:
+
+```python
+from typing import Dict
+
+from starlite import Starlite, get
+
+
+@get("/")
+def hello_world() -> Dict[str, str]:
+    """Handler function that returns a greeting dictionary."""
+    return {"hello": "world"}
+
+
+app = Starlite(route_handlers=[hello_world])
+
+# run: /
+```
+
+This will produce the following markdown:
+
+<pre>
+```python
+from typing import Dict
+
+from starlite import Starlite, get
+
+
+@get("/")
+def hello_world() -> Dict[str, str]:
+    """Handler function that returns a greeting dictionary."""
+    return {"hello": "world"}
+
+
+app = Starlite(route_handlers=[hello_world])
+```
+
+??? example "Run it"
+    ```shell
+    > curl http://127.0.0.1:8000/
+    {"hello": "world"}
+    ```
+</pre>
+
 #### Cleaning up examples
 
 If you want to contribute to the ongoing effort of #343, you can use the `tools/doc_examples.py`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ and include their result in the documentation page when its being built. This on
 1. Create an example file with an `app` object in it, which is an instance of `Starlite`
 2. Add a comment in the form of `# run: /hello` to the example file
 
-When building the docs (or serving them locally), a process serving the `app` instance 
+When building the docs (or serving them locally), a process serving the `app` instance
 will be launched, and the requests specified in the comments will be run against it. The
 comments will be stripped from the result, and the output of the `curl` invocation inserted
 after the example code-block.
@@ -142,7 +142,7 @@ def hello_world() -> Dict[str, str]:
 app = Starlite(route_handlers=[hello_world])
 ```
 
-??? example "Run it"
+!!! example
     ```shell
     > curl http://127.0.0.1:8000/
     {"hello": "world"}

--- a/docs/usage/3-parameters/1-query-parameters.md
+++ b/docs/usage/3-parameters/1-query-parameters.md
@@ -8,13 +8,6 @@ will be interpreted as a query parameter.
 --8<-- "examples/parameters/query_params.py"
 ```
 
-If you run the app, then visit http://localhost:8000/?param=hello in your browser,
-you'll see the following result:
-
-```json
-{"param": "hello"}
-```
-
 !!! info "Technical details"
       These parameters will be parsed from the function signature and used to generate a pydantic model.
       This model in turn will be used to validate the parameters and generate the OpenAPI schema.
@@ -33,52 +26,26 @@ a `ValidationException` will be raised.
 
 ## Settings defaults
 
+In this example, `param` will have the value `"hello"` if it's not specified in the request.
+If it's passed as a query parameter however, it will be overwritten:
+
 ```py
 --8<-- "examples/parameters/query_params_default.py"
 ```
-
-In this example, `param` will have the value `"hello"` if it's not specified in the request.
-
-Now, visiting http://localhost:8000 in your browser, results in
-
-```json
-{"param": "hello"}
-```
-
-without having specified the parameter. If you instead go to http://localhost:8000?param=world,
-you'll see that the default has been overwritten:
-
-```json
-{"param": "world"}
-```
-
 
 ## Optional parameters
 
 Instead of only setting a default value, it's also possible to make a query parameter
 entirely optional.
 
+Here, we give a default value of `None`, but still declare the type of the query parameter
+to be a string. This means "This parameter is not required. If it is given, it has to be a string.
+If it is not given, it will have a default value of `None`
+
 ```py
 --8<-- "examples/parameters/query_params_optional.py"
 ```
 
-Here, we give a default value of `None`, but still declare the type of the query parameter
-to be a string. This means "This parameter is not required. If it is given, it has to be a string.
-If it is not given, it will have a default value of `None`"
-
-To see this behaviour in action run the app and navigate your browser to: http://localhost:8000
-
-You'll see that the result is now:
-
-```json
-{"param": null}
-```
-
-If the query parameter is specified (http://localhost:8000?param=goodbye) it will be:
-
-```json
-{"param": "goodbye"}
-```
 
 ## Type coercion
 
@@ -91,22 +58,13 @@ everything that works there will work for query parameters as well.
 --8<-- "examples/parameters/query_params_types.py"
 ```
 
-Check it out by visiting: http://localhost:8000?date=2022-11-28T13:22:06.916540&floating_number=0.1&number=42&strings=1&strings=2
-
-```json
-{
-      "datetime": "2022-11-29T13:22:06",
-      "int":42,
-      "float":0.1,
-      "list":["1","2"]
-}
-```
-
 
 ## Specifying alternative names and constraints
 
 Sometimes you might want to "remap" query parameters to allow a different name in the URL
-than what's being used in the handler function. This can be done by making use of [Parameter](reference/params/0-parameter/).
+than what's being used in the handler function. This can be done by making use of
+[Parameter](reference/params/0-parameter/).
+
 
 ```py
 --8<-- "examples/parameters/query_params_remap.py"
@@ -115,6 +73,7 @@ than what's being used in the handler function. This can be done by making use o
 Here, we remap from `snake_case` in the handler function to `camelCase` in the URL.
 This means that for the URL `http://127.0.0.1:8000?camelCase=foo`, the value of `camelCase`
 will be used for the value of the `snake_case` parameter.
+
 
 `Parameter` also allows us to define additional constraints:
 

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -10,3 +10,5 @@ def hello_world() -> Dict[str, str]:
 
 
 app = Starlite(route_handlers=[hello_world])
+
+# run: /

--- a/examples/parameters/query_params.py
+++ b/examples/parameters/query_params.py
@@ -9,3 +9,6 @@ def index(param: str) -> Dict[str, str]:
 
 
 app = Starlite(route_handlers=[index])
+
+# run: /?param=foo
+# run: /?param=bar

--- a/examples/parameters/query_params_default.py
+++ b/examples/parameters/query_params_default.py
@@ -9,3 +9,7 @@ def index(param: str = "hello") -> Dict[str, str]:
 
 
 app = Starlite(route_handlers=[index])
+
+
+# run: /
+# run: /?param=john

--- a/examples/parameters/query_params_optional.py
+++ b/examples/parameters/query_params_optional.py
@@ -9,3 +9,7 @@ def index(param: Optional[str] = None) -> Dict[str, Optional[str]]:
 
 
 app = Starlite(route_handlers=[index])
+
+
+# run: /
+# run: /?param=goodbye

--- a/examples/parameters/query_params_remap.py
+++ b/examples/parameters/query_params_remap.py
@@ -9,3 +9,5 @@ def index(snake_case: str = Parameter(query="camelCase")) -> Dict[str, str]:
 
 
 app = Starlite(route_handlers=[index])
+
+# run: /?camelCase=foo

--- a/examples/parameters/query_params_types.py
+++ b/examples/parameters/query_params_types.py
@@ -20,3 +20,6 @@ def index(
 
 
 app = Starlite(route_handlers=[index])
+
+
+# run: /?date=2022-11-28T13:22:06.916540&floating_number=0.1&number=42&strings=1&strings=2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -310,6 +310,8 @@ plugins:
             separate_signature: true
             show_if_no_docstring: true
             line_length: 100
+hooks:
+  - tools/run_examples.py
 watch:
   - starlite
   - examples

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,6 @@
 mkdocs-material
 mkdocstrings[python]
 black
+httpx
+uvicorn
 git+https://github.com/provinzkraut/AutoPyTabs.git

--- a/tools/run_examples.py
+++ b/tools/run_examples.py
@@ -1,0 +1,183 @@
+import re
+import secrets
+import shlex
+import shutil
+import socket
+import subprocess
+import time
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Generator, List, Tuple
+
+import httpx
+from mkdocs.config.base import Config as MkDocsConfig
+from mkdocs.structure.files import File, Files
+
+RGX_RUN = re.compile(r"# +?run:(.*)")
+RGX_SNIPPET = re.compile(r'--8<-- "(.*)"')
+RGX_CODE_BLOCK = re.compile(r"```py[\w\W]+?```")
+
+
+AVAILABLE_PORTS = list(range(9000, 9999))
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    tmp_docs_file: Path
+    example_file: Path
+    args: List[List[str]]
+    code_block: str
+    updated_code_block: str
+
+
+def indent(string: str, level: int = 4) -> str:
+    return "\n".join((" " * level) + line for line in string.splitlines())
+
+
+@contextmanager
+def run_app(path: Path) -> Generator[int, None, None]:
+    while AVAILABLE_PORTS:
+        port = AVAILABLE_PORTS.pop()
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            if sock.connect_ex(("127.0.0.1", port)) != 0:
+                break
+    else:
+        raise RuntimeError("Could not find an open port")
+
+    proc = subprocess.Popen(
+        ["uvicorn", str(path.with_suffix("")).replace("/", ".") + ":app", "--no-access-log", "--port", str(port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=False,
+    )
+    for _ in range(50):
+        try:
+            httpx.get(f"http://127.0.0.1:{port}", timeout=0.1)
+        except httpx.TransportError:
+            time.sleep(0.1)
+        else:
+            break
+    try:
+        yield port
+    finally:
+        proc.kill()
+    AVAILABLE_PORTS.append(port)
+
+
+def extract_run_args(content: str) -> tuple[str, List[List[str]]]:
+    new_lines = []
+    run_configs = []
+    for line in content.splitlines():
+        if run_stmt_match := RGX_RUN.match(line):
+            run_stmt = run_stmt_match.group(1).lstrip()
+            run_configs.append(shlex.split(run_stmt))
+        else:
+            new_lines.append(line)
+    return "\n".join(new_lines), run_configs
+
+
+def extract_from_docs_file(file: File, tmp_path: Path) -> List[RunConfig]:
+    tmp_docs_file = tmp_path / secrets.token_hex()
+    content = Path(file.abs_src_path).read_text()
+
+    code_blocks = RGX_CODE_BLOCK.findall(content)
+    configs = []
+
+    if not code_blocks:
+        return []
+
+    for code_block in code_blocks:
+        snippet_sources = RGX_SNIPPET.findall(code_block)
+        if not snippet_sources:
+            continue
+        if len(snippet_sources) > 1:
+            raise RuntimeError("Multiple snippet sources found")
+
+        snippet_source = snippet_sources[0]
+        if not snippet_source.endswith("py"):
+            continue
+
+        example_file = Path(snippet_source)
+        if not example_file.exists():
+            continue
+        example_content = example_file.read_text()
+        updated_example_content, run_args = extract_run_args(example_content)
+        if not run_args:
+            continue
+
+        tmp_example_file = tmp_path / secrets.token_hex()
+        tmp_example_file.write_text(updated_example_content)
+        updated_code_block = code_block.replace(snippet_source, str(tmp_example_file.absolute()))
+
+        configs.append(
+            RunConfig(
+                args=run_args,
+                tmp_docs_file=tmp_docs_file,
+                example_file=example_file,
+                code_block=code_block,
+                updated_code_block=updated_code_block,
+            )
+        )
+
+    if configs:
+        file.abs_src_path = str(tmp_docs_file.absolute())
+        tmp_docs_file.write_text(content)
+
+    return configs
+
+
+def exec_from_config(config: RunConfig) -> Tuple[RunConfig, str]:
+    results = []
+
+    with run_app(config.example_file) as port:
+        for run_args in config.args:
+            url_path, *options = run_args
+            args = ["curl", f"http://127.0.0.1:{port}{url_path}", *options]
+            clean_args = ["curl", f"http://127.0.0.1:8000{url_path}", *options]
+
+            proc = subprocess.run(args, capture_output=True, text=True)
+            stdout = proc.stdout.splitlines()
+            if not stdout:
+                raise RuntimeError(f"Example: {config.example_file}:{args} yielded no results")
+
+            result = "\n".join(line for line in ("> " + (" ".join(clean_args)), *stdout))
+            results.append(result)
+
+    replacement_block = config.updated_code_block
+    replacement_block += '\n??? example "Run it"\n'
+    replacement_block += "\n".join((indent(f"```shell\n{r}\n```") for r in results))
+    return config, replacement_block
+
+
+def on_files(files: Files, config: MkDocsConfig) -> None:
+    tmp_examples_path = Path(".tmp_examples")
+    if tmp_examples_path.exists():
+        shutil.rmtree(tmp_examples_path)
+    tmp_examples_path.mkdir(exist_ok=True)
+
+    configs = []
+    for file in files:
+        if not file.is_documentation_page():
+            continue
+        configs.extend(extract_from_docs_file(file, tmp_examples_path))
+
+    transformations: Dict[Path, Dict[str, str]] = {}
+
+    with ThreadPoolExecutor() as executor:
+        for config, result_block in executor.map(exec_from_config, configs):
+            transformations.setdefault(config.tmp_docs_file, {})
+            transformations[config.tmp_docs_file][config.code_block] = result_block
+
+    for tmp_docs_file, replacements in transformations.items():
+        content = tmp_docs_file.read_text()
+        for code_block, updated_code_block in replacements.items():
+            content = content.replace(code_block, updated_code_block)
+        tmp_docs_file.write_text(content)
+
+
+def on_post_build(config: MkDocsConfig) -> None:
+    tmp_examples_path = Path(".tmp_examples")
+    if tmp_examples_path.exists():
+        shutil.rmtree(tmp_examples_path)


### PR DESCRIPTION
Introduce an mkdocs hook that can automatically run requests against example apps based on simple comment instructions and inject the output into the docs.

Why?
Including an input/output (e.g. "run this curl command > this is the result") example alongside the code examples makes them more easily digestible. By doing it this way we can ensure that the output work, are up-to-date and follow a consistent format without having to perform all those tasks manually.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
