### PR TITLE
Fix issue when response is an empty iterable of DTOs

### DIFF
--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -224,7 +224,7 @@ def _create_data_handler(
         if is_dto_annotation and not isinstance(data, DTO):
             data = return_annotation(**data) if isinstance(data, dict) else return_annotation.from_model_instance(data)
 
-        elif is_dto_iterable_annotation and not isinstance(data[0], DTO):  # pyright: ignore
+        elif is_dto_iterable_annotation and len(data) and not isinstance(data[0], DTO):  # pyright: ignore
             dto_type = cast("Type[DTO]", get_args(return_annotation)[0])
             data = [
                 dto_type(**datum) if isinstance(datum, dict) else dto_type.from_model_instance(datum) for datum in data

--- a/starlite/handlers/http.py
+++ b/starlite/handlers/http.py
@@ -224,7 +224,7 @@ def _create_data_handler(
         if is_dto_annotation and not isinstance(data, DTO):
             data = return_annotation(**data) if isinstance(data, dict) else return_annotation.from_model_instance(data)
 
-        elif is_dto_iterable_annotation and len(data) and not isinstance(data[0], DTO):  # pyright: ignore
+        elif is_dto_iterable_annotation and data and not isinstance(data[0], DTO):  # pyright: ignore
             dto_type = cast("Type[DTO]", get_args(return_annotation)[0])
             data = [
                 dto_type(**datum) if isinstance(datum, dict) else dto_type.from_model_instance(datum) for datum in data

--- a/tests/response/test_dto_response.py
+++ b/tests/response/test_dto_response.py
@@ -41,6 +41,7 @@ else:
 @pytest.mark.parametrize(
     "data, annotation",
     (
+        (PersonFactory.batch(0), List[PersonDTO]),  # type: ignore
         (PersonFactory.batch(5), List[PersonDTO]),  # type: ignore
         ([p.dict() for p in PersonFactory.batch(5)], List[PersonDTO]),  # type: ignore
         (PersonFactory.batch(5), Tuple[PersonDTO, ...]),
@@ -58,7 +59,8 @@ def test_dto_list_response(data: Any, annotation: Any) -> None:
     with create_test_client(handler) as client:
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
-        assert [PersonDTO(**p) for p in response.json()]
+        results = [PersonDTO(**p) for p in response.json()]
+        assert results == data
 
 
 def test_dto_response_with_the_sqla_plugin() -> None:


### PR DESCRIPTION
# PR Checklist

- [X] Have you followed the guidelines in `CONTRIBUTING.md`?
- [X] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

The implementation of the automatic `DTO` response converter has a small bug. If the response type is an iterable DTO, a check is made weather the first element in the iterable data is a `DTO`. This check will result in an `Indexerror` as the iterable data might have no elements at all.