### PR TITLE
Ensure http requests with invalid payloads return 400.

### DIFF
--- a/docs/reference/exceptions/0-base-exceptions.md
+++ b/docs/reference/exceptions/0-base-exceptions.md
@@ -6,3 +6,5 @@
             - __init__
 
 ::: starlite.exceptions.MissingDependencyException
+
+::: starlite.exceptions.SerializationException

--- a/docs/reference/exceptions/1-http-exceptions.md
+++ b/docs/reference/exceptions/1-http-exceptions.md
@@ -1,5 +1,10 @@
 # HTTP Exceptions
 
+::: starlite.exceptions.ClientException
+    options:
+        members:
+            - status_code
+
 :::starlite.exceptions.HTTPException
     options:
         members:

--- a/starlite/exceptions/__init__.py
+++ b/starlite/exceptions/__init__.py
@@ -1,5 +1,10 @@
-from .base_exceptions import MissingDependencyException, StarLiteException
+from .base_exceptions import (
+    MissingDependencyException,
+    SerializationException,
+    StarLiteException,
+)
 from .http_exceptions import (
+    ClientException,
     HTTPException,
     ImproperlyConfiguredException,
     InternalServerException,
@@ -16,6 +21,7 @@ from .http_exceptions import (
 from .websocket_exceptions import WebSocketDisconnect, WebSocketException
 
 __all__ = (
+    "ClientException",
     "HTTPException",
     "ImproperlyConfiguredException",
     "InternalServerException",
@@ -25,6 +31,7 @@ __all__ = (
     "NotAuthorizedException",
     "NotFoundException",
     "PermissionDeniedException",
+    "SerializationException",
     "ServiceUnavailableException",
     "StarLiteException",
     "TemplateNotFoundException",

--- a/starlite/exceptions/base_exceptions.py
+++ b/starlite/exceptions/base_exceptions.py
@@ -30,3 +30,7 @@ class MissingDependencyException(StarLiteException):
 
     This exception is raised only when a module depends on a dependency that has not been installed.
     """
+
+
+class SerializationException(StarLiteException):
+    """Encoding or decoding of an object failed."""

--- a/starlite/exceptions/http_exceptions.py
+++ b/starlite/exceptions/http_exceptions.py
@@ -64,14 +64,14 @@ class HTTPException(StarLiteException):
         return f"{self.status_code} - {self.__class__.__name__} - {self.detail}"
 
 
+class ImproperlyConfiguredException(HTTPException, ValueError):
+    """Application has improper configuration."""
+
+
 class ClientException(HTTPException):
     """Client error."""
 
     status_code: int = HTTP_400_BAD_REQUEST
-
-
-class ImproperlyConfiguredException(HTTPException, ValueError):
-    """Application has improper configuration."""
 
 
 class ValidationException(ClientException, ValueError):

--- a/starlite/exceptions/http_exceptions.py
+++ b/starlite/exceptions/http_exceptions.py
@@ -64,41 +64,45 @@ class HTTPException(StarLiteException):
         return f"{self.status_code} - {self.__class__.__name__} - {self.detail}"
 
 
+class ClientException(HTTPException):
+    """Client error."""
+
+    status_code: int = HTTP_400_BAD_REQUEST
+
+
 class ImproperlyConfiguredException(HTTPException, ValueError):
     """Application has improper configuration."""
 
 
-class ValidationException(HTTPException, ValueError):
-    """Client error."""
-
-    status_code = HTTP_400_BAD_REQUEST
+class ValidationException(ClientException, ValueError):
+    """Client data validation error."""
 
 
-class NotAuthorizedException(HTTPException):
+class NotAuthorizedException(ClientException):
     """Request lacks valid authentication credentials for the requested resource."""
 
     status_code = HTTP_401_UNAUTHORIZED
 
 
-class PermissionDeniedException(HTTPException):
+class PermissionDeniedException(ClientException):
     """Request understood, but not authorized."""
 
     status_code = HTTP_403_FORBIDDEN
 
 
-class NotFoundException(HTTPException, ValueError):
+class NotFoundException(ClientException, ValueError):
     """Cannot find the requested resource."""
 
     status_code = HTTP_404_NOT_FOUND
 
 
-class MethodNotAllowedException(HTTPException):
+class MethodNotAllowedException(ClientException):
     """Server knows the request method, but the target resource doesn't support this method."""
 
     status_code = HTTP_405_METHOD_NOT_ALLOWED
 
 
-class TooManyRequestsException(HTTPException):
+class TooManyRequestsException(ClientException):
     """Request limits have been exceeded."""
 
     status_code = HTTP_429_TOO_MANY_REQUESTS
@@ -107,10 +111,10 @@ class TooManyRequestsException(HTTPException):
 class InternalServerException(HTTPException):
     """Server encountered an unexpected condition that prevented it from fulfilling the request."""
 
-    status_code = HTTP_500_INTERNAL_SERVER_ERROR
+    status_code: int = HTTP_500_INTERNAL_SERVER_ERROR
 
 
-class ServiceUnavailableException(HTTPException):
+class ServiceUnavailableException(InternalServerException):
     """Server is not ready to handle the request."""
 
     status_code = HTTP_503_SERVICE_UNAVAILABLE

--- a/starlite/multipart.py
+++ b/starlite/multipart.py
@@ -29,9 +29,8 @@ from email.utils import decode_rfc2231
 from typing import Any, DefaultDict, Dict, List, Tuple
 from urllib.parse import unquote
 
-from msgspec import DecodeError
-
 from starlite.datastructures.upload_file import UploadFile
+from starlite.exceptions import SerializationException
 from starlite.utils.serialization import decode_json
 
 _token, _quoted = r"([\w!#$%&'*+\-.^_`|~]+)", r'"([^"]*)"'
@@ -121,7 +120,7 @@ def parse_multipart_form(body: bytes, boundary: bytes) -> Dict[str, Any]:
                 else:
                     try:
                         fields[field_name].append(decode_json(post_data))
-                    except DecodeError:
+                    except SerializationException:
                         fields[field_name].append(post_data.decode(content_charset))
 
     return {k: v if len(v) > 1 else v[0] for k, v in fields.items()}

--- a/starlite/routes/http.py
+++ b/starlite/routes/http.py
@@ -7,7 +7,11 @@ from starlite.constants import DEFAULT_ALLOWED_CORS_HEADERS
 from starlite.datastructures.headers import Headers
 from starlite.datastructures.upload_file import UploadFile
 from starlite.enums import HttpMethod, MediaType, ScopeType
-from starlite.exceptions import ImproperlyConfiguredException
+from starlite.exceptions import (
+    ClientException,
+    ImproperlyConfiguredException,
+    SerializationException,
+)
 from starlite.handlers.http import HTTPRouteHandler
 from starlite.response import Response
 from starlite.routes.base import BaseRoute
@@ -185,7 +189,10 @@ class HTTPRoute(BaseRoute):
             kwargs = parameter_model.to_kwargs(connection=request)
 
             if "data" in kwargs:
-                kwargs["data"] = await kwargs["data"]
+                try:
+                    kwargs["data"] = await kwargs["data"]
+                except SerializationException as exc:
+                    raise ClientException(str(exc)) from exc
 
             if "body" in kwargs:
                 kwargs["body"] = await kwargs["body"]

--- a/starlite/utils/serialization.py
+++ b/starlite/utils/serialization.py
@@ -124,7 +124,7 @@ def encode_json(obj: Any, default: Optional[Callable[[Any], Any]] = default_seri
         if default is None or default is default_serializer:
             return _msgspec_json_encoder.encode(obj)
         return msgspec.json.encode(obj, enc_hook=default)
-    except msgspec.EncodeError as msgspec_error:
+    except (TypeError, msgspec.EncodeError) as msgspec_error:
         raise SerializationException(str(msgspec_error)) from msgspec_error
 
 
@@ -163,7 +163,7 @@ def encode_msgpack(obj: Any, enc_hook: Optional[Callable[[Any], Any]] = default_
         if enc_hook is None or enc_hook is default_serializer:
             return _msgspec_msgpack_encoder.encode(obj)
         return msgspec.msgpack.encode(obj, enc_hook=enc_hook)
-    except msgspec.EncodeError as msgspec_error:
+    except (TypeError, msgspec.EncodeError) as msgspec_error:
         raise SerializationException(str(msgspec_error)) from msgspec_error
 
 

--- a/tests/connection/request/test_request.py
+++ b/tests/connection/request/test_request.py
@@ -8,11 +8,11 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, Optional
 from unittest.mock import patch
 
 import pytest
-from msgspec import DecodeError
 
 from starlite import InternalServerException, MediaType, StaticFilesConfig, get
 from starlite.connection import Request, empty_send
 from starlite.datastructures import Address
+from starlite.exceptions import SerializationException
 from starlite.response import Response
 from starlite.testing import TestClient, create_test_client
 from starlite.utils.serialization import encode_msgpack
@@ -31,7 +31,7 @@ async def test_request_empty_body_to_json(anyio_backend: str) -> None:
 
 
 async def test_request_invalid_body_to_json(anyio_backend: str) -> None:
-    with patch.object(Request, "body", return_value=b"invalid"), pytest.raises(DecodeError):
+    with patch.object(Request, "body", return_value=b"invalid"), pytest.raises(SerializationException):
         request_empty_payload: Request = Request(scope={"type": "http"})  # type: ignore
         await request_empty_payload.json()
 
@@ -51,7 +51,7 @@ async def test_request_empty_body_to_msgpack(anyio_backend: str) -> None:
 
 
 async def test_request_invalid_body_to_msgpack(anyio_backend: str) -> None:
-    with patch.object(Request, "body", return_value=b"invalid"), pytest.raises(DecodeError):
+    with patch.object(Request, "body", return_value=b"invalid"), pytest.raises(SerializationException):
         request_empty_payload: Request = Request(scope={"type": "http"})  # type: ignore
         await request_empty_payload.msgpack()
 

--- a/tests/kwargs/test_reserved_kwargs_injection.py
+++ b/tests/kwargs/test_reserved_kwargs_injection.py
@@ -17,7 +17,12 @@ from starlite import (
     put,
 )
 from starlite.datastructures.state import ImmutableState
-from starlite.status_codes import HTTP_200_OK, HTTP_201_CREATED, HTTP_204_NO_CONTENT
+from starlite.status_codes import (
+    HTTP_200_OK,
+    HTTP_201_CREATED,
+    HTTP_204_NO_CONTENT,
+    HTTP_400_BAD_REQUEST,
+)
 from starlite.testing import create_test_client
 from starlite.types import Scope
 from tests import Person, PersonFactory
@@ -119,6 +124,17 @@ def test_data_using_list_of_models(decorator: Any, http_method: Any, expected_st
     with create_test_client(MyController) as client:
         response = client.request(http_method, test_path, json=[p.dict() for p in people])
         assert response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize("media_type", [MediaType.JSON, MediaType.MESSAGEPACK])
+def test_request_with_invalid_data(media_type: MediaType) -> None:
+    @post()
+    def test_handler(data: Any) -> Any:
+        return data
+
+    with create_test_client(test_handler) as client:
+        response = client.post("/", content=b"abc", headers={"Content-Type": media_type})
+        assert response.status_code == HTTP_400_BAD_REQUEST
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -29,7 +29,14 @@ from pydantic import (
 )
 from pydantic.color import Color
 
-from starlite.utils.serialization import default_serializer, encode_json
+from starlite.exceptions import SerializationException
+from starlite.utils.serialization import (
+    decode_json,
+    decode_msgpack,
+    default_serializer,
+    encode_json,
+    encode_msgpack,
+)
 from tests import PersonFactory
 
 person = PersonFactory.build()
@@ -143,6 +150,13 @@ def test_pydantic_json_compatibility() -> None:
     assert json.loads(model.json()) == json.loads(encode_json(model))
 
 
-def test_unsupported_type_raises() -> None:
-    with pytest.raises(TypeError):
-        encode_json(lambda: None)
+@pytest.mark.parametrize("encoder", [encode_json, encode_msgpack])
+def test_encoder_raises_serialization_exception(encoder: Any) -> None:
+    with pytest.raises(SerializationException):
+        encoder(object())
+
+
+@pytest.mark.parametrize("decoder", [decode_json, decode_msgpack])
+def test_decode_json_raises_serialization_exception(decoder: Any) -> None:
+    with pytest.raises(SerializationException):
+        decoder(b"str")


### PR DESCRIPTION
At the point of parsing the `data` kwarg, this PR looks for a deserialization error and raises a client error http response.

Adds a new exception, `SerializationException` which wraps the `msgspec` operations. I think this better encapsulates the 3rd-party code.

Adds a new HTTP exception `ClientException` and makes other `4xx` errors a subclass.

Makes `ServiceUnavailableException` a subclass of `InternalServerException`.

Closes #1047

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
