### PR TITLE
fix: support utf-8 encoded strings in form data

### DIFF
--- a/starlite/parsers.py
+++ b/starlite/parsers.py
@@ -38,10 +38,10 @@ def parse_query_string(query_string: bytes, encoding: str = "utf-8") -> Tuple[Tu
     Returns:
         A tuple of key value pairs.
     """
-    _bools = {b"true": True, b"false": False, b"True": True, b"False": False}
+    _bools = {"true": True, "false": False, "True": True, "False": False}
     return tuple(
-        (k.decode(encoding), v.decode(encoding) if v not in _bools else _bools[v])
-        for k, v in parse_qsl(query_string, keep_blank_values=True)
+        (k, v if v not in _bools else _bools[v])
+        for k, v in parse_qsl(str(query_string, encoding=encoding), keep_blank_values=True, encoding=encoding)
     )
 
 

--- a/starlite/parsers.py
+++ b/starlite/parsers.py
@@ -59,7 +59,7 @@ def parse_form_query_string(form_query_string: bytes, encoding: str = "utf-8") -
     _bools = {"true": True, "false": False, "True": True, "False": False}
     return tuple(
         (k, v if v not in _bools else _bools[v])
-        for k, v in parse_qsl(str(form_query_string, encoding=encoding), keep_blank_values=True, encoding=encoding)
+        for k, v in parse_qsl(str(form_query_string, encoding=encoding), keep_blank_values=True)
     )
 
 

--- a/starlite/parsers.py
+++ b/starlite/parsers.py
@@ -38,16 +38,34 @@ def parse_query_string(query_string: bytes, encoding: str = "utf-8") -> Tuple[Tu
     Returns:
         A tuple of key value pairs.
     """
+    _bools = {b"true": True, b"false": False, b"True": True, b"False": False}
+    return tuple(
+        (k.decode(encoding), v.decode(encoding) if v not in _bools else _bools[v])
+        for k, v in parse_qsl(query_string, keep_blank_values=True)
+    )
+
+
+@lru_cache(1024)
+def parse_form_query_string(form_query_string: bytes, encoding: str = "utf-8") -> Tuple[Tuple[str, Any], ...]:
+    """Parse a form query string into a tuple of key value pairs.
+
+    Args:
+        form_query_string: A query string.
+        encoding: The encoding to use.
+
+    Returns:
+        A tuple of key value pairs.
+    """
     _bools = {"true": True, "false": False, "True": True, "False": False}
     return tuple(
         (k, v if v not in _bools else _bools[v])
-        for k, v in parse_qsl(str(query_string, encoding=encoding), keep_blank_values=True, encoding=encoding)
+        for k, v in parse_qsl(str(form_query_string, encoding=encoding), keep_blank_values=True, encoding=encoding)
     )
 
 
 @lru_cache(1024)
 def parse_url_encoded_form_data(encoded_data: bytes, encoding: str) -> Dict[str, Any]:
-    """Parse a url encoded form data dict.
+    """Parse an url encoded form data dict.
 
     Args:
         encoded_data: The encoded byte string.
@@ -57,7 +75,7 @@ def parse_url_encoded_form_data(encoded_data: bytes, encoding: str) -> Dict[str,
         A parsed dict.
     """
     decoded_dict: DefaultDict[str, List[Any]] = defaultdict(list)
-    for k, v in parse_query_string(query_string=encoded_data, encoding=encoding):
+    for k, v in parse_form_query_string(form_query_string=encoded_data, encoding=encoding):
         with suppress(DecodeError):
             v = decode_json(v) if isinstance(v, str) else v
         decoded_dict[k].append(v)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -38,6 +38,21 @@ def test_parse_form_data() -> None:
     }
 
 
+def test_parse_utf8_form_data() -> None:
+    result = parse_url_encoded_form_data(
+        encoded_data=urlencode(
+            [
+                ("value", "äüß"),
+            ]
+        ).encode(),
+        encoding="utf-8",
+    )
+    assert result == {
+        "value": "äüß"
+    }
+
+
+
 @pytest.mark.parametrize(
     "cookie_string, expected",
     (

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -47,10 +47,7 @@ def test_parse_utf8_form_data() -> None:
         ).encode(),
         encoding="utf-8",
     )
-    assert result == {
-        "value": "äüß"
-    }
-
+    assert result == {"value": "äüß"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?


Currently UTF-8 form data cannot be parsed and results in an internal server error.  
I added a test which test that and included the fix.