### PR TITLE
Fix a broken example for the "Response Headers" docs

### DIFF
--- a/docs/usage/5-responses/4-response-headers.md
+++ b/docs/usage/5-responses/4-response-headers.md
@@ -49,7 +49,7 @@ the handler on different layers of the application as explained in the pertinent
 the headers on the corresponding layer:
 
 ```py
---8<-- "examples/response_headers_3.py"
+--8<-- "examples/responses/response_headers_3.py"
 ```
 
 In the above we set the response header using an `after_request_handler` function on the router level. Because the


### PR DESCRIPTION
This PR provides a small fix with a broken example in the ["Response Headers" section of the docs](https://starlite-api.github.io/starlite/1.48/usage/5-responses/4-response-headers/).

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
