### PR TITLE
Fix typo in the docs (Testing. Test Client)

### DIFF
--- a/docs/usage/9-testing/1-test-client.md
+++ b/docs/usage/9-testing/1-test-client.md
@@ -70,7 +70,7 @@ across requests, then you might want to inject or inspect session data outside a
 two methods:
 
 - [set_session_data][starlite.testing.test_client.TestClient.set_session_data]
-- [set_session_data][starlite.testing.test_client.TestClient.get_session_data]
+- [get_session_data][starlite.testing.test_client.TestClient.get_session_data]
 
 !!! important
     - The **Session Middleware** must be enabled in Starlite app provided to the TestClient to use sessions.


### PR DESCRIPTION
Fix typo in the "Test Client" section.
set_session_data appears two times

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
