### PR TITLE
Docs: Add version warning for outdated / development versions.

### DIFF
--- a/docs/_static/js/version_select.js
+++ b/docs/_static/js/version_select.js
@@ -29,39 +29,72 @@ const createSelectedVersionEl = (currentVersion, latestVersion) => {
     return container
 }
 
-const makeVersionSelect = () => {
+
+const addVersionBanner = ({selectedVersion, latestVersion}) => {
+    if (selectedVersion === latestVersion) {
+        return
+    }
+    const page = document.querySelector(".page")
+    if (!page) {
+        return
+    }
+
+    const container = document.createElement("div")
+    container.id = "version-warning"
+    const versionAdjective = selectedVersion === "dev" ? "a preview" : "an older"
+
+    const versionText = document.createElement("span")
+    versionText.textContent = `You are viewing the documentation for ${versionAdjective} version of Starlite.`
+
+    const latestLink = document.createElement("a")
+    latestLink.href = baseURL + "latest"
+    latestLink.textContent = "Click here to get to the latest version"
+
+    container.appendChild(versionText)
+    container.appendChild(latestLink)
+
+    page.parentElement.insertBefore(container, page)
+}
+
+const addVersionSelect = ({versions, selectedVersion, latestVersion}) => {
+    const searchBoxElement = document.getElementById("searchbox")
+    const selectContainer = document.createElement("div")
+
+    selectContainer.id = "version-select"
+
+    const selectedVersionElement = createSelectedVersionEl(selectedVersion, latestVersion)
+    selectContainer.appendChild(selectedVersionElement)
+
+    const listElement = document.createElement("ul")
+    listElement.classList.add("hidden")
+    listElement.addEventListener("click", () => container.classList.toggle("hidden"))
+    versions.forEach(version => {
+        const listItem = document.createElement("li")
+        const link = document.createElement("a")
+        link.textContent = version.version === latestVersion ? version.title + " (latest)" : version.title
+        link.href = baseURL + version.version
+        listItem.appendChild(link)
+        listElement.appendChild(listItem)
+
+    })
+    selectContainer.appendChild(listElement)
+    searchBoxElement.after(selectContainer)
+}
+
+const setupVersionUtils = () => {
     const selectedVersion = getSelectedVersion()
     if (selectedVersion === null) {
         return
     }
 
     loadVersions().then(versions => {
-        const searchBoxElement = document.getElementById("searchbox")
-        const selectContainer = document.createElement("div")
-
-        selectContainer.id = "version-select"
-
         const latestVersion = versions[0]["version"]
-        const selectedVersionElement = createSelectedVersionEl(selectedVersion, latestVersion)
-        selectContainer.appendChild(selectedVersionElement)
+        const versionSpec = {versions, selectedVersion, latestVersion}
 
-        const listElement = document.createElement("ul")
-        listElement.classList.add("hidden")
-        listElement.addEventListener("click", () => container.classList.toggle("hidden"))
-        versions.forEach(version => {
-            const listItem = document.createElement("li")
-            const link = document.createElement("a")
-            link.textContent = version.version === latestVersion ? version.title + " (latest)" : version.title
-            link.href = baseURL + version.version
-            listItem.appendChild(link)
-            listElement.appendChild(listItem)
-
-        })
-        selectContainer.appendChild(listElement)
-
-        searchBoxElement.after(selectContainer)
+        addVersionSelect(versionSpec)
+        addVersionBanner(versionSpec)
     })
 }
 
 
-window.addEventListener("DOMContentLoaded", makeVersionSelect)
+window.addEventListener("DOMContentLoaded", setupVersionUtils)

--- a/docs/_static/js/version_select.js
+++ b/docs/_static/js/version_select.js
@@ -23,7 +23,7 @@ const createSelectedVersionEl = (currentVersion, latestVersion) => {
     container.textContent = "Version: "
 
     const versionEl = document.createElement("span")
-    versionEl.textContent = currentVersion === "latest" ? latestVersion : currentVersion
+    versionEl.textContent = currentVersion === "latest" ? `${latestVersion} (latest)` : currentVersion
     container.appendChild(versionEl)
 
     return container

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -32,3 +32,24 @@
 .article-container p {
 	text-align: justify;
 }
+
+#version-warning {
+	top: 0;
+	position: sticky;
+	z-index: 60;
+	width: 100%;
+	height: 2.5rem;
+	display: flex;
+	column-gap: .5rem;
+	justify-content: center;
+	justify-items: center;
+	align-items: center;
+	background-color: #eee;
+	border-bottom: 2px solid #ae2828;
+}
+
+@media (prefers-color-scheme: dark) {
+	body:not([data-theme="light"]) #version-warning {
+		background-color: black;
+	}
+}


### PR DESCRIPTION
Add a warning banner when viewing a documentation version for an outdated or development version of Starlite.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
