### PR TITLE
Add examples about background tasks usage with responses

### DIFF
--- a/docs/usage/5-responses/11-background-tasks.md
+++ b/docs/usage/5-responses/11-background-tasks.md
@@ -11,21 +11,8 @@ that will be called after the response finishes sending the data.
 
 Thus, in the following example the passed in background task will be executed after the response sends:
 
-```python
-import logging
-
-from starlite import BackgroundTask, get
-
-logger = logging.getLogger(__name__)
-
-
-async def logging_task(identifier: str, message: str) -> None:
-    logger.info(f"{identifier}: {message}")
-
-
-@get("/", background=BackgroundTask(logging_task, "greeter", message="was called"))
-def greeter() -> dict[str, str]:
-    return {"hello": "world"}
+```py title="Background Task Set in Decorator"
+--8<-- "examples/responses/background_tasks_2.py"
 ```
 
 When the `greeter` handler is called, the logging task will be called with any `*args` and `**kwargs` passed into the

--- a/docs/usage/5-responses/11-background-tasks.md
+++ b/docs/usage/5-responses/11-background-tasks.md
@@ -1,9 +1,8 @@
 # Background Tasks
 
-All Starlite responses and response containers (e.g. `File`, `Template` etc.) allow passing in a `background`
+All Starlite responses and response containers (e.g. `File`, `Template`, etc.) allow passing in a `background`
 kwarg. This kwarg accepts either an instance of [`BackgroundTask`][starlite.datastructures.background_tasks.BackgroundTask]
-or
-an instance of [`BackgroundTasks`][starlite.datastructures.background_tasks.BackgroundTasks], which wraps an iterable
+or an instance of [`BackgroundTasks`][starlite.datastructures.background_tasks.BackgroundTasks], which wraps an iterable
 of [`BackgroundTask`][starlite.datastructures.background_tasks.BackgroundTask] instances.
 
 A background task is a sync or async callable (function, method or class that implements the `__call__` dunder method)
@@ -11,25 +10,42 @@ that will be called after the response finishes sending the data.
 
 Thus, in the following example the passed in background task will be executed after the response sends:
 
-```py title="Background Task Set in Decorator"
---8<-- "examples/responses/background_tasks_2.py"
+```py title="Background Task Passed into Response"
+--8<-- "examples/responses/background_tasks_1.py"
 ```
 
 When the `greeter` handler is called, the logging task will be called with any `*args` and `**kwargs` passed into the
 `BackgroundTask`.
 
 !!! note
-    In the above example `"greeter"` is an arg and `message="was called"` is a kwarg. The function signature of
-    `logging_task` allows for this, so this should pose no problem. Starlite uses [`ParamSpec`][typing.ParamSpec] to ensure
-    that a [`BackgroundTask`][starlite.datastructures.background_tasks.BackgroundTask] is properly typed, so will get
-    type checking for any passed in args and kwargs.
+    In the above example `"greeter"` is an arg and `message=f"was called with name {name}"` is a kwarg.
+    The function signature of `logging_task` allows for this, so this should pose no problem.
+    Starlite uses [`ParamSpec`][typing.ParamSpec] to ensure that a
+    [`BackgroundTask`][starlite.datastructures.background_tasks.BackgroundTask] is properly typed,
+    so it will get type checking for any passed in args and kwargs.
 
-## Executing Multiple BackgroundTasks
+Route decorators (e.g. `@get`, `@post`, etc.) also allow passing in a background task with the `background` kwarg:
 
