### PR TITLE
De-referencing forward referenced annotations for signature models.

### DIFF
--- a/starlite/signature/parsing.py
+++ b/starlite/signature/parsing.py
@@ -18,6 +18,7 @@ from starlite.plugins.base import (
     get_plugin_for_value,
 )
 from starlite.signature.models import PydanticSignatureModel, SignatureModel
+from starlite.signature.utils import get_fn_type_hints
 from starlite.types import Empty
 from starlite.utils import is_optional_union
 from starlite.utils.helpers import unwrap_partial
@@ -36,13 +37,16 @@ class ParsedSignatureParameter:
     optional: bool
 
     @classmethod
-    def from_parameter(cls, fn_name: str, parameter_name: str, parameter: Parameter) -> ParsedSignatureParameter:
+    def from_parameter(
+        cls, fn_name: str, parameter_name: str, parameter: Parameter, fn_type_hints: dict[str, Any]
+    ) -> ParsedSignatureParameter:
         """Initialize ParsedSignatureParameter.
 
         Args:
             fn_name: Name of function.
             parameter_name: Name of parameter.
             parameter: inspect.Parameter
+            fn_type_hints: mapping of names to types for resolution of forward references.
 
         Returns:
             ParsedSignatureParameter.
@@ -53,8 +57,12 @@ class ParsedSignatureParameter:
                 f"should receive any value, use the 'Any' type."
             )
 
+        annotation: Any = parameter.annotation
+        if isinstance(annotation, str) and parameter_name in fn_type_hints:
+            annotation = fn_type_hints[parameter_name]
+
         return ParsedSignatureParameter(
-            annotation=parameter.annotation,
+            annotation=annotation,
             default=parameter.default,
             name=parameter_name,
             optional=is_optional_union(parameter.annotation),
@@ -120,7 +128,6 @@ def parse_fn_signature(
         A tuple containing the following values for generating a signature model: a mapping of field definitions, the
         callable's return annotation, a mapping of field names to plugins - if any, and an updated dependency name set.
     """
-
     signature = Signature.from_callable(fn)
     fn_name = getattr(fn, "__name__", "anonymous")
 
