### PR TITLE
Response doesn't match OpenAPI schema when using aliases

### DIFF
--- a/starlite/utils/serialization.py
+++ b/starlite/utils/serialization.py
@@ -47,7 +47,7 @@ DEFAULT_TYPE_ENCODERS: "TypeEncodersMap" = {
     Path: str,
     PurePath: str,
     # pydantic specific types
-    BaseModel: lambda m: m.dict(),
+    BaseModel: lambda m: m.dict(by_alias=False),
     ByteSize: lambda b: b.real,
     NameEmail: str,
     Color: str,


### PR DESCRIPTION
**Tests currently failing**

### Issue
I've created a few extra checks I believe should pass in regards to schema aliases. I'm not 100% certain how you'd guys would like to go about solving it. 

Somehow  `by_alias` on [this line](https://github.com/WardPearce/starlite/blob/1270892b81b375fae3f5ba087619ccc2985d6ecd/starlite/utils/serialization.py#L50) needs to be passed depending on `Starlite.openapi_config.by_alias`.

Related to Issue https://github.com/starlite-api/starlite/issues/952

### Context
I've been porting a older project what uses `"_id"` in its responses, so being able to continue using underscores is important to avoid breaking other clients interactions.

### Inconsistencies
- `by_alias` is true, request will use alias but response won't actually use the alias outside the schema.
- `by_alias` is false, request will use alias(?) but schema won't.
  - The following [schema](https://paaster.io/3rQtyWm2ZPOgt8vyTaRJW#puUdi83hBBhTn65AyTPOk58rGHCGzN-AshcNWcBnkYc), is generated with  `by_alias` is false. But in order for the request to succeed. `"_id"` must be used instead of `"id"`, but a response with the same object will use `"id"`
  - This results in type errors etc.