### PR TITLE
Check the type annotation of the `state` reserved kwarg.

### DIFF
--- a/starlite/signature/parsing.py
+++ b/starlite/signature/parsing.py
@@ -10,6 +10,7 @@ from pydantic_factories import ModelFactory
 from typing_extensions import get_args
 
 from starlite.constants import SKIP_VALIDATION_NAMES, UNDEFINED_SENTINELS
+from starlite.datastructures import ImmutableState
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.params import BodyKwarg, DependencyKwarg, ParameterKwarg
 from starlite.plugins.base import (
@@ -143,6 +144,13 @@ def parse_fn_signature(
         if name not in ("self", "cls")
     )
     for parameter in parameters:
+        if parameter.name == "state" and not issubclass(parameter.annotation, ImmutableState):
+            raise ImproperlyConfiguredException(
+                f"The type annotation `{parameter.annotation}` is an invalid type for the 'state' reserved kwarg. "
+                "It must be typed to a subclass of `starlite.datastructures.ImmutableState` or "
+                "`starlite.datastructures.State`."
+            )
+
         if isinstance(parameter.default, DependencyKwarg) and parameter.name not in dependency_name_set:
             if not parameter.optional and (
                 isinstance(parameter.default, DependencyKwarg) and parameter.default.default is Empty

--- a/tests/kwargs/test_reserved_kwargs_injection.py
+++ b/tests/kwargs/test_reserved_kwargs_injection.py
@@ -9,6 +9,7 @@ from starlite import (
     HttpMethod,
     MediaType,
     Request,
+    Starlite,
     delete,
     get,
     patch,
@@ -16,6 +17,7 @@ from starlite import (
     put,
 )
 from starlite.datastructures.state import ImmutableState, State
+from starlite.exceptions import ImproperlyConfiguredException
 from starlite.status_codes import (
     HTTP_200_OK,
     HTTP_201_CREATED,
@@ -296,3 +298,18 @@ def test_body(decorator: Any, http_method: Any, expected_status_code: Any) -> No
     with create_test_client(MyController) as client:
         response = client.request(http_method, test_path)
         assert response.status_code == expected_status_code
+
+
+def test_improper_use_of_state_kwarg() -> None:
+    """Test error condition of State kwarg with unexpected type.."""
+    test_path = "/bad-state"
+
+    class MyController(Controller):
+        path = test_path
+
+        @get()
+        async def test_method(self, state: str) -> None:
+            return None
+
+    with pytest.raises(ImproperlyConfiguredException):
+        Starlite(route_handlers=[MyController], openapi_config=None)


### PR DESCRIPTION
Depends on #1263.

Raises improper config exception where a user annotates "state" kwarg with anything other than a subclass of `ImmutableState`.

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
