### PR TITLE
Class As Dependency

### DIFF
--- a/docs/examples/datastructures/pagination/using_offset_pagination_with_sqlalchemy.py
+++ b/docs/examples/datastructures/pagination/using_offset_pagination_with_sqlalchemy.py
@@ -1,0 +1,52 @@
+from typing import List, TYPE_CHECKING
+
+from sqlalchemy import Column, Integer, String, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, declarative_base
+
+from starlite import AbstractAsyncOffsetPaginator, OffsetPagination, Provide, Starlite, get
+from starlite.plugins.sql_alchemy import SQLAlchemyConfig, SQLAlchemyPlugin
+
+Base = declarative_base()
+
+if TYPE_CHECKING:
+    from sqlalchemy.engine.result import ScalarResult
+
+
+class Person(Base):
+    id: Mapped[int] = Column(Integer, primary_key=True)
+    name: Mapped[str] = Column(String)
+
+
+class PersonOffsetPaginator(AbstractAsyncOffsetPaginator[Person]):
+    def __init__(self, async_session: AsyncSession) -> None:  # 'async_session' dependency will be injected here.
+        self.async_session = async_session
+
+    async def get_total(self) -> int:
+        return await self.async_session.scalar(select(func.count(Person.id)))
+
+    async def get_items(self, limit: int, offset: int) -> List[Person]:
+        people: "ScalarResult" = await self.async_session.scalars(select(Person).slice(offset, limit))
+        return list(people.all())
+
+
+# Create a route handler. The handler will receive two query parameters - 'limit' and 'offset', which is passed
+# to the paginator instance. Also create a dependency 'paginator' which will be injected into the handler.
+@get("/people", dependencies={"paginator": Provide(PersonOffsetPaginator)})
+async def people_handler(paginator: PersonOffsetPaginator, limit: int, offset: int) -> OffsetPagination[Person]:
+    return await paginator(limit=limit, offset=offset)
+
+
+sqlalchemy_config = SQLAlchemyConfig(
+    connection_string="sqlite+aiosqlite:///test.sqlite", dependency_key="async_session"
+)  # Create 'async_session' dependency.
+sqlalchemy_plugin = SQLAlchemyPlugin(config=sqlalchemy_config)
+
+
+async def on_startup() -> None:
+    """Initializes the database."""
+    async with sqlalchemy_config.engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+app = Starlite(route_handlers=[people_handler], on_startup=[on_startup], plugins=[sqlalchemy_plugin])

--- a/docs/usage/responses.rst
+++ b/docs/usage/responses.rst
@@ -780,6 +780,20 @@ If you require async logic, you can implement
 the :class:`AbstractAsyncOffsetPaginator <starlite.datastructures.pagination.AbstractAsyncOffsetPaginator>` instead of
 the :class:`AbstractSyncOffsetPaginator <starlite.datastructures.pagination.AbstractSyncOffsetPaginator>`.
 
+Offset Pagination With SQLAlchemy
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When retrieving paginated data from the database by using sqlalchemy, the paginator instance requires sqlalchemy session
+instance to make queries. This can be achieved with :ref:`dependency injection <usage/dependency-injection:dependency
+kwargs>`
+
+.. literalinclude:: /examples/datastructures/pagination/using_offset_pagination_with_sqlalchemy.py
+    :caption: Offset Pagination With SQLAlchemy
+    :language: python
+
+
+See :ref:`SQLAlchemy plugin <usage/plugins/sqlalchemy:SQLAlchemy Plugin>` for sqlalchemy integration.
+
 Cursor Pagination
 +++++++++++++++++
 

--- a/docs/usage/responses.rst
+++ b/docs/usage/responses.rst
@@ -783,7 +783,7 @@ the :class:`AbstractSyncOffsetPaginator <starlite.datastructures.pagination.Abst
 Offset Pagination With SQLAlchemy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-When retrieving paginated data from the database by using sqlalchemy, the paginator instance requires sqlalchemy session
+When retrieving paginated data from the database using SQLAlchemy, the Paginator instance requires an SQLAlchemy session
 instance to make queries. This can be achieved with :ref:`dependency injection <usage/dependency-injection:dependency
 kwargs>`
 

--- a/starlite/datastructures/provide.py
+++ b/starlite/datastructures/provide.py
@@ -1,4 +1,4 @@
-from inspect import isasyncgen
+import inspect
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -57,7 +57,7 @@ class Provide:
         self.dependency = Ref["AnyCallable"](dependency)
         self.use_cache = use_cache
         self.value: Any = Empty
-        self.has_sync_callable = not is_async_callable(self.dependency.value)
+        self.has_sync_callable = inspect.isclass(self.dependency.value) or not is_async_callable(self.dependency.value)
 
     async def __call__(self, **kwargs: Any) -> Any:
         """Proxy a call to ``self.proxy``."""
@@ -120,7 +120,7 @@ class DependencyCleanupGroup:
 
     @staticmethod
     def _wrap_next(generator: "AnyGenerator") -> Callable[[], Coroutine[None, None, None]]:
-        if isasyncgen(generator):
+        if inspect.isasyncgen(generator):
 
             async def wrapped_async() -> None:
                 await async_next(generator, None)  # type: ignore[arg-type]
@@ -179,7 +179,7 @@ class DependencyCleanupGroup:
         """
         for gen in self._generators:
             try:
-                if isasyncgen(gen):
+                if inspect.isasyncgen(gen):
                     await gen.athrow(exc)
                 else:
                     gen.throw(exc)  # type: ignore[union-attr]

--- a/starlite/datastructures/provide.py
+++ b/starlite/datastructures/provide.py
@@ -1,4 +1,4 @@
-import inspect
+from inspect import isasyncgen, isclass
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -57,7 +57,7 @@ class Provide:
         self.dependency = Ref["AnyCallable"](dependency)
         self.use_cache = use_cache
         self.value: Any = Empty
-        self.has_sync_callable = inspect.isclass(self.dependency.value) or not is_async_callable(self.dependency.value)
+        self.has_sync_callable = isclass(self.dependency.value) or not is_async_callable(self.dependency.value)
 
     async def __call__(self, **kwargs: Any) -> Any:
         """Proxy a call to ``self.proxy``."""
@@ -120,7 +120,7 @@ class DependencyCleanupGroup:
 
     @staticmethod
     def _wrap_next(generator: "AnyGenerator") -> Callable[[], Coroutine[None, None, None]]:
-        if inspect.isasyncgen(generator):
+        if isasyncgen(generator):
 
             async def wrapped_async() -> None:
                 await async_next(generator, None)  # type: ignore[arg-type]
@@ -179,7 +179,7 @@ class DependencyCleanupGroup:
         """
         for gen in self._generators:
             try:
-                if inspect.isasyncgen(gen):
+                if isasyncgen(gen):
                     await gen.athrow(exc)
                 else:
                     gen.throw(exc)  # type: ignore[union-attr]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,6 +43,9 @@ sync_callable = SyncTestCallable()
         (sync_callable.method, False),
         (async_func, True),
         (sync_func, False),
+        (lambda: ..., False),
+        (AsyncTestCallable, True),
+        (SyncTestCallable, False),
     ],
 )
 def test_is_async_callable(c: Callable[[int, int], None], exp: bool) -> None:


### PR DESCRIPTION
Currently, the `Provide` class takes a callable and accordingly calls it based on if it is a sync callable or an async callable. But when the class with an async `__call__` method is given to Provide, it awaits its `__init__` method. Class is callable but not awaitable so I have added a condition to always call the class as a sync object.

The offset pagination with sqlalchemy depends on this fix as I am passing the paginator class directly to Provide to create its dependency.