### PR TITLE
Support `Cookie` instances in `Response.set_cookie`

### DIFF
--- a/examples/responses/response_cookies_4.py
+++ b/examples/responses/response_cookies_4.py
@@ -20,7 +20,7 @@ def retrieve_resource() -> Resource:
 
 
 def after_request_handler(response: Response) -> Response:
-    response.set_cookie(**Cookie(key="Random-Cookie", value=str(randint(1, 100))).dict)
+    response.set_cookie(key="Random-Cookie", value=str(randint(1, 100)))
     return response
 
 

--- a/examples/responses/response_cookies_5.py
+++ b/examples/responses/response_cookies_5.py
@@ -32,7 +32,7 @@ def retrieve_resource() -> Response[Resource]:
 
 
 def after_request_handler(response: Response) -> Response:
-    response.set_cookie(**Cookie(key="Random-Cookie", value=str(randint(1, 100))).dict)
+    response.set_cookie(key="Random-Cookie", value=str(randint(1, 100)))
     return response
 
 

--- a/starlite/response/base.py
+++ b/starlite/response/base.py
@@ -11,6 +11,7 @@ from typing import (
     Tuple,
     TypeVar,
     Union,
+    overload,
 )
 
 from starlite.datastructures import Cookie, ETag
@@ -118,6 +119,11 @@ class Response(Generic[T]):
         )
         self.raw_headers: List[Tuple[bytes, bytes]] = []
 
+    @overload
+    def set_cookie(self, /, cookie: Cookie) -> None:
+        ...
+
+    @overload
     def set_cookie(
         self,
         key: str,
@@ -130,10 +136,25 @@ class Response(Generic[T]):
         httponly: bool = False,
         samesite: Literal["lax", "strict", "none"] = "lax",
     ) -> None:
-        """Ses a cookie on the response.
+        ...
+
+    def set_cookie(  # type: ignore[misc]
+        self,
+        key: Union[str, Cookie],
+        value: Optional[str] = None,
+        max_age: Optional[int] = None,
+        expires: Optional[int] = None,
+        path: str = "/",
+        domain: Optional[str] = None,
+        secure: bool = False,
+        httponly: bool = False,
+        samesite: Literal["lax", "strict", "none"] = "lax",
+    ) -> None:
+        """Set a cookie on the response. If passed a [Cookie][starlite.Cookie] instance, keyword arguments will be
+        ignored.
 
         Args:
-            key: Key for the cookie.
+            key: Key for the cookie or a [Cookie][starlite.Cookie] instance.
             value: Value for the cookie, if none given defaults to empty string.
             max_age: Maximal age of the cookie before its invalidated.
             expires: Expiration date as unix MS timestamp.
@@ -146,8 +167,8 @@ class Response(Generic[T]):
         Returns:
             None.
         """
-        self.cookies.append(
-            Cookie(
+        if not isinstance(key, Cookie):
+            key = Cookie(
                 domain=domain,
                 expires=expires,
                 httponly=httponly,
@@ -158,7 +179,7 @@ class Response(Generic[T]):
                 secure=secure,
                 value=value,
             )
-        )
+        self.cookies.append(key)
 
     def set_header(self, key: str, value: str) -> None:
         """Set a header on the response.

--- a/tests/response/test_base_response.py
+++ b/tests/response/test_base_response.py
@@ -3,7 +3,13 @@ from typing import Any, Optional
 import pytest
 from pydantic_openapi_schema.v3_1_0 import Info, OpenAPI
 
-from starlite import ImproperlyConfiguredException, MediaType, OpenAPIMediaType, get
+from starlite import (
+    Cookie,
+    ImproperlyConfiguredException,
+    MediaType,
+    OpenAPIMediaType,
+    get,
+)
 from starlite.response import Response
 from starlite.status_codes import (
     HTTP_100_CONTINUE,
@@ -43,11 +49,15 @@ def test_response_headers_do_not_lowercase_values() -> None:
         assert response.headers["foo"] == "BaR"
 
 
-def test_set_cookie() -> None:
+@pytest.mark.parametrize("as_instance", [True, False])
+def test_set_cookie(as_instance: bool) -> None:
     @get("/")
     def handler() -> Response:
         response = Response(content=None)
-        response.set_cookie("test", "abc", max_age=60, expires=60, secure=True, httponly=True)
+        if as_instance:
+            response.set_cookie(Cookie(key="test", value="abc", max_age=60, expires=60, secure=True, httponly=True))
+        else:
+            response.set_cookie(key="test", value="abc", max_age=60, expires=60, secure=True, httponly=True)
         assert len(response.cookies) == 1
         return response
 


### PR DESCRIPTION
Add support for setting `Cookie` instances in `Response.set_cookie` alongside of keyword arguments.
Implements #961 

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
