### PR TITLE
chore(ci): ruff should be run before all other formatting tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,11 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.254"
+    hooks:
+      - id: ruff
+        args: ["--fix"]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.4
     hooks:
@@ -31,11 +36,6 @@ repos:
     hooks:
       - id: prettier
         exclude: "_templates"
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.254"
-    hooks:
-      - id: ruff
-        args: ["--fix"]
   - repo: https://github.com/python-formate/flake8-dunder-all
     rev: v0.2.2
     hooks:


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?


As per [ruff-pre-commit guidance](https://github.com/charliermarsh/ruff-pre-commit):
> Note that Ruff's pre-commit hook should run before Black, isort, and other formatting tools.


This is because:
> If you're not running autofix on pre-commit, then you should run Black, isort, etc. first
The issue is that Ruff's autofixes aren't guaranteed to produce Black-stable code

> So if you run Black, then Ruff... then run Black again, you might see changes on that second Black invocation, because we might've produced some code that Black wants to reformat when we applied our autofixes
Black, for example, has really specific rules around when and how it wraps lines. So if we autofix something and introduce a tuple, Black might end up wanting to wrap that in a way that differs from what Ruff did by default.