### PR TITLE
feat: return valid OAuth2 response body by default

### DIFF
--- a/docs/examples/contrib/jwt/using_oauth2_password_bearer.py
+++ b/docs/examples/contrib/jwt/using_oauth2_password_bearer.py
@@ -13,7 +13,7 @@ from starlite import (
     get,
     post,
 )
-from starlite.contrib.jwt import OAuth2PasswordBearerAuth, Token
+from starlite.contrib.jwt import OAuth2Login, OAuth2PasswordBearerAuth, Token
 
 
 # Let's assume we have a User model that is a pydantic model.
@@ -52,8 +52,22 @@ oauth2_auth = OAuth2PasswordBearerAuth[User](
 
 # Given an instance of 'OAuth2PasswordBearerAuth' we can create a login handler function:
 @post("/login")
-async def login_handler(request: "Request[Any, Any]", data: User) -> Response[User]:
+async def login_handler(request: "Request[Any, Any]", data: User) -> Response[OAuth2Login]:
     await request.cache.set(str(data.id), data.dict())
+    # if we do not define a response body, the login process will return a standard OAuth2 login response.  Note the `Response[OAuth2Login]` return type.
+    response = oauth2_auth.login(identifier=str(data.id))
+
+    # you can do whatever you want to update the response instance here
+    # e.g. response.set_cookie(...)
+
+    return response
+
+
+@post("/login_custom")
+async def login_custom_response_handler(request: "Request[Any, Any]", data: User) -> Response[User]:
+    await request.cache.set(str(data.id), data.dict())
+
+    # If you'd like to define a custom response body, use the `response_body` parameter.  Note the `Response[User]` return type.
     response = oauth2_auth.login(identifier=str(data.id), response_body=data)
 
     # you can do whatever you want to update the response instance here

--- a/starlite/contrib/jwt/__init__.py
+++ b/starlite/contrib/jwt/__init__.py
@@ -1,12 +1,21 @@
-from .jwt_auth import JWTAuth, JWTCookieAuth, OAuth2PasswordBearerAuth
-from .jwt_token import Token
-from .middleware import JWTAuthenticationMiddleware, JWTCookieAuthenticationMiddleware
+from starlite.contrib.jwt.jwt_auth import (
+    JWTAuth,
+    JWTCookieAuth,
+    OAuth2Login,
+    OAuth2PasswordBearerAuth,
+)
+from starlite.contrib.jwt.jwt_token import Token
+from starlite.contrib.jwt.middleware import (
+    JWTAuthenticationMiddleware,
+    JWTCookieAuthenticationMiddleware,
+)
 
 __all__ = (
     "JWTAuth",
     "JWTAuthenticationMiddleware",
     "JWTCookieAuth",
     "JWTCookieAuthenticationMiddleware",
+    "OAuth2Login",
     "OAuth2PasswordBearerAuth",
     "Token",
 )

--- a/starlite/contrib/jwt/jwt_auth.py
+++ b/starlite/contrib/jwt/jwt_auth.py
@@ -314,9 +314,9 @@ class OAuth2Login(BaseModel):
 
     access_token: str
     """Valid JWT access token"""
-    refresh_token: str | None = None
+    refresh_token: Optional[str] = None
     """Optional valid refresh token JWT"""
-    expires_in: int | None = None
+    expires_in: Optional[int] = None
     """Expiration time of the token in seconds. """
     token_type: str
 

--- a/tests/contrib/jwt/test_auth.py
+++ b/tests/contrib/jwt/test_auth.py
@@ -323,7 +323,7 @@ async def test_oauth2_password_bearer_auth_openapi(
         return await mock_db.get(token.sub)
 
     jwt_auth = OAuth2PasswordBearerAuth(
-        token_url="/login", token_secret="abc123", retrieve_user_handler=retrieve_user_handler
+        token_url="/login", token_secret="abc123", retrieve_user_handler=retrieve_user_handler  # type: ignore
     )
 
     @get("/login")

--- a/tests/contrib/jwt/test_auth.py
+++ b/tests/contrib/jwt/test_auth.py
@@ -311,10 +311,35 @@ def test_jwt_auth_openapi() -> None:
     }
 
 
-def test_oauth2_password_bearer_auth_openapi() -> None:
+async def test_oauth2_password_bearer_auth_openapi(
+    mock_db: "SimpleCacheBackend",
+) -> None:
+    user = UserFactory.build()
+
+    await mock_db.set(str(user.id), user, 120)
+
+    async def retrieve_user_handler(token: Token, connection: Any) -> Any:
+        assert connection
+        return await mock_db.get(token.sub)
+
     jwt_auth = OAuth2PasswordBearerAuth(
-        token_url="/login", token_secret="abc123", retrieve_user_handler=lambda _: None  # type: ignore
+        token_url="/login", token_secret="abc123", retrieve_user_handler=retrieve_user_handler
     )
+
+    @get("/login")
+    def login_handler() -> Response["User"]:
+        return jwt_auth.login(identifier=str(user.id))
+
+    @get("/login_custom")
+    def login_custom_handler() -> Response["User"]:
+        return jwt_auth.login(identifier=str(user.id), response_body=user)
+
+    with create_test_client(route_handlers=[login_custom_handler, login_handler]) as client:
+        response = client.get("/login")
+        response_custom = client.get("/login_custom")
+        assert "access_token" in response.content.decode()
+        assert response.content != response_custom.content
+
     assert jwt_auth.openapi_components.dict(exclude_none=True) == {
         "securitySchemes": {
             "BearerToken": {


### PR DESCRIPTION
This enhancement sets the default response for the `OAuth2PasswordBearerAuth` login to a valid [RFC-6749 response](https://www.rfc-editor.org/rfc/rfc6749#section-4.1.4):

The RFC specifies the following fields to be included on a response (any others can be appended to this list): 
```json
{
       "access_token":"2YotnFZFEjr1zCsicMWpAA",
       "token_type":"bearer",
       "expires_in":3600,
       "refresh_token":""
     }
```

If you do not specify a `response_body` when calling the login function, it will return an `OAuth2Login` response.

