### PR TITLE
Run CodeQL with dependencies on a schedule instead of within CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,9 +97,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Initialize CodeQL With Dependencies
-        if: github.event_name == 'push'
-        uses: github/codeql-action/init@v2
       - name: Initialize CodeQL Without Dependencies
         if: github.event_name == 'pull_request'
         uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,18 @@
+name: CodeQL scheduled
+on:
+  schedule:
+    - cron: "0 4 * * *"
+jobs:
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: "main"
+      - name: Initialize CodeQL With Dependencies
+        uses: github/codeql-action/init@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
Remove CodeQL (with dependencies) from the regular CI and set up a workflow that runs CodeQL with dependencies once a day.

Reasoning is that CodeQL with dependencies regularly takes 20+ minutes, which can quite bothersome if you're depending on the workflow to finish.

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
