### PR TITLE
fix: add granular noqa to allow linting to catch other issues

### DIFF
--- a/starlite/contrib/sqlalchemy_1/config.py
+++ b/starlite/contrib/sqlalchemy_1/config.py
@@ -265,7 +265,7 @@ class SQLAlchemyConfig:
             )
         return cast("sessionmaker", self.session_maker_instance)
 
-    def create_db_session_dependency(self, state: State, scope: Scope) -> Union[Session, AsyncSession]:  # noqa
+    def create_db_session_dependency(self, state: State, scope: Scope) -> Union[Session, AsyncSession]:  # noqa: F821
         """Create a session instance.
 
         Args:


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

This PR seeks to make the linter error suppression less wide in scope. `# noqa` by itself is quite disruptive and can generally be made more granular by specifying a specific rule to suppress. 

This PR adds `# noqa: F821` from [pyflakes](https://beta.ruff.rs/docs/rules/#pyflakes-f)

F821 | undefined-name | Undefined name {name}
-- | -- | --


Resolves #1326