### PR TITLE
docs: fix note block spacing in cache usage

### DIFF
--- a/docs/usage/15-caching/0-cache-backends.md
+++ b/docs/usage/15-caching/0-cache-backends.md
@@ -27,8 +27,8 @@ Starlite also ships with two other ready to use cache backends:
   [aiomcache](https://github.com/aio-libs/aiomcache) to make sure requests are not blocked.
 
 !!! note
-  `memcached` is a required dependency when using this backend. You can install it as an extra with
-  `pip install starlite[memcached]` or independently.
+    `memcached` is a required dependency when using this backend. You can install it as an extra with
+    `pip install starlite[memcached]` or independently.
 
 ## Configuring Caching
 

--- a/docs/usage/8-security/3-guards.md
+++ b/docs/usage/8-security/3-guards.md
@@ -112,7 +112,7 @@ The deciding factor on where to place a guard is on the kind of access restricti
 route handlers need to be restricted? An entire controller? All the paths under a specific router? Or the entire app?
 
 As you can see in the above examples - `guards` is a list. This means you can add **multiple** guards at every layer.
-Unlike `dependencies`, guards do not override each other but are rather _cumulative_. This means that you can define
+Unlike `dependencies`, guards do not override each other but are rather *cumulative*. This means that you can define
 guards on different levels of your app, and they will combine.
 
 ## The Route Handler "opt" Key


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

_No PR is too small, right?_ Adding a minor spacing fix to the cache backend usage docs so that mkdocs can render an admonition correctly

## Screenshots

### Before
![screenshot_broken_note_block](https://user-images.githubusercontent.com/14207857/208023470-294325ca-279f-4713-8349-19f2a5b903c1.png)

### After
![screenshot_fixed_note_block](https://user-images.githubusercontent.com/14207857/208023485-0a78f6aa-e27a-4935-b476-33d07290afd8.png)
