### PR TITLE
fix(docs): typo in core Starlite app

### DIFF
--- a/starlite/app.py
+++ b/starlite/app.py
@@ -463,7 +463,7 @@ class Starlite(Router):
         """Initialize a ``Starlite`` application from a configuration instance.
 
         Args:
-            config: An instance of :class:`AppConfig` <startlite.config.AppConfig>
+            config: An instance of :class:`AppConfig` <starlite.config.AppConfig>
 
         Returns:
             An instance of ``Starlite`` application.


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?


Fixes a typo `startlite` in the core Starlite application `from_config` class method.

Resolves #1287