### PR TITLE
Skip tests for asyncpg repository on non-linux platforms

### DIFF
--- a/tests/contrib/sqlalchemy/repository/test_sqlalchemy_asyncpg.py
+++ b/tests/contrib/sqlalchemy/repository/test_sqlalchemy_asyncpg.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 import timeit
 from asyncio import AbstractEventLoop, get_event_loop_policy
 from datetime import datetime
@@ -26,6 +27,9 @@ from tests.contrib.sqlalchemy.models import Author, AuthorRepository, BookReposi
 
 if TYPE_CHECKING:
     from pytest_docker.plugin import Services
+
+
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="docker not available on this platform")
 
 
 here = Path(__file__).parent


### PR DESCRIPTION
Skips `tests/contrib/sqlalchemy/repository/test_sqlalchemy_asyncpg.py` on non-linux platforms, since they require docker which is currently not available in our MacOS and Windows CI setup.

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