@@ -128,11 +135,14 @@ def parse_fn_signature(
     parsed_params: list[ParsedSignatureParameter] = []
     dependency_names: set[str] = set()
 
-    for parameter in (
-        ParsedSignatureParameter.from_parameter(parameter=parameter, parameter_name=name, fn_name=fn_name)
+    parameters = (
+        ParsedSignatureParameter.from_parameter(
+            parameter=parameter, parameter_name=name, fn_name=fn_name, fn_type_hints=get_fn_type_hints(fn)
+        )
         for name, parameter in signature.parameters.items()
         if name not in ("self", "cls")
-    ):
+    )
+    for parameter in parameters:
         if isinstance(parameter.default, DependencyKwarg) and parameter.name not in dependency_name_set:
             if not parameter.optional and (
                 isinstance(parameter.default, DependencyKwarg) and parameter.default.default is Empty

--- a/starlite/signature/parsing.py
+++ b/starlite/signature/parsing.py
@@ -134,10 +134,11 @@ def parse_fn_signature(
     field_plugin_mappings: dict[str, PluginMapping] = {}
     parsed_params: list[ParsedSignatureParameter] = []
     dependency_names: set[str] = set()
+    fn_type_hints = get_fn_type_hints(fn)
 
     parameters = (
         ParsedSignatureParameter.from_parameter(
-            parameter=parameter, parameter_name=name, fn_name=fn_name, fn_type_hints=get_fn_type_hints(fn)
+            parameter=parameter, parameter_name=name, fn_name=fn_name, fn_type_hints=fn_type_hints
         )
         for name, parameter in signature.parameters.items()
         if name not in ("self", "cls")

--- a/starlite/signature/utils.py
+++ b/starlite/signature/utils.py
@@ -1,11 +1,38 @@
 from __future__ import annotations
 
+import sys
+from inspect import isclass, ismethod
 from typing import TYPE_CHECKING, Any, cast
 
+from typing_extensions import get_type_hints
+
+from starlite.connection import Request, WebSocket
+from starlite.datastructures import Headers, ImmutableState, State
 from starlite.exceptions import ImproperlyConfiguredException
+from starlite.types import ASGIApp, HTTPScope, Receive, Scope, Send, WebSocketScope
+from starlite.utils.compat import py_38_safe_annotations
 
 if TYPE_CHECKING:
     from starlite.signature.models import SignatureModel
+
+
+STARLITE_GLOBAL_NAMES = {
+    "ASGIApp": ASGIApp,
+    "HTTPScope": HTTPScope,
+    "Headers": Headers,
+    "ImmutableState": ImmutableState,
+    "Receive": Receive,
+    "Request": Request,
+    "Scope": Scope,
+    "Send": Send,
+    "State": State,
+    "WebSocket": WebSocket,
+    "WebSocketScope": WebSocketScope,
+}
+"""A mapping of names used for handler signature forward-ref resolution.
+
+This allows users to include these names within an `if TYPE_CHECKING:` block in their handler module.
+"""
 
 
 def get_signature_model(value: Any) -> type[SignatureModel]:
@@ -14,3 +41,32 @@ def get_signature_model(value: Any) -> type[SignatureModel]:
         return cast("type[SignatureModel]", value.signature_model)
     except AttributeError as e:  # pragma: no cover
         raise ImproperlyConfiguredException(f"The 'signature_model' attribute for {value} is not set") from e
+
+
+def get_fn_type_hints(fn: Any) -> dict[str, Any]:
+    """Resolve type hits for ``fn``.
+
+    Args:
+        fn: Thing that is having its signature modelled.
+
+    Returns:
+        Mapping of names to types.
+    """
+    fn_to_inspect: Any = fn
+
+    if isclass(fn_to_inspect):
+        fn_to_inspect = fn_to_inspect.__init__
+
+    # detect objects that are not functions and that have a `__call__` method
+    if callable(fn_to_inspect) and ismethod(fn_to_inspect.__call__):
+        fn_to_inspect = fn_to_inspect.__call__
+
+    # inspect the underlying function for methods
+    if hasattr(fn_to_inspect, "__func__"):
+        fn_to_inspect = fn_to_inspect.__func__
+
+    # Order important. If a starlite name has been overridden in the function module, we want
+    # to use that instead of the starlite one.
+    namespace = {**STARLITE_GLOBAL_NAMES, **vars(sys.modules[fn_to_inspect.__module__])}
+    with py_38_safe_annotations(fn_to_inspect):
+        return get_type_hints(fn_to_inspect, globalns=namespace)

--- a/starlite/signature/utils.py
+++ b/starlite/signature/utils.py
@@ -9,7 +9,7 @@ from typing_extensions import get_type_hints
 from starlite.connection import Request, WebSocket
 from starlite.datastructures import Headers, ImmutableState, State
 from starlite.exceptions import ImproperlyConfiguredException
-from starlite.types import ASGIApp, HTTPScope, Receive, Scope, Send, WebSocketScope
+from starlite.types import Receive, Scope, Send, WebSocketScope
 from starlite.utils.compat import py_38_safe_annotations
 
 if TYPE_CHECKING:
@@ -17,8 +17,6 @@ if TYPE_CHECKING:
 
 
 STARLITE_GLOBAL_NAMES = {
-    "ASGIApp": ASGIApp,
-    "HTTPScope": HTTPScope,
     "Headers": Headers,
     "ImmutableState": ImmutableState,
     "Receive": Receive,

--- a/starlite/signature/utils.py
+++ b/starlite/signature/utils.py
@@ -44,7 +44,7 @@ def get_signature_model(value: Any) -> type[SignatureModel]:
 
 
 def get_fn_type_hints(fn: Any) -> dict[str, Any]:
-    """Resolve type hits for ``fn``.
+    """Resolve type hints for ``fn``.
 
     Args:
         fn: Thing that is having its signature modelled.

--- a/starlite/static_files/base.py
+++ b/starlite/static_files/base.py
@@ -43,8 +43,8 @@ class StaticFiles:
         self.send_as_attachment = send_as_attachment
 
     async def get_fs_info(
-        self, directories: Sequence["PathType"], file_path: str
-    ) -> tuple[str, "FileInfo"] | tuple[None, None]:
+        self, directories: Sequence[PathType], file_path: str
+    ) -> tuple[str, FileInfo] | tuple[None, None]:
         """Return the resolved path and a :func:`stat_result <os.stat_result>`.
 
         Args:
@@ -65,7 +65,7 @@ class StaticFiles:
                 continue
         return None, None
 
-    async def __call__(self, scope: "Scope", receive: "Receive", send: "Send") -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         """ASGI callable.
 
         Args:

--- a/starlite/utils/compat.py
+++ b/starlite/utils/compat.py
@@ -28,7 +28,7 @@ except NameError:  # pragma: no cover
 
 @contextmanager
 def py_38_safe_annotations(annotated: Any) -> Generator[Any, None, None]:
-    """Ensure annotations that are backward compatible with Python 3.8.
+    """Ensure annotations are backward compatible with Python 3.8.
 
     If detected python version is < 3.9, converts forward referenced annotations like `"A | B"` into `"Union[A, B]"`.
 

--- a/starlite/utils/compat.py
+++ b/starlite/utils/compat.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
-from typing import Any, AsyncGenerator, TypeVar
+import sys
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, TypeVar
 
 from starlite.types import Empty, EmptyType
+
+if TYPE_CHECKING:
+    from typing import Any, AsyncGenerator, Generator
 
 T = TypeVar("T")
 D = TypeVar("D")
@@ -19,3 +24,30 @@ except NameError:  # pragma: no cover
             if default is not Empty:
                 return default  # type: ignore[return-value]
             raise exc
+
+
+@contextmanager
+def py_38_safe_annotations(annotated: Any) -> Generator[Any, None, None]:
+    """Ensure annotations that are backward compatible with Python 3.8.
+
+    If detected python version is < 3.9, converts forward referenced annotations like `"A | B"` into `"Union[A, B]"`.
+
+    On exit of the context manager, the original annotations are replaced.
+
+    Args:
+        annotated: something that has `__annotations__` attribute.
+
+    Yields:
+        ``annotated`` with patched `__annotations__` attribute if on python 3.8.
+    """
+    if sys.version_info < (3, 9):
+        orig_annotations = getattr(annotated, "__annotations__", {})
+        new_annotations = dict(orig_annotations)
+        for k, v in orig_annotations.items():
+            if isinstance(v, str) and "|" in v:
+                new_annotations[k] = f"Union[{','.join(map(str.strip, v.split('|')))}]"
+        annotated.__annotations__ = new_annotations
+        yield
+        annotated.__annotations__ = orig_annotations
+    else:
+        yield

--- a/tests/compatibility/test_starlette_responses.py
+++ b/tests/compatibility/test_starlette_responses.py
@@ -1,19 +1,14 @@
-from typing import TYPE_CHECKING
-
 from starlette.responses import JSONResponse
 
 from starlite import get
 from starlite.status_codes import HTTP_200_OK
 from starlite.testing import create_test_client
 
-if TYPE_CHECKING:
-    from starlite.types import ASGIApp
-
 
 def test_starlette_json_response() -> None:
     @get("/starlette-json-response")
-    def get_json_response() -> "ASGIApp":
-        return JSONResponse(content={"hello": "world"})  # type: ignore
+    def get_json_response() -> JSONResponse:
+        return JSONResponse(content={"hello": "world"})
 
     with create_test_client(get_json_response) as client:
         response = client.get("/starlette-json-response")

--- a/tests/signature/test_utils.py
+++ b/tests/signature/test_utils.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from starlite.signature.utils import get_fn_type_hints
+from starlite.static_files import StaticFiles
+from starlite.types.asgi_types import Receive, Scope, Send
+from starlite.types.builtin_types import NoneType
+from starlite.utils.file import BaseLocalFileSystem
+
+
+def test_get_fn_type_hints_asgi_app() -> None:
+    app = StaticFiles(is_html_mode=False, directories=[], file_system=BaseLocalFileSystem())
+    assert get_fn_type_hints(app) == {"scope": Scope, "receive": Receive, "send": Send, "return": NoneType}
+
+
+def func(a: int, b: str, c: float) -> None:
+    ...
+
+
+class C:
+    def __init__(self, a: int, b: str, c: float) -> None:
+        ...
+
+    def method(self, a: int, b: str, c: float) -> None:
+        ...
+
+    def __call__(self, a: int, b: str, c: float) -> None:
+        ...
+
+
+@pytest.mark.parametrize("fn", [func, C, C(1, "2", 3.0).method, C(1, "2", 3.0)])
+def test_get_fn_type_hints(fn: Any) -> None:
+    assert get_fn_type_hints(fn) == {"a": int, "b": str, "c": float, "return": NoneType}

--- a/tests/utils/test_compat.py
+++ b/tests/utils/test_compat.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+from starlite.utils.compat import py_38_safe_annotations
+
+if TYPE_CHECKING:
+    from pytest import MonkeyPatch
+
+
+def test_py38_safe_annotations_on_39_plus(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "version_info", (3, 9))
+
+    def func(a: int | str) -> None:
+        ...
+
+    with py_38_safe_annotations(func):
+        assert func.__annotations__["a"] == "int | str"
+
+
+def test_py38_safe_annotations_on_38(monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "version_info", (3, 8))
+
+    def func(a: int | str) -> None:
+        ...
+
+    assert func.__annotations__["a"] == "int | str"
+    with py_38_safe_annotations(func):
+        assert func.__annotations__["a"] == "Union[int,str]"
+    assert func.__annotations__["a"] == "int | str"


### PR DESCRIPTION
We currently rely on pydantic to resolve forward references for signature models. However, in order to continue our migration away from pydantic we should do this ourselves.

This change is a pre-cursor to add checks for improper use of reserved kwargs, such as 'state'. In order to check the type that is annotated against the reserved kwargs in function signatures, we need to have resolved any forward references to their types first.

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
