### PR TITLE
Fix py38 tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Set up python ${{ matrix.python-version }}
+      - name: Set up python ${{ inputs.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
@@ -40,14 +40,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: v1-venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: v1-venv-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Load cached pip wheels
         if: runner.os == 'Windows'
         id: cached-pip-wheels
         uses: actions/cache@v3
         with:
           path: ~/.cache
-          key: cache-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: cache-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
       - name: Install dependencies
         run: poetry install --no-interaction
       - name: Set pythonpath

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -4,7 +4,7 @@ import importlib.util
 import sys
 from pathlib import Path
 from shutil import rmtree
-from typing import TYPE_CHECKING, Callable, Generator, List, Optional, Protocol, Union, cast
+from typing import TYPE_CHECKING, Callable, Generator, Protocol, cast
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -26,8 +26,8 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def patch_autodiscovery_paths(request: FixtureRequest) -> Callable[[List[str]], None]:
-    def patcher(paths: List[str]) -> None:
+def patch_autodiscovery_paths(request: FixtureRequest) -> Callable[[list[str]], None]:
+    def patcher(paths: list[str]) -> None:
         from starlite.cli._utils import AUTODISCOVERY_FILE_NAMES
 
         old_paths = AUTODISCOVERY_FILE_NAMES[::]
@@ -52,9 +52,9 @@ def tmp_project_dir(monkeypatch: MonkeyPatch, tmp_path: Path) -> Path:
 class CreateAppFileFixture(Protocol):
     def __call__(
         self,
-        file: Union[str, Path],
-        directory: Optional[Union[str, Path]] = None,
-        content: Optional[str] = None,
+        file: str | Path,
+        directory: str | Path | None = None,
+        content: str | None = None,
         init_content: str = "",
     ) -> Path:
         ...
@@ -73,9 +73,9 @@ def create_app_file(
     request: FixtureRequest,
 ) -> CreateAppFileFixture:
     def _create_app_file(
-        file: Union[str, Path],
-        directory: Optional[Union[str, Path]] = None,
-        content: Optional[str] = None,
+        file: str | Path,
+        directory: str | Path | None = None,
+        content: str | None = None,
         init_content: str = "",
     ) -> Path:
         base = tmp_project_dir

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib.util
 import sys
 from pathlib import Path
@@ -130,7 +132,7 @@ def mock_confirm_ask(mocker: MockerFixture) -> Generator["MagicMock", None, None
     ]
 )
 def _app_file_content(request: FixtureRequest) -> tuple[str, str]:
-    return cast(tuple[str, str], request.param)
+    return cast("tuple[str, str]", request.param)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes tests.

Changes references from `matrix.python-version` in CI to `inputs.python-version`.

Adds `__future__.annotations` to `tests/cli/conftest.py` and associated linting fixes.

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
