### PR TITLE
Fix critical bug in parsing headers

### DIFF
--- a/starlite/parsers.py
+++ b/starlite/parsers.py
@@ -52,7 +52,7 @@ def parse_cookie_string(cookie_string: str) -> Dict[str, str]:
     return output
 
 
-@lru_cache(1024)
+# @lru_cache(1024)
 def parse_headers(headers: Tuple[Tuple[bytes, bytes], ...]) -> Dict[str, str]:
     """Parse ASGI headers into a dict of string keys and values.
 

--- a/starlite/parsers.py
+++ b/starlite/parsers.py
@@ -1,3 +1,4 @@
+import os
 from functools import lru_cache
 from http.cookies import _unquote as unquote_cookie
 from typing import Any, Dict, Tuple
@@ -63,3 +64,6 @@ def parse_headers(headers: Tuple[Tuple[bytes, bytes], ...]) -> Dict[str, str]:
         A string / string dict.
     """
     return {k.decode(): v.decode() for k, v in headers}
+
+if not "AWS_EXECUTION_ENV" in os.environ:
+    parse_headers = lru_cache(1024)(parse_headers)

--- a/starlite/parsers.py
+++ b/starlite/parsers.py
@@ -1,7 +1,6 @@
-import os
 from functools import lru_cache
 from http.cookies import _unquote as unquote_cookie
-from typing import Any, Dict, Tuple, Iterable
+from typing import Any, Dict, Iterable, List, Tuple, Union
 from urllib.parse import unquote
 
 from fast_query_parsers import parse_query_string as fast_parse_query_string
@@ -66,12 +65,11 @@ def _parse_headers(headers: Tuple[Tuple[bytes, bytes], ...]) -> Dict[str, str]:
     return {k.decode(): v.decode() for k, v in headers}
 
 
-def parse_headers(headers: Iterable[Iterable[Tuple[bytes, bytes]]]) -> Dict[str, str]:
-    """
-    Parse ASGI headers into a dict of string keys and values.
+def parse_headers(headers: Iterable[Union[Tuple[bytes, bytes], List[bytes]]]) -> Dict[str, str]:
+    """Parse ASGI headers into a dict of string keys and values.
 
     Since the ASGI protocol only allows for lists (not tuples) which cannot be hashed,
     this function will convert the headers to a tuple of tuples before invoking the cached function.
     """
-    headers = tuple(tuple(header) for header in headers)
+    headers = tuple(tuple(header) for header in headers)  # type: ignore[misc]
     return _parse_headers(headers)

--- a/starlite/parsers.py
+++ b/starlite/parsers.py
@@ -71,5 +71,4 @@ def parse_headers(headers: Iterable[Union[Tuple[bytes, bytes], List[bytes]]]) ->
     Since the ASGI protocol only allows for lists (not tuples) which cannot be hashed,
     this function will convert the headers to a tuple of tuples before invoking the cached function.
     """
-    headers = tuple(tuple(header) for header in headers)  # type: ignore[misc]
-    return _parse_headers(headers)
+    return _parse_headers(tuple(tuple(h) for h in headers))

