### PR TITLE
add support for setting openapi operation summary to normalized callable name

### DIFF
--- a/starlite/openapi/path_item.py
+++ b/starlite/openapi/path_item.py
@@ -7,6 +7,7 @@ from pydantic_openapi_schema.v3_1_0.path_item import PathItem
 from starlite.openapi.parameters import create_parameter_for_handler
 from starlite.openapi.request_body import create_request_body
 from starlite.openapi.responses import create_responses
+from starlite.openapi.utils import SEPARATORS_CLEANUP_PATTERN
 from starlite.utils.helpers import unwrap_partial
 
 if TYPE_CHECKING:
@@ -97,7 +98,7 @@ def create_path_item(
             operation = Operation(
                 operationId=operation_id,
                 tags=tags,
-                summary=route_handler.summary,
+                summary=route_handler.summary or SEPARATORS_CLEANUP_PATTERN.sub("", route_handler.handler_name.title()),
                 description=get_description_for_handler(route_handler, use_handler_docstrings),
                 deprecated=route_handler.deprecated,
                 responses=create_responses(

--- a/tests/openapi/test_config.py
+++ b/tests/openapi/test_config.py
@@ -97,6 +97,7 @@ def test_allows_customization_of_operation_id_creator() -> None:
                 "deprecated": False,
                 "operationId": "x",
                 "responses": {"200": {"description": "Request fulfilled, document follows", "headers": {}}},
+                "summary": "Handler1",
             }
         },
         "/2": {
@@ -104,6 +105,7 @@ def test_allows_customization_of_operation_id_creator() -> None:
                 "deprecated": False,
                 "operationId": "y",
                 "responses": {"200": {"description": "Request fulfilled, document follows", "headers": {}}},
+                "summary": "Handler2",
             }
         },
     }

--- a/tests/openapi/test_path_item.py
+++ b/tests/openapi/test_path_item.py
@@ -55,12 +55,16 @@ def test_create_path_item(route: HTTPRoute) -> None:
     )
     assert schema.delete
     assert schema.delete.operationId == "ServiceIdPersonPersonIdDeletePerson"
+    assert schema.delete.summary == "DeletePerson"
     assert schema.get
     assert schema.get.operationId == "ServiceIdPersonPersonIdGetPersonById"
+    assert schema.get.summary == "GetPersonById"
     assert schema.patch
     assert schema.patch.operationId == "ServiceIdPersonPersonIdPartialUpdatePerson"
+    assert schema.patch.summary == "PartialUpdatePerson"
     assert schema.put
     assert schema.put.operationId == "ServiceIdPersonPersonIdUpdatePerson"
+    assert schema.put.summary == "UpdatePerson"
 
 
 def test_unique_operation_ids_for_multiple_http_methods(route_with_multiple_methods: HTTPRoute) -> None:


### PR DESCRIPTION
add support for setting openapi operation summary to normalized callable name

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
