### PR TITLE
Fix 964: Jinja Template response ignores MediaType settings

### DIFF
--- a/docs/reference/6-enums.md
+++ b/docs/reference/6-enums.md
@@ -18,6 +18,8 @@
             - JSON
             - TEXT
             - MESSAGEPACK
+            - CSS
+            - XML
 
 ::: starlite.enums.OpenAPIMediaType
     options:

--- a/starlite/datastructures/response_containers.py
+++ b/starlite/datastructures/response_containers.py
@@ -290,7 +290,7 @@ class Stream(ResponseContainer[StreamingResponse]):
         )
 
 
-class Template(ResponseContainer["TemplateResponse"]):
+class Template(ResponseContainer[TemplateResponse]):
     """Container type for returning Template responses."""
 
     name: str
@@ -336,6 +336,7 @@ class Template(ResponseContainer["TemplateResponse"]):
             status_code=status_code,
             template_engine=app.template_engine,
             template_name=self.name,
+            media_type=media_type,
         )
 
     def create_template_context(self, request: "Request") -> Dict[str, Any]:

--- a/starlite/enums.py
+++ b/starlite/enums.py
@@ -20,6 +20,8 @@ class MediaType(str, Enum):
     MESSAGEPACK = "application/x-msgpack"
     HTML = "text/html"
     TEXT = "text/plain"
+    CSS = "text/css"
+    XML = "application/xml"
 
 
 class OpenAPIMediaType(str, Enum):

--- a/starlite/response/template.py
+++ b/starlite/response/template.py
@@ -1,3 +1,4 @@
+from mimetypes import guess_type
 from pathlib import PurePath
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
@@ -9,13 +10,6 @@ if TYPE_CHECKING:
     from starlite.datastructures import BackgroundTask, BackgroundTasks
     from starlite.template import TemplateEngineProtocol
     from starlite.types import ResponseCookies
-
-
-EXTENSION_MEDIA_TYPES = {
-    ".html": MediaType.HTML,
-    ".xml": MediaType.XML,
-    ".css": MediaType.CSS,
-}
 
 
 class TemplateResponse(Response[bytes]):
@@ -52,15 +46,9 @@ class TemplateResponse(Response[bytes]):
                 the media type based on the template name. If this fails, fall back to `text/plain`.
         """
         if media_type == MediaType.JSON:  # we assume this is the default
-            # if ".htm" in template_name:
-            #     media_type = MediaType.HTML
-            # elif ".xml" in template_name:
-            #     media_type = MediaType.XML
-            # else:
-            #     media_type = MediaType.TEXT
             suffixes = PurePath(template_name).suffixes
             for suffix in suffixes:
-                if _type := EXTENSION_MEDIA_TYPES.get(suffix):
+                if _type := guess_type("name" + suffix)[0]:
                     media_type = _type
                     break
             else:

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -84,7 +84,7 @@ def test_media_type(media_type: Union[MediaType, str], template_dir: Path) -> No
         (".xml", MediaType.XML),
         (".xml.other", MediaType.XML),
         (".txt", MediaType.TEXT),
-        (".tpl", MediaType.TEXT),
+        (".unknown", MediaType.TEXT),
         ("", MediaType.TEXT),
     ],
 )

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -1,15 +1,15 @@
-from typing import TYPE_CHECKING, Optional, Type
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Type, Union
 
 import pytest
 from pydantic import ValidationError
 
-from starlite import Starlite, Template, TemplateConfig, get
+from starlite import MediaType, Starlite, Template, TemplateConfig, get
 from starlite.contrib.jinja import JinjaTemplateEngine
 from starlite.contrib.mako import MakoTemplateEngine
 from starlite.testing import create_test_client
 
 if TYPE_CHECKING:
-    from pathlib import Path
 
     from starlite.template import TemplateEngineProtocol
 
@@ -56,3 +56,49 @@ def test_engine_instance(engine: Type["TemplateEngineProtocol"], template_dir: "
 def test_directory_validation(engine: Type["TemplateEngineProtocol"], template_dir: "Path") -> None:
     with pytest.raises(ValidationError):
         TemplateConfig(engine=engine)
+
+
+@pytest.mark.parametrize("media_type", [MediaType.HTML, MediaType.TEXT, "text/arbitrary"])
+def test_media_type(media_type: Union[MediaType, str], template_dir: Path) -> None:
+    (template_dir / "hello.tpl").write_text("hello")
+
+    @get("/", media_type=media_type)
+    def index() -> Template:
+        return Template(name="hello.tpl")
+
+    with create_test_client(
+        [index], template_config=TemplateConfig(directory=template_dir, engine=JinjaTemplateEngine)
+    ) as client:
+        res = client.get("/")
+        assert res.status_code == 200
+        assert res.headers["content-type"].startswith(
+            media_type if isinstance(media_type, str) else media_type.value,  # type: ignore[union-attr]
+        )
+
+
+@pytest.mark.parametrize(
+    "extension,expected_type",
+    [
+        (".html", MediaType.HTML),
+        (".html.other", MediaType.HTML),
+        (".xml", MediaType.XML),
+        (".xml.other", MediaType.XML),
+        (".txt", MediaType.TEXT),
+        (".tpl", MediaType.TEXT),
+        ("", MediaType.TEXT),
+    ],
+)
+def test_media_type_inferred(extension: str, expected_type: MediaType, template_dir: Path) -> None:
+    tpl_name = "hello" + extension
+    (template_dir / tpl_name).write_text("hello")
+
+    @get("/")
+    def index() -> Template:
+        return Template(name=tpl_name)
+
+    with create_test_client(
+        [index], template_config=TemplateConfig(directory=template_dir, engine=JinjaTemplateEngine)
+    ) as client:
+        res = client.get("/")
+        assert res.status_code == 200
+        assert res.headers["content-type"].startswith(expected_type.value)


### PR DESCRIPTION
Add support for setting a `media_type` in template responses.
If no media type is passed explicitly, try to infer the correct one using `mimetypes.guess_type` or fall back to `text/plain`. 

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