--- a/starlite/parsers.py
+++ b/starlite/parsers.py
@@ -65,5 +65,6 @@ def parse_headers(headers: Tuple[Tuple[bytes, bytes], ...]) -> Dict[str, str]:
     """
     return {k.decode(): v.decode() for k, v in headers}
 
-if not "AWS_EXECUTION_ENV" in os.environ:
+
+if "AWS_EXECUTION_ENV" not in os.environ:
     parse_headers = lru_cache(1024)(parse_headers)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -9,6 +9,8 @@ from starlite.parsers import (
     parse_cookie_string,
     parse_query_string,
     parse_url_encoded_form_data,
+    parse_headers,
+    _parse_headers,
 )
 from starlite.testing import RequestFactory
 
@@ -105,3 +107,30 @@ def test_query_parsing_of_escaped_values(values: Tuple[Tuple[str, str], Tuple[st
         request = client.build_request(method=HttpMethod.GET, url="http://www.example.com", params=dict(values))
         parsed_query = parse_query_string(request.url.query)
         assert parsed_query == values
+
+
+def test_parse_headers():
+    """Test that headers are parsed correctly."""
+    headers = [
+        [b"Host", b"localhost:8000"],
+        [b"User-Agent", b"curl/7.64.1"],
+        [b"Accept", b"*/*"],
+        [b"Cookie", b"foo=bar; bar=baz"],
+        [b"Content-Type", b"application/x-www-form-urlencoded"],
+        [b"Content-Length", b"12"],
+    ]
+    parsed = parse_headers(headers)
+    assert parsed["Host"] == "localhost:8000"
+    assert parsed["User-Agent"] == "curl/7.64.1"
+    assert parsed["Accept"] == "*/*"
+    assert parsed["Cookie"] == "foo=bar; bar=baz"
+    assert parsed["Content-Type"] == "application/x-www-form-urlencoded"
+    assert parsed["Content-Length"] == "12"
+    # ensure that calling the function with the same headers doesn't raise
+    # an error due to lists not being hashable
+    parse_headers(headers)
+    # demonstrate that calling the private function with only strings (as ASGI) specifies
+    # does raise an error
+    with pytest.raises(TypeError):
+        _parse_headers(headers)
+        _parse_headers(headers)

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -6,11 +6,11 @@ import pytest
 from starlite import Cookie, HttpMethod, create_test_client
 from starlite.datastructures import MultiDict
 from starlite.parsers import (
+    _parse_headers,
     parse_cookie_string,
+    parse_headers,
     parse_query_string,
     parse_url_encoded_form_data,
-    parse_headers,
-    _parse_headers,
 )
 from starlite.testing import RequestFactory
 
@@ -109,7 +109,7 @@ def test_query_parsing_of_escaped_values(values: Tuple[Tuple[str, str], Tuple[st
         assert parsed_query == values
 
 
-def test_parse_headers():
+def test_parse_headers() -> None:
     """Test that headers are parsed correctly."""
     headers = [
         [b"Host", b"localhost:8000"],
@@ -126,7 +126,7 @@ def test_parse_headers():
     assert parsed["Cookie"] == "foo=bar; bar=baz"
     assert parsed["Content-Type"] == "application/x-www-form-urlencoded"
     assert parsed["Content-Length"] == "12"
-    # demonstrate that calling the private function with lists (as ASGI) specifies
+    # demonstrate that calling the private function with lists (as ASGI specifies)
     # does raise an error
     with pytest.raises(TypeError):
-        _parse_headers(headers)
+        _parse_headers(headers)  # type: ignore[arg-type]

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -126,11 +126,7 @@ def test_parse_headers():
     assert parsed["Cookie"] == "foo=bar; bar=baz"
     assert parsed["Content-Type"] == "application/x-www-form-urlencoded"
     assert parsed["Content-Length"] == "12"
-    # ensure that calling the function with the same headers doesn't raise
-    # an error due to lists not being hashable
-    parse_headers(headers)
-    # demonstrate that calling the private function with only strings (as ASGI) specifies
+    # demonstrate that calling the private function with lists (as ASGI) specifies
     # does raise an error
     with pytest.raises(TypeError):
-        _parse_headers(headers)
         _parse_headers(headers)


### PR DESCRIPTION
# Description

This bug addresses a bug when parsing HTTP headers from `scope["headers"]`.

Currently, the `parse_headers` function is decorated with `lru_cache` which can't hash lists. 

This is problematic because lists (not tuples) are what the ASGI protocol allows for since they're serializable. 

The ASGI server will pass lists of lists to `parse_headers` leading to `TypeError`.

We are currently running into this bug with starlite `1.51.0`

> Because these messages could be sent over a network, they need to be serializable, and so they are only allowed to contain the following types:

    Byte strings
    Unicode strings
    Integers (within the signed 64-bit range)
    Floating point numbers (within the IEEE 754 double precision range; no Nan or infinities)
    Lists (tuples should be encoded as lists)
    Dicts (keys must be Unicode strings)
    Booleans
    None

This PR maintains the current internal API for `parse_headers` by casting its input to a tuple of tuples and passing it to the original, decorated function.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?
