### PR TITLE
Extend serializable types

### DIFF
--- a/starlite/utils/serialization.py
+++ b/starlite/utils/serialization.py
@@ -1,27 +1,30 @@
+from collections import deque
+from decimal import Decimal
+from ipaddress import (
+    IPv4Address,
+    IPv4Interface,
+    IPv4Network,
+    IPv6Address,
+    IPv6Interface,
+    IPv6Network,
+)
 from pathlib import PurePosixPath
+from re import Pattern
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
 
 import msgspec
 from pydantic import (
-    AnyUrl,
     BaseModel,
     ByteSize,
     ConstrainedBytes,
     ConstrainedDate,
     ConstrainedDecimal,
-    ConstrainedFloat,
-    ConstrainedFrozenSet,
-    ConstrainedInt,
-    ConstrainedList,
-    ConstrainedSet,
-    ConstrainedStr,
-    EmailStr,
     NameEmail,
-    PaymentCardNumber,
     SecretField,
     StrictBool,
 )
 from pydantic.color import Color
+from pydantic.json import decimal_encoder
 
 if TYPE_CHECKING:
     from starlite.types import TypeEncodersMap
@@ -31,22 +34,34 @@ DEFAULT_TYPE_ENCODERS: "TypeEncodersMap" = {
     # pydantic specific types
     BaseModel: lambda m: m.dict(),
     ByteSize: lambda b: b.real,
-    EmailStr: str,
     NameEmail: str,
     Color: str,
-    AnyUrl: str,
     SecretField: str,
-    ConstrainedInt: int,
-    ConstrainedFloat: float,
-    ConstrainedStr: str,
     ConstrainedBytes: lambda b: b.decode("utf-8"),
-    ConstrainedList: list,
-    ConstrainedSet: set,
-    ConstrainedFrozenSet: frozenset,
     ConstrainedDecimal: float,
     ConstrainedDate: lambda d: d.isoformat(),
-    PaymentCardNumber: str,
-    StrictBool: int,  # pydantic compatibility
+    IPv4Address: str,
+    IPv4Interface: str,
+    IPv4Network: str,
+    IPv6Address: str,
+    IPv6Interface: str,
+    IPv6Network: str,
+    # pydantic compatibility
+    deque: list,
+    Decimal: decimal_encoder,
+    StrictBool: int,
+    Pattern: lambda o: o.pattern,
+    # support subclasses of stdlib types, e.g. pydantic's constrained types.
+    # see https://github.com/jcrist/msgspec/issues/248
+    # and https://github.com/starlite-api/starlite/issues/1003
+    str: str,
+    int: int,
+    float: float,
+    list: list,
+    tuple: tuple,
+    set: set,
+    frozenset: frozenset,
+    dict: dict,
 }
 
 

--- a/starlite/utils/serialization.py
+++ b/starlite/utils/serialization.py
@@ -51,7 +51,9 @@ DEFAULT_TYPE_ENCODERS: "TypeEncodersMap" = {
     Decimal: decimal_encoder,
     StrictBool: int,
     Pattern: lambda o: o.pattern,
-    # support subclasses of stdlib types, e.g. pydantic's constrained types.
+    # support subclasses of stdlib types, e.g. pydantic's constrained types. If no
+    # previous type matched, these will be the last type in the mro, so we use this to
+    # (attempt to) convert a subclass into its base class.
     # see https://github.com/jcrist/msgspec/issues/248
     # and https://github.com/starlite-api/starlite/issues/1003
     str: str,

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -35,6 +35,34 @@ from tests import PersonFactory
 person = PersonFactory.build()
 
 
+class CustomStr(str):
+    pass
+
+
+class CustomInt(int):
+    pass
+
+
+class CustomFloat(float):
+    pass
+
+
+class CustomList(list):
+    pass
+
+
+class CustomSet(set):
+    pass
+
+
+class CustomFrozenSet(frozenset):
+    pass
+
+
+class CustomTuple(tuple):
+    pass
+
+
 class Model(BaseModel):
     path: PosixPath = PosixPath("example")
 
@@ -61,6 +89,14 @@ class Model(BaseModel):
     strict_float: StrictFloat = StrictFloat(1.0)
     strict_bytes: StrictBytes = StrictBytes(b"hello")
     strict_bool: StrictBool = StrictBool(True)
+
+    custom_str: CustomStr = CustomStr()
+    custom_int: CustomInt = CustomInt()
+    custom_float: CustomFloat = CustomFloat()
+    custom_list: CustomList = CustomList()
+    custom_set: CustomSet = CustomSet()
+    custom_frozenset: CustomFrozenSet = CustomFrozenSet()
+    custom_tuple: CustomTuple = CustomTuple()
 
 
 model = Model()
@@ -90,6 +126,13 @@ model = Model()
         (model.strict_bytes, "hello"),
         (model.strict_bool, 1),
         (model, model.dict()),
+        (model.custom_str, ""),
+        (model.custom_int, 0),
+        (model.custom_float, 0.0),
+        (model.custom_list, []),
+        (model.custom_set, set()),
+        (model.custom_frozenset, frozenset()),
+        (model.custom_tuple, ()),
     ],
 )
 def test_default_serializer(value: Any, expected: Any) -> None:


### PR DESCRIPTION
Fixes #1003, by adding support for subclassed stdlib types. Also simplifies some of the pydantic-specific type conversion logic. 

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
