### PR TITLE
Implement #1299: Accept header parsing and content negotiation

### DIFF
--- a/docs/examples/responses/response_content.py
+++ b/docs/examples/responses/response_content.py
@@ -1,0 +1,18 @@
+from starlite import MediaType, Request, Response, Starlite, get
+
+
+@get("/resource")
+def retrieve_resource(request: Request) -> Response[str]:
+    provided_types = [MediaType.TEXT, MediaType.HTML, "application/xml"]
+    preferred_type = request.accept.best_match(provided_types, default=MediaType.TEXT)
+
+    if preferred_type == MediaType.TEXT:
+        content = "Hello World!"
+    elif preferred_type == MediaType.HTML:
+        content = "<h1>Hello World!</h1>"
+    elif preferred_type == "application/xml":
+        content = "<xml><msg>Hello World!</msg></xml>"
+    return Response(content=content, media_type=preferred_type)
+
+
+app = Starlite(route_handlers=[retrieve_resource])

--- a/docs/examples/responses/response_content.py
+++ b/docs/examples/responses/response_content.py
@@ -2,17 +2,21 @@ from starlite import MediaType, Request, Response, Starlite, get
 
 
 @get("/resource")
-def retrieve_resource(request: Request) -> Response[str]:
+def retrieve_resource(request: Request) -> Response[bytes]:
     provided_types = [MediaType.TEXT, MediaType.HTML, "application/xml"]
     preferred_type = request.accept.best_match(provided_types, default=MediaType.TEXT)
 
     if preferred_type == MediaType.TEXT:
-        content = "Hello World!"
+        content = b"Hello World!"
     elif preferred_type == MediaType.HTML:
-        content = "<h1>Hello World!</h1>"
+        content = b"<h1>Hello World!</h1>"
     elif preferred_type == "application/xml":
-        content = "<xml><msg>Hello World!</msg></xml>"
+        content = b"<xml><msg>Hello World!</msg></xml>"
     return Response(content=content, media_type=preferred_type)
 
 
 app = Starlite(route_handlers=[retrieve_resource])
+
+# run: /resource
+# run: /resource -H "Accept: text/html"
+# run: /resource -H "Accept: application/xml"

--- a/docs/usage/responses.rst
+++ b/docs/usage/responses.rst
@@ -144,20 +144,11 @@ Content Negotiation
 If your handler can return data with different media types and you want to use
 `Content Negotiation <https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation>`_
 to allow the client to choose which type to return, you can use the
-:class:`Request.accept <starlite.connection.request.Request>` property to
+:attr:`Request.accept <starlite.connection.Request.accept>` property to
 calculate the best matching return media type.
 
 .. literalinclude:: /examples/responses/response_content.py
     :language: python
-
-.. code-block:: console
-
-    $ curl -H "Accept: text/plain" http://127.0.0.1:8000/resource
-    Hello World!
-    $ curl -H "Accept: text/html" http://127.0.0.1:8000/resource
-    <h1>Hello World!</h1>
-    $ curl -H "Accept: application/xml" http://127.0.0.1:8000/resource
-    <xml><msg>Hello World!</msg></xml>
 
 
 Status Codes

--- a/docs/usage/responses.rst
+++ b/docs/usage/responses.rst
@@ -138,6 +138,28 @@ For ``MediaType.HTML``, route handlers should return a :class:`str` or :class:`b
    and to write the template itself in a separate file rather than a string.
 
 
+Content Negotiation
+-------------------
+
+If your handler can return data with different media types and you want to use
+`Content Negotiation <https://developer.mozilla.org/en-US/docs/Web/HTTP/Content_negotiation>`_
+to allow the client to choose which type to return, you can use the
+:class:`Request.accept <starlite.connection.request.Request>` property to
+calculate the best matching return media type.
+
+.. literalinclude:: /examples/responses/response_content.py
+    :language: python
+
+.. code-block:: console
+
+    $ curl -H "Accept: text/plain" http://127.0.0.1:8000/resource
+    Hello World!
+    $ curl -H "Accept: text/html" http://127.0.0.1:8000/resource
+    <h1>Hello World!</h1>
+    $ curl -H "Accept: application/xml" http://127.0.0.1:8000/resource
+    <xml><msg>Hello World!</msg></xml>
+
+
 Status Codes
 ------------
 

