### PR TITLE
Feature/open api unique operation

### DIFF
--- a/docs/usage/12-openapi/2-route-handler-configuration.md
+++ b/docs/usage/12-openapi/2-route-handler-configuration.md
@@ -23,7 +23,7 @@ You can also modify the generated schema for the route handler using the followi
 - `description`: Text used for the route's schema _description_ section.
 - `response_description`: Text used for the route's response schema _description_ section.
 - `operation_id`: An identifier used for the route's schema _operationId_. Defaults to the `__name__` attribute of the
-  wrapped function.
+  wrapped function. Will be prefixed with the method name when function is decorated with `HTTPRouteHandler` and multiple `http_method`. Will also be prefixed with path strings used in `Routers` and `Controllers` to make sure id is unique.
 - `deprecated`: A boolean dictating whether this route should be marked as deprecated in the OpenAPI schema. Defaults
   to `False`.
 - `raises`: A list of exception classes extending from `starlite.HttpException`. This list should describe all

--- a/docs/usage/12-openapi/2-route-handler-configuration.md
+++ b/docs/usage/12-openapi/2-route-handler-configuration.md
@@ -23,7 +23,7 @@ You can also modify the generated schema for the route handler using the followi
 - `description`: Text used for the route's schema _description_ section.
 - `response_description`: Text used for the route's response schema _description_ section.
 - `operation_id`: An identifier used for the route's schema _operationId_. Defaults to the `__name__` attribute of the
-  wrapped function. Will be prefixed with the method name when function is decorated with `HTTPRouteHandler` and multiple `http_method`. Will also be prefixed with path strings used in `Routers` and `Controllers` to make sure id is unique.
+  wrapped function.
 - `deprecated`: A boolean dictating whether this route should be marked as deprecated in the OpenAPI schema. Defaults
   to `False`.
 - `raises`: A list of exception classes extending from `starlite.HttpException`. This list should describe all
@@ -33,6 +33,9 @@ You can also modify the generated schema for the route handler using the followi
 - `responses`: A dictionary of additional status codes and a description of their expected content.
     The expected content should be based on a Pydantic model describing its structure. It can also include
     a description and the expected media type. For example:
