### PR TITLE
fix: JWT Auth correctly handles `domain` configuration value.

### DIFF
--- a/starlite/contrib/jwt/jwt_auth.py
+++ b/starlite/contrib/jwt/jwt_auth.py
@@ -310,7 +310,7 @@ class JWTCookieAuth(Generic[UserType], JWTAuth[UserType]):
             path=self.path,
             httponly=True,
             value=self.format_auth_header(encoded_token),
-            expires=int((datetime.now(timezone.utc) + (token_expiration or self.default_token_expiration)).timestamp()),
+            max_age=int((token_expiration or self.default_token_expiration).total_seconds()),
             secure=self.secure,
             samesite=self.samesite,
             domain=self.domain,
@@ -434,13 +434,13 @@ class OAuth2PasswordBearerAuth(Generic[UserType], JWTCookieAuth[UserType]):
             token_audience=token_audience,
             token_unique_jwt_id=token_unique_jwt_id,
         )
-        expires_in = int((datetime.now(timezone.utc) + (token_expiration or self.default_token_expiration)).timestamp())
+        expires_in = int((token_expiration or self.default_token_expiration).total_seconds())
         cookie = Cookie(
             key=self.key,
             path=self.path,
             httponly=True,
             value=self.format_auth_header(encoded_token),
-            expires=expires_in,
+            max_age=expires_in,
             secure=self.secure,
             samesite=self.samesite,
             domain=self.domain,

--- a/starlite/contrib/jwt/jwt_auth.py
+++ b/starlite/contrib/jwt/jwt_auth.py
@@ -313,6 +313,7 @@ class JWTCookieAuth(Generic[UserType], JWTAuth[UserType]):
             expires=int((datetime.now(timezone.utc) + (token_expiration or self.default_token_expiration)).timestamp()),
             secure=self.secure,
             samesite=self.samesite,
+            domain=self.domain,
         )
 
         if response_body is not Empty:
@@ -442,6 +443,7 @@ class OAuth2PasswordBearerAuth(Generic[UserType], JWTCookieAuth[UserType]):
             expires=expires_in,
             secure=self.secure,
             samesite=self.samesite,
+            domain=self.domain,
         )
 
         if response_body is not Empty:

--- a/tests/contrib/jwt/test_auth.py
+++ b/tests/contrib/jwt/test_auth.py
@@ -208,6 +208,7 @@ async def test_jwt_cookie_auth(
             "/my-endpoint",
         )
         assert response.status_code == HTTP_200_OK
+        assert response.cookies.get(jwt_auth.key) == f"key={jwt_auth.key}; Path=/; SameSite=lax"
 
         client.cookies.clear()
         response = client.get("/my-endpoint", headers={auth_header: encoded_token})


### PR DESCRIPTION
The JWT Cookie Auth configuration was missing the parameter for `domain` when setting the response cookie.  This PR adds that parameter.