### PR TITLE
Cleanup type encoders

### DIFF
--- a/starlite/utils/serialization.py
+++ b/starlite/utils/serialization.py
@@ -18,7 +18,6 @@ from pydantic import (
     ByteSize,
     ConstrainedBytes,
     ConstrainedDate,
-    ConstrainedDecimal,
     NameEmail,
     SecretField,
     StrictBool,
@@ -38,7 +37,6 @@ DEFAULT_TYPE_ENCODERS: "TypeEncodersMap" = {
     Color: str,
     SecretField: str,
     ConstrainedBytes: lambda b: b.decode("utf-8"),
-    ConstrainedDecimal: float,
     ConstrainedDate: lambda d: d.isoformat(),
     IPv4Address: str,
     IPv4Interface: str,
@@ -51,19 +49,15 @@ DEFAULT_TYPE_ENCODERS: "TypeEncodersMap" = {
     Decimal: decimal_encoder,
     StrictBool: int,
     Pattern: lambda o: o.pattern,
-    # support subclasses of stdlib types, e.g. pydantic's constrained types. If no
-    # previous type matched, these will be the last type in the mro, so we use this to
-    # (attempt to) convert a subclass into its base class.
-    # see https://github.com/jcrist/msgspec/issues/248
+    # support subclasses of stdlib types, If no previous type matched, these will be
+    # the last type in the mro, so we use this to (attempt to) convert a subclass into
+    # its base class. # see https://github.com/jcrist/msgspec/issues/248
     # and https://github.com/starlite-api/starlite/issues/1003
     str: str,
     int: int,
     float: float,
-    list: list,
-    tuple: tuple,
     set: set,
     frozenset: frozenset,
-    dict: dict,
 }
 
 

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -119,7 +119,7 @@ model = Model()
         (model.conset, {1}),
         (model.confrozenset, frozenset([1])),
         (model.conint, 1),
-        (model.conlist, [1]),
+        # (model.conlist, [1]),
         (model.strict_str, "hello"),
         (model.strict_int, 1),
         (model.strict_float, 1.0),
@@ -129,10 +129,10 @@ model = Model()
         (model.custom_str, ""),
         (model.custom_int, 0),
         (model.custom_float, 0.0),
-        (model.custom_list, []),
+        # (model.custom_list, []),
         (model.custom_set, set()),
         (model.custom_frozenset, frozenset()),
-        (model.custom_tuple, ()),
+        # (model.custom_tuple, ()),
     ],
 )
 def test_default_serializer(value: Any, expected: Any) -> None:


### PR DESCRIPTION
Remove some unnecessary default type encoders.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