+
+!!! note
+    `operation_id` will be prefixed with the method name when function is decorated with `HTTPRouteHandler` and multiple `http_method`. Will also be prefixed with path strings used in `Routers` and `Controllers` to make sure id is unique.
 
 ```python
 from datetime import datetime

--- a/starlite/openapi/path_item.py
+++ b/starlite/openapi/path_item.py
@@ -74,7 +74,7 @@ def get_start_of_path_components_str(path_components: List[Union[str, PathParame
     for component in path_components:
         if isinstance(component, PathParameterDefinition):
             break
-        output.append(component)
+        output.append(component.title())
     return output
 
 
@@ -97,11 +97,11 @@ def create_path_item(
                 or None
             )
             raises_validation_error = bool("data" in handler_fields or path_item.parameters or parameters)
-            handler_name = unwrap_partial(route_handler.handler_name)
+            handler_name = unwrap_partial(route_handler.handler_name).title().replace("_", "")
             operation_id = route_handler.operation_id or handler_name
             if len(route_handler.http_methods) > 1:
-                operation_id = "_".join((http_method, operation_id))
-            operation_id = "_".join((*get_start_of_path_components_str(route.path_components), operation_id))
+                operation_id = "".join((http_method.title(), operation_id))
+            operation_id = "".join((*get_start_of_path_components_str(route.path_components), operation_id))
 
             request_body = None
             if "data" in handler_fields:

--- a/starlite/openapi/path_item.py
+++ b/starlite/openapi/path_item.py
@@ -60,7 +60,7 @@ def extract_layered_values(
     return list(set(tags)) if tags else None, security or None
 
 
-def get_start_of_path_components_str(path_components: List[Union[str, PathParameterDefinition]]) -> list[str]:
+def get_start_of_path_components_str(path_components: List[Union[str, PathParameterDefinition]]) -> List[str]:
     """Extract str from path_components until the first occurrence of PathParameterDefinition. This is used to get none
     parameter paths from Routes to prefix operation_id.
 

--- a/starlite/openapi/path_item.py
+++ b/starlite/openapi/path_item.py
@@ -61,6 +61,15 @@ def extract_layered_values(
 
 
 def get_start_of_path_components_str(path_components: list[str | PathParameterDefinition]) -> list[str]:
+    """Extract str from path_components until the first occurrence of PathParameterDefinition. This is used to get none
+    parameter paths from Routes to prefix operation_id.
+
+    Args:
+        path_components: A list of str and PathParameterDefinition instances
+
+    Returns:
+        A list of str
+    """
     output = []
     for component in path_components:
         if isinstance(component, PathParameterDefinition):

--- a/starlite/openapi/path_item.py
+++ b/starlite/openapi/path_item.py
@@ -1,5 +1,5 @@
 from inspect import cleandoc
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union, cast
 
 from pydantic_openapi_schema.v3_1_0.operation import Operation
 from pydantic_openapi_schema.v3_1_0.path_item import PathItem
@@ -60,7 +60,7 @@ def extract_layered_values(
     return list(set(tags)) if tags else None, security or None
 
 
-def get_start_of_path_components_str(path_components: list[str | PathParameterDefinition]) -> list[str]:
+def get_start_of_path_components_str(path_components: List[Union[str, PathParameterDefinition]]) -> list[str]:
     """Extract str from path_components until the first occurrence of PathParameterDefinition. This is used to get none
     parameter paths from Routes to prefix operation_id.
 

--- a/starlite/openapi/path_item.py
+++ b/starlite/openapi/path_item.py
@@ -60,22 +60,6 @@ def extract_layered_values(
     return list(set(tags)) if tags else None, security or None
 
 
-def get_unique_operation_id(route: "HTTPRoute", route_handler: "HTTPRouteHandler", http_method: "Method") -> str:
-    if route_handler.operation_id:
-        if len(route_handler.http_methods) > 1:
-            return f"{http_method}_{route_handler.operation_id}"
-        else:
-            return route_handler.operation_id
-    else:
-        path_components_str = []
-        for path_component in route.path_components:
-            if isinstance(path_component, PathParameterDefinition):
-                path_components_str.append(path_component.name)
-            else:
-                path_components_str.append(path_component)
-        return "_".join(path_components_str) + f"_{http_method}_{route_handler.handler_name}"
-
-
 def get_start_of_path_components_str(path_components: list[str | PathParameterDefinition]) -> list[str]:
     output = []
     for component in path_components:

--- a/tests/openapi/test_path_item.py
+++ b/tests/openapi/test_path_item.py
@@ -1,8 +1,9 @@
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
-from starlite import HTTPRoute, Starlite
+from starlite import Controller, HTTPRoute, Request, Router, Starlite
+from starlite.handlers import HTTPRouteHandler
 from starlite.openapi.path_item import create_path_item
 from starlite.utils import find_index
 from tests.openapi.utils import PersonController
@@ -15,16 +16,64 @@ def route() -> HTTPRoute:
     return cast("HTTPRoute", app.routes[index])
 
 
+@pytest.fixture()
+def routes_with_router() -> tuple[HTTPRoute, HTTPRoute]:
+    class PersonControllerV2(PersonController):
+        pass
+
+    router_v1 = Router(
+        path="/v1",
+        route_handlers=[PersonController]
+    )
+    router_v2 = Router(
+        path="/v2",
+        route_handlers=[PersonControllerV2]
+    )
+    app = Starlite(route_handlers=[router_v1, router_v2], openapi_config=None)
+    index_v1 = find_index(app.routes, lambda x: x.path_format == "/v1/{service_id}/person/{person_id}")
+    index_v2 = find_index(app.routes, lambda x: x.path_format == "/v2/{service_id}/person/{person_id}")
+    return cast("HTTPRoute", app.routes[index_v1]), cast("HTTPRoute", app.routes[index_v2])
+
+
+@pytest.fixture()
+def route_with_multiple_methods() -> HTTPRoute:
+
+    class MultipleMethodsRouteController(Controller):
+        path = "/"
+
+        @HTTPRouteHandler("/", http_method=["GET", "HEAD"])
+        async def root(
+                self, *, request: Request[str, str]
+        ) -> None:
+            pass
+
+    app = Starlite(route_handlers=[MultipleMethodsRouteController], openapi_config=None)
+    index = find_index(app.routes, lambda x: x.path_format == "/")
+    return cast("HTTPRoute", app.routes[index])
+
+
 def test_create_path_item(route: HTTPRoute) -> None:
     schema = create_path_item(route=route, create_examples=True, plugins=[], use_handler_docstrings=False)
     assert schema.delete
-    assert schema.delete.operationId == "Delete Person"
+    assert schema.delete.operationId == "delete_person"
     assert schema.get
-    assert schema.get.operationId == "Get Person By Id"
+    assert schema.get.operationId == "get_person_by_id"
     assert schema.patch
-    assert schema.patch.operationId == "Partial Update Person"
+    assert schema.patch.operationId == "partial_update_person"
     assert schema.put
-    assert schema.put.operationId == "Update Person"
+    assert schema.put.operationId == "update_person"
+
+
+def test_unique_operation_ids_for_multiple_http_methods(route_with_multiple_methods: HTTPRoute) -> None:
+    schema = create_path_item(route=route_with_multiple_methods, create_examples=True, plugins=[], use_handler_docstrings=False)
+    assert schema.get.operationId != schema.head.operationId
+
+
+def test_routes_with_different_paths_should_generate_unique_operation_ids(routes_with_router: tuple[HTTPRoute, HTTPRoute]) -> None:
+    route_v1, route_v2 = routes_with_router
+    schema_v1 = create_path_item(route=route_v1, create_examples=True, plugins=[], use_handler_docstrings=False)
+    schema_v2 = create_path_item(route=route_v2, create_examples=True, plugins=[], use_handler_docstrings=False)
+    assert schema_v1.get.operationId != schema_v2.get.operationId
 
 
 def test_create_path_item_use_handler_docstring_false(route: HTTPRoute) -> None:

--- a/tests/openapi/test_path_item.py
+++ b/tests/openapi/test_path_item.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any, cast, Tuple
 
 import pytest
 
@@ -17,7 +17,7 @@ def route() -> HTTPRoute:
 
 
 @pytest.fixture()
-def routes_with_router() -> tuple[HTTPRoute, HTTPRoute]:
+def routes_with_router() -> Tuple[HTTPRoute, HTTPRoute]:
     class PersonControllerV2(PersonController):
         pass
 
@@ -69,7 +69,7 @@ def test_unique_operation_ids_for_multiple_http_methods(route_with_multiple_meth
     assert schema.get.operationId != schema.head.operationId
 
 
-def test_routes_with_different_paths_should_generate_unique_operation_ids(routes_with_router: tuple[HTTPRoute, HTTPRoute]) -> None:
+def test_routes_with_different_paths_should_generate_unique_operation_ids(routes_with_router: Tuple[HTTPRoute, HTTPRoute]) -> None:
     route_v1, route_v2 = routes_with_router
     schema_v1 = create_path_item(route=route_v1, create_examples=True, plugins=[], use_handler_docstrings=False)
     schema_v2 = create_path_item(route=route_v2, create_examples=True, plugins=[], use_handler_docstrings=False)

--- a/tests/openapi/test_path_item.py
+++ b/tests/openapi/test_path_item.py
@@ -1,4 +1,4 @@
-from typing import Any, cast, Tuple
+from typing import Tuple, cast
 
 import pytest
 
@@ -21,14 +21,8 @@ def routes_with_router() -> Tuple[HTTPRoute, HTTPRoute]:
     class PersonControllerV2(PersonController):
         pass
 
-    router_v1 = Router(
-        path="/v1",
-        route_handlers=[PersonController]
-    )
-    router_v2 = Router(
-        path="/v2",
-        route_handlers=[PersonControllerV2]
-    )
+    router_v1 = Router(path="/v1", route_handlers=[PersonController])
+    router_v2 = Router(path="/v2", route_handlers=[PersonControllerV2])
     app = Starlite(route_handlers=[router_v1, router_v2], openapi_config=None)
     index_v1 = find_index(app.routes, lambda x: x.path_format == "/v1/{service_id}/person/{person_id}")
     index_v2 = find_index(app.routes, lambda x: x.path_format == "/v2/{service_id}/person/{person_id}")
@@ -37,14 +31,11 @@ def routes_with_router() -> Tuple[HTTPRoute, HTTPRoute]:
 
 @pytest.fixture()
 def route_with_multiple_methods() -> HTTPRoute:
-
     class MultipleMethodsRouteController(Controller):
         path = "/"
 
         @HTTPRouteHandler("/", http_method=["GET", "HEAD"])
-        async def root(
-                self, *, request: Request[str, str]
-        ) -> None:
+        async def root(self, *, request: Request[str, str]) -> None:
             pass
 
     app = Starlite(route_handlers=[MultipleMethodsRouteController], openapi_config=None)
@@ -55,24 +46,34 @@ def route_with_multiple_methods() -> HTTPRoute:
 def test_create_path_item(route: HTTPRoute) -> None:
     schema = create_path_item(route=route, create_examples=True, plugins=[], use_handler_docstrings=False)
     assert schema.delete
-    assert schema.delete.operationId == "delete_person"
+    assert schema.delete.operationId == "DeletePerson"
     assert schema.get
-    assert schema.get.operationId == "get_person_by_id"
+    assert schema.get.operationId == "GetPersonById"
     assert schema.patch
-    assert schema.patch.operationId == "partial_update_person"
+    assert schema.patch.operationId == "PartialUpdatePerson"
     assert schema.put
-    assert schema.put.operationId == "update_person"
+    assert schema.put.operationId == "UpdatePerson"
 
 
 def test_unique_operation_ids_for_multiple_http_methods(route_with_multiple_methods: HTTPRoute) -> None:
-    schema = create_path_item(route=route_with_multiple_methods, create_examples=True, plugins=[], use_handler_docstrings=False)
+    schema = create_path_item(
+        route=route_with_multiple_methods, create_examples=True, plugins=[], use_handler_docstrings=False
+    )
+    assert schema.get
+    assert schema.get.operationId
+    assert schema.head
+    assert schema.head.operationId
     assert schema.get.operationId != schema.head.operationId
 
 
-def test_routes_with_different_paths_should_generate_unique_operation_ids(routes_with_router: Tuple[HTTPRoute, HTTPRoute]) -> None:
+def test_routes_with_different_paths_should_generate_unique_operation_ids(
+    routes_with_router: Tuple[HTTPRoute, HTTPRoute]
+) -> None:
     route_v1, route_v2 = routes_with_router
     schema_v1 = create_path_item(route=route_v1, create_examples=True, plugins=[], use_handler_docstrings=False)
     schema_v2 = create_path_item(route=route_v2, create_examples=True, plugins=[], use_handler_docstrings=False)
+    assert schema_v1.get
+    assert schema_v2.get
     assert schema_v1.get.operationId != schema_v2.get.operationId
 
 


### PR DESCRIPTION
# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

According to OpenAPI specification, operationId must be unique among all operations described in the API, https://spec.openapis.org/oas/v3.1.0#fixed-fields-7. Currently this breaks when array of http_method is supplied in HTTPRouteHandler decorator. This can also break if same method names are used in different routes.

This for instance causes an error when using openapi-generator to generate client stubs from schema.

This proposal adds the method name when multiple http_methods are used and also adds string paths from path_component as a prefix to make the operationId unique. It also formats operationId by using _ instead of " " to follow common programming naming conventions as suggested in the OpenAPI specification.