### PR TITLE
Fix #1228: create a new dictionary of values in obfuscate()

### DIFF
--- a/starlite/utils/extractors.py
+++ b/starlite/utils/extractors.py
@@ -35,10 +35,7 @@ def obfuscate(values: Dict[str, Any], fields_to_obfuscate: Set[str]) -> Dict[str
     Returns:
         A dictionary with obfuscated strings
     """
-    for key in values:
-        if key.lower() in fields_to_obfuscate:
-            values[key] = "*****"
-    return values
+    return {key: "*****" if key.lower() in fields_to_obfuscate else value for key, value in values.items()}
 
 
 RequestExtractorField = Literal[


### PR DESCRIPTION
# PR Checklist

- [X] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [X] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

It looks like this issue can be resolved by simply passing a copy of `connection.cookies` to the `obfuscate()` function in [starlite/utils/extractors.py](https://github.com/starlite-api/starlite/blob/e21052705875d0657cbe3aeeeadc1a074e7b354e/starlite/utils/extractors.py#L218). The addition of `copy()` allows the test I created to pass, and it fixes the issue in the application in which the bug was original observed.