--- a/starlite/connection/request.py
+++ b/starlite/connection/request.py
@@ -87,10 +87,10 @@ class Request(Generic[UserT, AuthT, StateT], ASGIConnection["HTTPRouteHandler", 
 
     @property
     def accept(self) -> Accept:
-        """Parse the request's 'Accept' header, returning an 'Accept' instance.
+        """Parse the request's 'Accept' header, returning an :class:`Accept <starlite.datastructures.headers.Accept>` instance.
 
         Returns:
-            An 'Accept' instance, representing the list of acceptable media types.
+            An :class:`Accept <starlite.datastructures.headers.Accept>` instance, representing the list of acceptable media types.
         """
         if self._accept is Empty:
             self._accept = self.scope["_accept"] = Accept(self.headers.get("Accept", "*/*"))  # type: ignore[typeddict-unknown-key]

--- a/starlite/datastructures/__init__.py
+++ b/starlite/datastructures/__init__.py
@@ -1,5 +1,6 @@
 from starlite.datastructures.cookie import Cookie
 from starlite.datastructures.headers import (
+    Accept,
     CacheControlHeader,
     ETag,
     Header,
@@ -18,6 +19,7 @@ from starlite.datastructures.upload_file import UploadFile
 from starlite.datastructures.url import URL, Address
 
 __all__ = (
+    "Accept",
     "Address",
     "CacheControlHeader",
     "Cookie",

--- a/starlite/datastructures/headers.py
+++ b/starlite/datastructures/headers.py
@@ -469,12 +469,13 @@ class Accept:
 
         Args:
             provided_types: A list of media types that can be provided as a response. These types
-                            can contain a wildcard '*' character in the main- or subtype part.
+                            can contain a wildcard ``*`` character in the main- or subtype part.
             default: The media type that is returned if none of the provided types match.
 
         Returns:
             The best matching media type. If the matching provided type contains wildcard characters,
-            they are replaced with the corresponding part of the accepted type.
+            they are replaced with the corresponding part of the accepted type. Otherwise the
+            provided type is returned as-is.
         """
         types = [_MediaType(t) for t in provided_types]
 
@@ -494,12 +495,12 @@ class Accept:
     def accepts(self, media_type: str) -> bool:
         """Check if the request accepts the specified media type.
 
-        If multiple media types can be provided, it is better to use `best_match()`.
+        If multiple media types can be provided, it is better to use :func:`best_match`.
 
         Args:
             media_type: The media type to check for.
 
         Returns:
-            True if the request accepts 'media_type'
+            True if the request accepts ``media_type``.
         """
         return self.best_match([media_type]) == media_type

--- a/starlite/datastructures/headers.py
+++ b/starlite/datastructures/headers.py
@@ -1,5 +1,7 @@
 import re
 from abc import ABC, abstractmethod
+from contextlib import suppress
+from copy import copy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -20,11 +22,12 @@ from multidict import CIMultiDict, CIMultiDictProxy, MultiMapping
 from pydantic import BaseModel, Extra, Field, ValidationError, validator
 from typing_extensions import Annotated
 
+from starlite._multipart import parse_content_header
 from starlite._parsers import parse_headers
 from starlite.datastructures.multi_dicts import MultiMixin
 from starlite.exceptions import ImproperlyConfiguredException
 
-__all__ = ("CacheControlHeader", "ETag", "Header", "Headers", "MutableScopeHeaders")
+__all__ = ("Accept", "CacheControlHeader", "ETag", "Header", "Headers", "MutableScopeHeaders")
 
 
 if TYPE_CHECKING:
@@ -386,3 +389,117 @@ class ETag(Header):
         if values.get("documentation_only") or value is not None:
             return value
         raise ValueError("value must be set if documentation_only is false")
+
+
+class _MediaType:
+    """A helper class for ``Accept`` header parsing."""
+
+    __slots__ = ("maintype", "subtype", "params", "_params_str")
+
+    def __init__(self, type_str: str):
+        # preserve the original parameters, because the order might be
+        # changed in the dict
+        self._params_str = "".join(type_str.partition(";")[1:])
+
+        full_type, self.params = parse_content_header(type_str)
+        self.maintype, _, self.subtype = full_type.partition("/")
+
+    def __str__(self) -> str:
+        return f"{self.maintype}/{self.subtype}{self._params_str}"
+
+    @property
+    def priority(self) -> Tuple[int, int]:
+        # Use fixed point values with two decimals to avoid problems
+        # when comparing float values
+        quality = 100
+        if "q" in self.params:
+            with suppress(ValueError):
+                quality = int(100 * float(self.params["q"]))
+
+        if self.maintype == "*":
+            specificity = 0
+        elif self.subtype == "*":
+            specificity = 1
+        elif not self.params or ("q" in self.params and len(self.params) == 1):
+            # no params or 'q' is the only one which we ignore
+            specificity = 2
+        else:
+            specificity = 3
+
+        return quality, specificity
+
+    def match(self, other: "_MediaType") -> bool:
+        # Check parameters first, ignore the weight parameter 'q'.
+        # Additional parameters on other are also ignored.
+        for key, value in self.params.items():
+            if key != "q" and value != other.params.get(key):
+                return False
+
+        # Then check if the subtypes match, ignoring the wildcard '*'
+        if self.subtype != "*" and other.subtype != "*" and self.subtype != other.subtype:
+            return False
+
+        # Lastly check the main type, also ignoring the wildcard '*'
+        if self.maintype != "*" and other.maintype != "*" and self.maintype != other.maintype:
+            return False
+
+        return True
+
+
+class Accept:
+    """An ``Accept`` header."""
+
+    __slots__ = ("_accepted_types",)
+
+    def __init__(self, accept_value: str):
+        self._accepted_types = [_MediaType(t) for t in accept_value.split(",")]
+        self._accepted_types.sort(key=lambda t: t.priority, reverse=True)
+
+    def __len__(self) -> int:
+        return len(self._accepted_types)
+
+    def __getitem__(self, key: int) -> str:
+        return str(self._accepted_types[key])
+
+    def __iter__(self) -> Iterator[str]:
+        return map(str, self._accepted_types)
+
+    def best_match(self, provided_types: List[str], default: Optional[str] = None) -> Optional[str]:
+        """Find the best matching media type for the request.
+
+        Args:
+            provided_types: A list of media types that can be provided as a response. These types
+                            can contain a wildcard '*' character in the main- or subtype part.
+            default: The media type that is returned if none of the provided types match.
+
+        Returns:
+            The best matching media type. If the matching provided type contains wildcard characters,
+            they are replaced with the corresponding part of the accepted type.
+        """
+        types = [_MediaType(t) for t in provided_types]
+
+        for accepted in self._accepted_types:
+            for provided in types:
+                if provided.match(accepted):
+                    # Return the accepted type with wildcards replaced
+                    # by concrete parts from the provided type
+                    result = copy(provided)
+                    if result.subtype == "*":
+                        result.subtype = accepted.subtype
+                    if result.maintype == "*":
+                        result.maintype = accepted.maintype
+                    return str(result)
+        return default
+
+    def accepts(self, media_type: str) -> bool:
+        """Check if the request accepts the specified media type.
+
+        If multiple media types can be provided, it is better to use `best_match()`.
+
+        Args:
+            media_type: The media type to check for.
+
+        Returns:
+            True if the request accepts 'media_type'
+        """
+        return self.best_match([media_type]) == media_type

--- a/tests/connection/request/test_request.py
+++ b/tests/connection/request/test_request.py
@@ -182,6 +182,17 @@ def test_request_headers() -> None:
     }
 
 
+def test_request_accept_header() -> None:
+    async def app(scope: "Scope", receive: "Receive", send: "Send") -> None:
+        request = Request[Any, Any, Any](scope, receive)
+        response = Response(content={"accepted_types": list(request.accept)})
+        await response(scope, receive, send)
+
+    client = TestClient(app)
+    response = client.get("/", headers={"Accept": "text/plain, application/xml;q=0.7, text/html;p=test"})
+    assert response.json() == {"accepted_types": ["text/html;p=test", "text/plain", "application/xml;q=0.7"]}
+
+
 @pytest.mark.parametrize(
     "scope,expected_client",
     (

--- a/tests/datastructures/test_headers.py
+++ b/tests/datastructures/test_headers.py
@@ -1,10 +1,12 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional
 
 import pytest
 from pydantic import ValidationError
 from pytest import FixtureRequest
 
+from starlite import MediaType
 from starlite.datastructures import (
+    Accept,
     CacheControlHeader,
     ETag,
     Headers,
@@ -332,3 +334,31 @@ def test_etag_to_header() -> None:
 
 def test_etag_to_header_weak() -> None:
     assert ETag(value="foo", weak=True).to_header() == 'W/"foo"'
+
+
+@pytest.mark.parametrize(
+    "accept_value,provided_types,best_match",
+    (
+        ("text/plain", ["text/plain"], "text/plain"),
+        ("text/plain", [MediaType.TEXT], MediaType.TEXT),
+        ("text/plain", ["text/plain"], "text/plain"),
+        ("text/plain", ["text/html"], None),
+        ("text/*", ["text/html"], "text/html"),
+        ("*/*", ["text/html"], "text/html"),
+        ("text/plain;p=test", ["text/plain"], "text/plain"),
+        ("text/plain", ["text/plain;p=test"], None),
+        ("text/plain;p=test", ["text/plain;p=test"], "text/plain;p=test"),
+        ("text/plain", ["text/*"], "text/plain"),
+        ("text/html", ["*/*"], "text/html"),
+        ("text/plain;q=0.8,text/html", ["text/plain", "text/html"], "text/html"),
+        ("text/*,text/html", ["text/plain", "text/html"], "text/html"),
+    ),
+)
+def test_accept_best_match(accept_value: str, provided_types: List[str], best_match: Optional[str]) -> None:
+    accept = Accept(accept_value)
+    assert accept.best_match(provided_types) == best_match
+
+
+def test_accept_accepts() -> None:
+    accept = Accept("text/plain;q=0.8,text/html")
+    assert accept.accepts(MediaType.TEXT)


### PR DESCRIPTION
First iteration to implement Accept header parsing and content negotioation. Documentation is missing until the code is stable.

# Things to discuss/check

- I'm not sure where to put the helper types, `Accept` might reside in request.py, the other I don't know.
- Should `MediaType` be exposed or only used internally?
- Are the tests appropiate?
- Is the ordering correct based on [RFC 2616](https://www.rfc-editor.org/rfc/rfc2616#section-14.1)?

# MediaType class
Exposing the results as `str` is obviously easier. But when paramters are involved it gets more complicated:
```
Accept("text/plain,text/plain;p=test").best_match(["text/plain", "text/html"]) == "text/plain;p=test"
```
In a handler you would do:
```
preferred_type = request.accept.best_mach(["text/plain", "text/html"])
if preferred_type == "text/plain":
   return text_response
```
which would not match because of the missing parameter. 

Implementing parameters might just be too cumbersome and so rarely used that it might be best to ignore them, except for `q` and for specificity. Or my logic could be better and the method should only return elements from `provided_types`.

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
