### PR TITLE
Configure logger and force "DEBUG" level in debug mode

### DIFF
--- a/starlite/config/logging.py
+++ b/starlite/config/logging.py
@@ -174,6 +174,7 @@ class LoggingConfig(BaseLoggingConfig, BaseModel):
             value["starlite"] = {
                 "level": "INFO",
                 "handlers": ["queue_listener"],
+                "propagate": False,
             }
         return value
 

--- a/tests/app/test_app_config.py
+++ b/tests/app/test_app_config.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 
+from starlite import LoggingConfig
 from starlite.app import DEFAULT_CACHE_CONFIG, Starlite
 from starlite.config.app import AppConfig
 from starlite.router import Router
@@ -99,3 +100,24 @@ def test_app_config_object_used(app_config_object: AppConfig, monkeypatch: pytes
     # this ensures that each of the properties of the `AppConfig` object have been accessed within `Starlite.__init__()`
     for mock in property_mocks:
         mock.assert_called()
+
+
+def test_app_debug_create_logger() -> None:
+    app = Starlite([], debug=True)
+
+    assert app.logging_config
+    assert app.logging_config.loggers["starlite"]["level"] == "DEBUG"  # type: ignore[attr-defined]
+
+
+def test_app_debug_explicitly_disable_logging() -> None:
+    app = Starlite([], debug=True, logging_config=None)
+
+    assert not app.logging_config
+
+
+def test_app_debug_update_logging_config() -> None:
+    logging_config = LoggingConfig()
+    app = Starlite([], debug=True, logging_config=logging_config)
+
+    assert app.logging_config is logging_config
+    assert app.logging_config.loggers["starlite"]["level"] == "DEBUG"  # type: ignore[attr-defined]


### PR DESCRIPTION
Implement the proposal made in https://github.com/starlite-api/starlite/pull/976#issuecomment-1410297133.

1. Configure a `starlite` logger in debug mode if no `LoggingConfig` was given, and `logging_config` was not explicitly set to `None`
2. Set the level of the `starlite` logger to `DEBUG` when in debug mode

This generally makes the use of `debug` more intuitive, especially in combination with #976: Setting `debug=True` will the result in exceptions being logged without having to specify any additional configuration. 

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.md`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
