### PR TITLE
Fix CLI `--reload` flag not working as expected

### DIFF
--- a/starlite/cli/commands/core.py
+++ b/starlite/cli/commands/core.py
@@ -10,7 +10,7 @@ from click import command, option
 from rich.tree import Tree
 
 from starlite import Starlite
-from starlite.cli.utils import StarliteCLIException, StarliteEnv, console, show_app_info
+from starlite.cli.utils import StarliteEnv, console, show_app_info
 from starlite.routes import HTTPRoute, WebSocketRoute
 from starlite.utils.helpers import unwrap_partial
 
@@ -64,11 +64,6 @@ def run_command(
     functions with the name ``create_app`` are considered, or functions that are annotated as returning a ``Starlite``
     instance.
     """
-
-    try:
-        pass
-    except ImportError:
-        raise StarliteCLIException("Uvicorn needs to be installed to run an app")  # pylint: disable=W0707
 
     if debug or env.debug:
         app.debug = True


### PR DESCRIPTION
Fixes #1191 by invoking uvicorn with `subprocess.run`. This is the only actual workaround due to https://github.com/encode/uvicorn/issues/1045.

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
