### PR TITLE
Docs: Fix autorun examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ autodoc_typehints_format = "short"
 
 auto_pytabs_min_version = (3, 8)
 auto_pytabs_max_version = (3, 11)
+auto_pytabs_compat_mode = True
 
 autosectionlabel_prefix_document = True
 

--- a/tools/sphinx_ext.py
+++ b/tools/sphinx_ext.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Generator
 
 import httpx
 import uvicorn
-from auto_pytabs.sphinx_ext import LiteralIncludeOverride
+from auto_pytabs.sphinx_ext import CodeBlockOverride, LiteralIncludeOverride
 from docutils.nodes import Node, admonition, literal_block, title
 from sphinx.addnodes import highlightlang
 
@@ -174,6 +174,7 @@ def on_env_before_read_docs(app: Sphinx, env: BuildEnvironment, docnames: set[st
 
 def setup(app: Sphinx) -> dict[str, bool]:
     app.add_directive("literalinclude", LiteralInclude, override=True)
+    app.add_directive("code-block", CodeBlockOverride, override=True)
     app.connect("env-before-read-docs", on_env_before_read_docs)
 
     return {"parallel_read_safe": True, "parallel_write_safe": True}


### PR DESCRIPTION
Due to a change in AutoPyTabs our custom directive is overridden. This fixes it by using AutoPyTab's compatibility mode.

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
