### PR TITLE
chore: update docstrings to use new exception error class name

### DIFF
--- a/starlite/contrib/repository/abc.py
+++ b/starlite/contrib/repository/abc.py
@@ -78,7 +78,7 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
             The deleted instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found identified by ``item_id``.
+            NotFoundError: If no instance found identified by ``item_id``.
         """
 
     @abstractmethod
@@ -116,7 +116,7 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
             The retrieved instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found identified by ``item_id``.
+            NotFoundError: If no instance found identified by ``item_id``.
         """
 
     @abstractmethod
@@ -130,7 +130,7 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
             The retrieved instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found identified by ``kwargs``.
+            NotFoundError: If no instance found identified by ``kwargs``.
         """
 
     @abstractmethod
@@ -167,7 +167,7 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
             The updated instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found with same identifier as ``data``.
+            NotFoundError: If no instance found with same identifier as ``data``.
         """
 
     @abstractmethod
@@ -182,7 +182,7 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
             a list of the updated instances.
 
         Raises:
-            RepositoryNotFoundException: If no instance found with same identifier as ``data``.
+            NotFoundError: If no instance found with same identifier as ``data``.
         """
 
     @abstractmethod
@@ -201,7 +201,7 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
             The updated or created instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found with same identifier as ``data``.
+            NotFoundError: If no instance found with same identifier as ``data``.
         """
 
     @abstractmethod
@@ -245,7 +245,7 @@ class AbstractRepository(Generic[T], metaclass=ABCMeta):
 
     @staticmethod
     def check_not_found(item_or_none: T | None) -> T:
-        """Raise :class:`RepositoryNotFoundException` if ``item_or_none`` is ``None``.
+        """Raise :class:`NotFoundError` if ``item_or_none`` is ``None``.
 
         Args:
             item_or_none: Item to be tested for existence.

--- a/starlite/contrib/repository/testing/generic_mock_repository.py
+++ b/starlite/contrib/repository/testing/generic_mock_repository.py
@@ -126,7 +126,7 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
             The deleted instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found identified by ``item_id``.
+            NotFoundError: If no instance found identified by ``item_id``.
         """
         try:
             return self._find_or_raise_not_found(item_id)
@@ -175,7 +175,7 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
             The retrieved instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found identified by ``item_id``.
+            NotFoundError: If no instance found identified by ``item_id``.
         """
         return self._find_or_raise_not_found(item_id)
 
@@ -204,7 +204,7 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
             The retrieved instance or None
 
         Raises:
-            RepositoryNotFoundException: If no instance found identified by ``kwargs``.
+            NotFoundError: If no instance found identified by ``kwargs``.
         """
         data = await self.list(**kwargs)
         return self.check_not_found(data[0] if data else None)
@@ -244,7 +244,7 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
             The updated instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found with same identifier as ``data``.
+            NotFoundError: If no instance found with same identifier as ``data``.
         """
         item = self._find_or_raise_not_found(self.get_id_attribute_value(data))
         self._update_audit_attributes(data, do_created=False)
@@ -265,7 +265,7 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
             The updated instances.
 
         Raises:
-            RepositoryNotFoundException: If no instance found with same identifier as ``data``.
+            NotFoundError: If no instance found with same identifier as ``data``.
         """
         items = [self._find_or_raise_not_found(self.get_id_attribute_value(row)) for row in data]
         now = self._now()
@@ -292,7 +292,7 @@ class GenericMockRepository(AbstractRepository[ModelT], Generic[ModelT]):
             The updated or created instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found with same identifier as ``data``.
+            NotFoundError: If no instance found with same identifier as ``data``.
         """
         item_id = self.get_id_attribute_value(data)
         if item_id in self.collection:

--- a/starlite/contrib/sqlalchemy/repository.py
+++ b/starlite/contrib/sqlalchemy/repository.py
@@ -122,7 +122,7 @@ class SQLAlchemyRepository(AbstractRepository[ModelT], Generic[ModelT]):
             The deleted instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found identified by `item_id`.
+            NotFoundError: If no instance found identified by `item_id`.
         """
         with wrap_sqlalchemy_exception():
             instance = await self.get(item_id)
@@ -192,7 +192,7 @@ class SQLAlchemyRepository(AbstractRepository[ModelT], Generic[ModelT]):
             The retrieved instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found identified by `item_id`.
+            NotFoundError: If no instance found identified by `item_id`.
         """
         with wrap_sqlalchemy_exception():
             statement = self._filter_select_by_kwargs(statement=self.statement, **{self.id_attribute: item_id})
@@ -211,7 +211,7 @@ class SQLAlchemyRepository(AbstractRepository[ModelT], Generic[ModelT]):
             The retrieved instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found identified by `item_id`.
+            NotFoundError: If no instance found identified by `item_id`.
         """
         with wrap_sqlalchemy_exception():
             statement = self._filter_select_by_kwargs(statement=self.statement, **kwargs)
@@ -282,7 +282,7 @@ class SQLAlchemyRepository(AbstractRepository[ModelT], Generic[ModelT]):
             The updated instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found with same identifier as `data`.
+            NotFoundError: If no instance found with same identifier as `data`.
         """
         with wrap_sqlalchemy_exception():
             item_id = self.get_id_attribute_value(data)
@@ -310,7 +310,7 @@ class SQLAlchemyRepository(AbstractRepository[ModelT], Generic[ModelT]):
             The updated instances.
 
         Raises:
-            RepositoryNotFoundException: If no instance found with same identifier as `data`.
+            NotFoundError: If no instance found with same identifier as `data`.
         """
         data_to_update: list[dict[str, Any]] = [v.to_dict() if isinstance(v, self.model_type) else v for v in data]  # type: ignore
         with wrap_sqlalchemy_exception():
@@ -401,7 +401,7 @@ class SQLAlchemyRepository(AbstractRepository[ModelT], Generic[ModelT]):
             The updated or created instance.
 
         Raises:
-            RepositoryNotFoundException: If no instance found with same identifier as `data`.
+            NotFoundError: If no instance found with same identifier as `data`.
         """
         with wrap_sqlalchemy_exception():
             instance = await self._attach_to_session(data, strategy="merge")


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

Fixed and issue where `RepositoryNotFoundException` was renamed to `NotFoundError` but was not updated in the docstrings.