### PR TITLE
Install dependencies needed for tools/run_examples.py in docs GH action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,6 +13,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          installer-parallel: true
+      - name: Install App Dependencies
+        run: poetry install --no-interaction --only main
       - run: pip install -r requirements-docs.txt
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
#943 Was missing the inclusion of dependencies needed to run in the CI. This fixes it :upside_down_face: 

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
