### PR TITLE
Xfail windows flaky test

### DIFF
--- a/tests/template/test_builtin_functions.py
+++ b/tests/template/test_builtin_functions.py
@@ -14,6 +14,7 @@ from starlite.template.config import TemplateConfig
 from starlite.testing import create_test_client
 
 
+@pytest.mark.xfail(sys.platform == "win32", reason="For some reason this is flaky on windows")
 def test_jinja_url_for(template_dir: Path) -> None:
     template_config = TemplateConfig(engine=JinjaTemplateEngine, directory=template_dir)
 


### PR DESCRIPTION
Xfail `tests/templates/test_builtin_functions.py::test_jinja_url_for` because it is flaky on windows.
Follow up to #1282 

# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
