### PR TITLE
Add package version parsing utils and `starlite.__version__`

### DIFF
--- a/starlite/__init__.py
+++ b/starlite/__init__.py
@@ -15,6 +15,10 @@ from starlite.handlers import (
 )
 from starlite.response import Response
 from starlite.router import Router
+from starlite.utils.version import get_version
+
+__version__ = get_version()
+
 
 __all__ = (
     "Controller",
@@ -34,4 +38,5 @@ __all__ = (
     "put",
     "route",
     "websocket",
+    "__version__",
 )

--- a/starlite/cli/_utils.py
+++ b/starlite/cli/_utils.py
@@ -5,7 +5,6 @@ import inspect
 import sys
 from dataclasses import dataclass
 from functools import wraps
-from importlib.metadata import version
 from os import getenv
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, TypeVar, cast
@@ -15,7 +14,7 @@ from rich.console import Console
 from rich.table import Table
 from typing_extensions import Concatenate, ParamSpec
 
-from starlite import Starlite
+from starlite import Starlite, __version__
 from starlite.middleware import DefineMiddleware
 from starlite.utils import get_name
 
@@ -284,7 +283,7 @@ def show_app_info(app: Starlite) -> None:  # pragma: no cover
     table.add_column("title", style="cyan")
     table.add_column("value", style="bright_blue")
 
-    table.add_row("Starlite version", version("starlite"))
+    table.add_row("Starlite version", f"{__version__.major}.{__version__.minor}.{__version__.patch}")
     table.add_row("Debug mode", _format_is_enabled(app.debug))
     table.add_row("CORS", _format_is_enabled(app.cors_config))
     table.add_row("CSRF", _format_is_enabled(app.csrf_config))

--- a/starlite/utils/version.py
+++ b/starlite/utils/version.py
@@ -1,0 +1,51 @@
+import re
+import sys
+from typing import Literal, NamedTuple
+
+__all__ = ("Version", "get_version", "parse_version")
+
+
+if sys.version_info >= (3, 10):
+    import importlib.metadata as importlib_metadata
+else:
+    import importlib_metadata  # pragma: no cover
+
+
+_PRE_RELEASE_TAGS = {"alpha", "beta", "rc"}
+_VERSION_PARTS_RE = re.compile(r"(\d+|[a-z]+|\.)")
+_ReleaseLevel = Literal["alpha", "beta", "rc", "final"]
+
+
+class Version(NamedTuple):
+    """Starlite version information"""
+
+    major: int
+    minor: int
+    patch: int
+    release_level: _ReleaseLevel
+    serial: int
+
+
+def parse_version(raw_version: str) -> Version:
+    """Parse a version string into a :class:`Version`"""
+    parts = [p for p in _VERSION_PARTS_RE.split(raw_version) if p and p != "."]
+    release_level: _ReleaseLevel = "final"
+    serial = "0"
+
+    if len(parts) == 3:
+        major, minor, patch = parts
+    elif len(parts) == 5:
+        major, minor, patch, release_level, serial = parts  # type: ignore[assignment]
+        if release_level not in _PRE_RELEASE_TAGS:
+            raise ValueError(f"Invalid release level: {release_level}")
+    else:
+        raise ValueError(f"Invalid version: {raw_version}")
+
+    return Version(
+        major=int(major), minor=int(minor), patch=int(patch), release_level=release_level, serial=int(serial)
+    )
+
+
+def get_version() -> Version:
+    """Get the version of the installed starlite package"""
+    return parse_version(importlib_metadata.version("starlite"))

--- a/starlite/utils/version.py
+++ b/starlite/utils/version.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 import sys
 from typing import Literal, NamedTuple
@@ -11,9 +13,11 @@ else:
     import importlib_metadata  # pragma: no cover
 
 
-_PRE_RELEASE_TAGS = {"alpha", "beta", "rc"}
-_VERSION_PARTS_RE = re.compile(r"(\d+|[a-z]+|\.)")
 _ReleaseLevel = Literal["alpha", "beta", "rc", "final"]
+_PRE_RELEASE_TAGS = {"alpha", "a", "beta", "b", "rc"}
+_PRE_RELEASE_TAGS_CONVERSIONS: dict[str, _ReleaseLevel] = {"a": "alpha", "b": "beta"}
+
+_VERSION_PARTS_RE = re.compile(r"(\d+|[a-z]+|\.)")
 
 
 class Version(NamedTuple):
@@ -38,6 +42,7 @@ def parse_version(raw_version: str) -> Version:
         major, minor, patch, release_level, serial = parts  # type: ignore[assignment]
         if release_level not in _PRE_RELEASE_TAGS:
             raise ValueError(f"Invalid release level: {release_level}")
+        release_level = _PRE_RELEASE_TAGS_CONVERSIONS.get(release_level, release_level)
     else:
         raise ValueError(f"Invalid version: {raw_version}")
 

--- a/tests/utils/test_version.py
+++ b/tests/utils/test_version.py
@@ -7,8 +7,10 @@ from starlite.utils.version import Version, parse_version
     "raw_version,expected",
     [
         ("2.0.0alpha1", Version(2, 0, 0, "alpha", 1)),
+        ("2.0.0a1", Version(2, 0, 0, "alpha", 1)),  # test importlib.metadata.version coercion
         ("2.0.0alpha2", Version(2, 0, 0, "alpha", 2)),
         ("2.0.0beta1", Version(2, 0, 0, "beta", 1)),
+        ("2.0.0b1", Version(2, 0, 0, "beta", 1)),  # test importlib.metadata.version coercion
         ("2.0.0beta2", Version(2, 0, 0, "beta", 2)),
         ("2.0.0rc1", Version(2, 0, 0, "rc", 1)),
         ("2.0.0rc2", Version(2, 0, 0, "rc", 2)),

--- a/tests/utils/test_version.py
+++ b/tests/utils/test_version.py
@@ -1,0 +1,26 @@
+import pytest
+
+from starlite.utils.version import Version, parse_version
+
+
+@pytest.mark.parametrize(
+    "raw_version,expected",
+    [
+        ("2.0.0alpha1", Version(2, 0, 0, "alpha", 1)),
+        ("2.0.0alpha2", Version(2, 0, 0, "alpha", 2)),
+        ("2.0.0beta1", Version(2, 0, 0, "beta", 1)),
+        ("2.0.0beta2", Version(2, 0, 0, "beta", 2)),
+        ("2.0.0rc1", Version(2, 0, 0, "rc", 1)),
+        ("2.0.0rc2", Version(2, 0, 0, "rc", 2)),
+        ("2.0.0", Version(2, 0, 0, "final", 0)),
+        ("2.13.45", Version(2, 13, 45, "final", 0)),
+    ],
+)
+def test_parse_version(raw_version: str, expected: Version) -> None:
+    assert parse_version(raw_version) == expected
+
+
+@pytest.mark.parametrize("raw_version", ["0.1", "1.0.0foo1", "1.0.0alpha", "1.0.0.0"])
+def test_parse_invalid_version(raw_version: str) -> None:
+    with pytest.raises(ValueError):
+        parse_version(raw_version)


### PR DESCRIPTION
Add utilities to parse the package version defined in `pyproject.toml` into a `NamedTuple` and expose the version information in `starlite.__version__`.

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
