### PR TITLE
Fix raising deprecation warning for wrong name.

### DIFF
--- a/starlite/middleware/session/__init__.py
+++ b/starlite/middleware/session/__init__.py
@@ -8,7 +8,7 @@ from .base import SessionMiddleware
 def __getattr__(name: str) -> Any:
     """Provide lazy importing as per https://peps.python.org/pep-0562/"""
 
-    if name != "SessionCookieConfig":
+    if name != "CookieBackendConfig":
         raise AttributeError(f"Module {__package__} has no attribute {name}")
 
     from .cookie_backend import CookieBackendConfig
@@ -16,7 +16,7 @@ def __getattr__(name: str) -> Any:
     warn_deprecation(
         deprecated_name=f"{name} from {__package__}",
         kind="import",
-        alternative="'from startlite.middleware.sessions.cookie_backend import CookieBackendConfig'",
+        alternative="'from starlite.middleware.session.cookie_backend import CookieBackendConfig'",
         version="1.47.0",
     )
 

--- a/starlite/template/__init__.py
+++ b/starlite/template/__init__.py
@@ -32,7 +32,7 @@ def __getattr__(name: str) -> Any:
     warn_deprecation(
         deprecated_name=f"{name} from {__package__}",
         kind="import",
-        alternative=f"'from startlite.contrib.{module} import {name}'",
+        alternative=f"'from starlite.contrib.{module} import {name}'",
         version="1.46.0",
     )
 


### PR DESCRIPTION
Corrects an incorrect name check in `starlite/middleware/session/__init__.py` that was causing a deprecation error  to be thrown for the wrong type.

Closes #1284

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