-You can also use the [`BackgroundTasks`][starlite.datastructures.background_tasks.BackgroundTasks] class instead, and pass
-to it an iterable (list, tuple etc.) of [`BackgroundTask`][starlite.datastructures.background_tasks.BackgroundTask]
-instances. This class accepts one optional kwargs aside from the tasks - `run_in_task_group`, which is a boolean flag
-that defaults to `False`. If you set this value to `True` than the tasks will run concurrently, using
+```py title="Background Task Passed into Decorator"
+--8<-- "examples/responses/background_tasks_2.py"
+```
+
+!!! note
+    Route handler arguments cannot be passed into background tasks when they are passed into decorators.
+
+## Executing Multiple Background Tasks
+
+You can also use the [`BackgroundTasks`][starlite.datastructures.background_tasks.BackgroundTasks] class and pass
+to it an iterable (list, tuple, etc.) of [`BackgroundTask`][starlite.datastructures.background_tasks.BackgroundTask]
+instances:
+
+```py title="Multiple Background Tasks"
+--8<-- "examples/responses/background_tasks_3.py"
+```
+
+[`BackgroundTasks`][starlite.datastructures.background_tasks.BackgroundTasks] class
+accepts one optional kwargs aside from the tasks, `run_in_task_group`, which is a boolean flag
+that defaults to `False`. If you set this value to `True`, then the tasks will run concurrently, using
 an [`anyio.task_group`](https://anyio.readthedocs.io/en/stable/tasks.html).
 
 !!! note

--- a/docs/usage/5-responses/11-background-tasks.md
+++ b/docs/usage/5-responses/11-background-tasks.md
@@ -20,9 +20,7 @@ When the `greeter` handler is called, the logging task will be called with any `
 !!! note
     In the above example `"greeter"` is an arg and `message=f"was called with name {name}"` is a kwarg.
     The function signature of `logging_task` allows for this, so this should pose no problem.
-    Starlite uses [`ParamSpec`][typing.ParamSpec] to ensure that a
-    [`BackgroundTask`][starlite.datastructures.background_tasks.BackgroundTask] is properly typed,
-    so it will get type checking for any passed in args and kwargs.
+    [`BackgroundTask`][starlite.datastructures.background_tasks.BackgroundTask] is typed with [`ParamSpec`][typing.ParamSpec], enabling correct type checking for arguments and keyword arguments passed to it.
 
 Route decorators (e.g. `@get`, `@post`, etc.) also allow passing in a background task with the `background` kwarg:
 
@@ -44,9 +42,7 @@ instances:
 ```
 
 [`BackgroundTasks`][starlite.datastructures.background_tasks.BackgroundTasks] class
-accepts one optional kwargs aside from the tasks, `run_in_task_group`, which is a boolean flag
-that defaults to `False`. If you set this value to `True`, then the tasks will run concurrently, using
-an [`anyio.task_group`](https://anyio.readthedocs.io/en/stable/tasks.html).
+accepts an optional keyword argument `run_in_task_group` with a default value of `False`. Setting this to `True` allows background tasks to run concurrently, using an [`anyio.task_group`](https://anyio.readthedocs.io/en/stable/tasks.html). 
 
 !!! note
     Setting `run_in_task_group` to `True` will not preserve execution order.

--- a/docs/usage/5-responses/11-background-tasks.md
+++ b/docs/usage/5-responses/11-background-tasks.md
@@ -42,7 +42,7 @@ instances:
 ```
 
 [`BackgroundTasks`][starlite.datastructures.background_tasks.BackgroundTasks] class
-accepts an optional keyword argument `run_in_task_group` with a default value of `False`. Setting this to `True` allows background tasks to run concurrently, using an [`anyio.task_group`](https://anyio.readthedocs.io/en/stable/tasks.html). 
+accepts an optional keyword argument `run_in_task_group` with a default value of `False`. Setting this to `True` allows background tasks to run concurrently, using an [`anyio.task_group`](https://anyio.readthedocs.io/en/stable/tasks.html).
 
 !!! note
     Setting `run_in_task_group` to `True` will not preserve execution order.

--- a/docs/usage/5-responses/11-background-tasks.md
+++ b/docs/usage/5-responses/11-background-tasks.md
@@ -1,6 +1,6 @@
 # Background Tasks
 
-All Starlite responses and response containers (e.g. `File`, `Template` etc.) allow passing in a `background_task`
+All Starlite responses and response containers (e.g. `File`, `Template` etc.) allow passing in a `background`
 kwarg. This kwarg accepts either an instance of [`BackgroundTask`][starlite.datastructures.background_tasks.BackgroundTask]
 or
 an instance of [`BackgroundTasks`][starlite.datastructures.background_tasks.BackgroundTasks], which wraps an iterable

--- a/examples/responses/background_tasks_1.py
+++ b/examples/responses/background_tasks_1.py
@@ -1,0 +1,20 @@
+import logging
+
+from starlite import BackgroundTask, Response, Starlite, get
+
+logger = logging.getLogger(__name__)
+
+
+async def logging_task(identifier: str, message: str) -> None:
+    logger.info("%s: %s", identifier, message)
+
+
+@get("/")
+def greeter(name: str) -> Response[dict[str, str]]:
+    return Response(
+        {"hello": name},
+        background=BackgroundTask(logging_task, "greeter", message=f"was called with name {name}"),
+    )
+
+
+app = Starlite(route_handlers=[greeter])

--- a/examples/responses/background_tasks_1.py
+++ b/examples/responses/background_tasks_1.py
@@ -1,6 +1,5 @@
-from typing import Dict
-
 import logging
+from typing import Dict
 
 from starlite import BackgroundTask, Response, Starlite, get
 

--- a/examples/responses/background_tasks_1.py
+++ b/examples/responses/background_tasks_1.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import logging
 
 from starlite import BackgroundTask, Response, Starlite, get
@@ -10,7 +12,7 @@ async def logging_task(identifier: str, message: str) -> None:
 
 
 @get("/")
-def greeter(name: str) -> Response[dict[str, str]]:
+def greeter(name: str) -> Response[Dict[str, str]]:
     return Response(
         {"hello": name},
         background=BackgroundTask(logging_task, "greeter", message=f"was called with name {name}"),

--- a/examples/responses/background_tasks_2.py
+++ b/examples/responses/background_tasks_2.py
@@ -1,0 +1,17 @@
+import logging
+
+from starlite import BackgroundTask, Starlite, get
+
+logger = logging.getLogger(__name__)
+
+
+async def logging_task(identifier: str, message: str) -> None:
+    logger.info(f"{identifier}: {message}")
+
+
+@get("/", background=BackgroundTask(logging_task, "greeter", message="was called"))
+def greeter() -> dict[str, str]:
+    return {"hello": "world"}
+
+
+app = Starlite(route_handlers=[greeter])

--- a/examples/responses/background_tasks_2.py
+++ b/examples/responses/background_tasks_2.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 async def logging_task(identifier: str, message: str) -> None:
-    logger.info(f"{identifier}: {message}")
+    logger.info("%s: %s", identifier, message)
 
 
 @get("/", background=BackgroundTask(logging_task, "greeter", message="was called"))

--- a/examples/responses/background_tasks_2.py
+++ b/examples/responses/background_tasks_2.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import logging
 
 from starlite import BackgroundTask, Starlite, get
@@ -10,7 +12,7 @@ async def logging_task(identifier: str, message: str) -> None:
 
 
 @get("/", background=BackgroundTask(logging_task, "greeter", message="was called"))
-def greeter() -> dict[str, str]:
+def greeter() -> Dict[str, str]:
     return {"hello": "world"}
 
 

--- a/examples/responses/background_tasks_2.py
+++ b/examples/responses/background_tasks_2.py
@@ -1,6 +1,5 @@
-from typing import Dict
-
 import logging
+from typing import Dict
 
 from starlite import BackgroundTask, Starlite, get
 

--- a/examples/responses/background_tasks_3.py
+++ b/examples/responses/background_tasks_3.py
@@ -1,0 +1,30 @@
+import logging
+
+from starlite import BackgroundTask, BackgroundTasks, Response, Starlite, get
+
+logger = logging.getLogger(__name__)
+greeted = set()
+
+
+async def logging_task(name: str) -> None:
+    logger.info("%s was greeted", name)
+
+
+async def saving_task(name: str) -> None:
+    greeted.add(name)
+
+
+@get("/")
+def greeter(name: str) -> Response[dict[str, str]]:
+    return Response(
+        {"hello": name},
+        background=BackgroundTasks(
+            [
+                BackgroundTask(logging_task, name),
+                BackgroundTask(saving_task, name),
+            ]
+        ),
+    )
+
+
+app = Starlite(route_handlers=[greeter])

--- a/examples/responses/background_tasks_3.py
+++ b/examples/responses/background_tasks_3.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import logging
 
 from starlite import BackgroundTask, BackgroundTasks, Response, Starlite, get
@@ -15,7 +17,7 @@ async def saving_task(name: str) -> None:
 
 
 @get("/")
-def greeter(name: str) -> Response[dict[str, str]]:
+def greeter(name: str) -> Response[Dict[str, str]]:
     return Response(
         {"hello": name},
         background=BackgroundTasks(

--- a/examples/responses/background_tasks_3.py
+++ b/examples/responses/background_tasks_3.py
@@ -1,6 +1,5 @@
-from typing import Dict
-
 import logging
+from typing import Dict
 
 from starlite import BackgroundTask, BackgroundTasks, Response, Starlite, get
 

--- a/examples/tests/responses/test_background_tasks.py
+++ b/examples/tests/responses/test_background_tasks.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch
+import logging
+from typing import TYPE_CHECKING
 
 from examples.responses.background_tasks_1 import app as app_1
 from examples.responses.background_tasks_2 import app as app_2
@@ -6,35 +7,35 @@ from examples.responses.background_tasks_3 import app as app_3
 from examples.responses.background_tasks_3 import greeted as greeted_3
 from starlite import TestClient
 
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
 
-def test_background_tasks_1() -> None:
-    with TestClient(app=app_1) as client, patch("examples.responses.background_tasks_1.logger.info") as mock_info:
+
+def test_background_tasks_1(caplog: "LogCaptureFixture") -> None:
+    with caplog.at_level(logging.INFO), TestClient(app=app_1) as client:
         name = "Jane"
         res = client.get("/", params={"name": name})
         assert res.status_code == 200
         assert res.json()["hello"] == name
-        mock_info.assert_called_once()
-        mock_call_args: tuple[str] = mock_info.call_args[0]
-        assert any([name in arg for arg in mock_call_args])
+        assert len(caplog.messages) == 1
+        assert name in caplog.messages[0]
 
 
-def test_background_tasks_2() -> None:
-    with TestClient(app=app_2) as client, patch("examples.responses.background_tasks_2.logger.info") as mock_info:
+def test_background_tasks_2(caplog: "LogCaptureFixture") -> None:
+    with caplog.at_level(logging.INFO), TestClient(app=app_2) as client:
         res = client.get("/")
         assert res.status_code == 200
         assert "hello" in res.json()
-        mock_info.assert_called_once()
-        mock_call_args: tuple[str] = mock_info.call_args[0]
-        assert any(["greeter" in arg for arg in mock_call_args])
+        assert len(caplog.messages) == 1
+        assert "greeter" in caplog.messages[0]
 
 
-def test_background_tasks_3() -> None:
-    with TestClient(app=app_3) as client, patch("examples.responses.background_tasks_3.logger.info") as mock_info:
+def test_background_tasks_3(caplog: "LogCaptureFixture") -> None:
+    with caplog.at_level(logging.INFO), TestClient(app=app_3) as client:
         name = "Jane"
         res = client.get("/", params={"name": name})
         assert res.status_code == 200
         assert res.json()["hello"] == name
-        mock_info.assert_called_once()
-        mock_call_args: tuple[str] = mock_info.call_args[0]
-        assert any([name in arg for arg in mock_call_args])
+        assert len(caplog.messages) == 1
+        assert name in caplog.messages[0]
         assert name in greeted_3

--- a/examples/tests/responses/test_background_tasks.py
+++ b/examples/tests/responses/test_background_tasks.py
@@ -1,11 +1,40 @@
 from unittest.mock import patch
 
+from examples.responses.background_tasks_1 import app as app_1
 from examples.responses.background_tasks_2 import app as app_2
+from examples.responses.background_tasks_3 import app as app_3
+from examples.responses.background_tasks_3 import greeted as greeted_3
 from starlite import TestClient
+
+
+def test_background_tasks_1() -> None:
+    with TestClient(app=app_1) as client, patch("examples.responses.background_tasks_1.logger.info") as mock_info:
+        name = "Jane"
+        res = client.get("/", params={"name": name})
+        assert res.status_code == 200
+        assert res.json()["hello"] == name
+        mock_info.assert_called_once()
+        mock_call_args: tuple[str] = mock_info.call_args[0]
+        assert any([name in arg for arg in mock_call_args])
 
 
 def test_background_tasks_2() -> None:
     with TestClient(app=app_2) as client, patch("examples.responses.background_tasks_2.logger.info") as mock_info:
         res = client.get("/")
         assert res.status_code == 200
+        assert "hello" in res.json()
         mock_info.assert_called_once()
+        mock_call_args: tuple[str] = mock_info.call_args[0]
+        assert any(["greeter" in arg for arg in mock_call_args])
+
+
+def test_background_tasks_3() -> None:
+    with TestClient(app=app_3) as client, patch("examples.responses.background_tasks_3.logger.info") as mock_info:
+        name = "Jane"
+        res = client.get("/", params={"name": name})
+        assert res.status_code == 200
+        assert res.json()["hello"] == name
+        mock_info.assert_called_once()
+        mock_call_args: tuple[str] = mock_info.call_args[0]
+        assert any([name in arg for arg in mock_call_args])
+        assert name in greeted_3

--- a/examples/tests/responses/test_background_tasks.py
+++ b/examples/tests/responses/test_background_tasks.py
@@ -1,0 +1,11 @@
+from unittest.mock import patch
+
+from examples.responses.background_tasks_2 import app as app_2
+from starlite import TestClient
+
+
+def test_background_tasks_2() -> None:
+    with TestClient(app=app_2) as client, patch("examples.responses.background_tasks_2.logger.info") as mock_info:
+        res = client.get("/")
+        assert res.status_code == 200
+        mock_info.assert_called_once()


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

The reason why I opened this PR is that I did not understand how to pass route handler arguments to background tasks, but discussion #765 was helpful, and I thought that adding a few examples, as suggested within the discussion, might help other users.

This PR contains the following items:

- Moved existing example into a separate file.
- Added tests for new and previous examples.
- Name of kwarg was incorrectly documented as `background_task`, it should be `background`, if I am not mistaken.
- Given more visibility to new examples, because I thought that the use case in which a background task has to receive route handler arguments might be more common. I also emphasized the fact that background tasks passed into route decorators cannot use handler arguments.

Of course, I am open to any feedback, in particular about the fourth point.

Thank you very much,
Goodbye,
Alessio