### PR TITLE
Don't show version banner if URL is 'latest'

### DIFF
--- a/docs/_static/js/version_select.js
+++ b/docs/_static/js/version_select.js
@@ -31,7 +31,7 @@ const createSelectedVersionEl = (currentVersion, latestVersion) => {
 
 
 const addVersionBanner = ({selectedVersion, latestVersion}) => {
-    if (selectedVersion === latestVersion) {
+    if (selectedVersion === latestVersion || selectedVersion === "latest") {
         return
     }
     const page = document.querySelector(".page")


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

The link in the sidebar of this repo directs to [https://starlite-api.github.io/starlite/latest/](https://starlite-api.github.io/starlite/latest/) which shows a warning that you're not viewing the latest version of the docs, which is wrong. The link within the banner also redirects to this same page so the only way to make it go away is click the sidebar link for the current latest version number.

My fix is just an update to the `addVersionBanner()` method. It's missing a condition to check if the current URL version is `"latest"`.

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/8821589/215600118-13344916-651b-40f7-98f4-85fe471aeb61.png">

