### PR TITLE
Various refactors.

### DIFF
--- a/starlite/_signature/parsing.py
+++ b/starlite/_signature/parsing.py
@@ -244,26 +244,31 @@ def create_pydantic_signature_model(
     field_definitions: dict[str, tuple[Any, Any]] = {}
 
     for parameter in parsed_params:
-        if parameter.should_skip_validation:
-            if isinstance(parameter.default, DependencyKwarg):
-                field_definitions[parameter.name] = (
-                    Any,
-                    parameter.default.default if parameter.default.default is not Empty else None,
-                )
-            else:
-                field_definitions[parameter.name] = (Any, ...)
-        elif isinstance(parameter.default, (ParameterKwarg, BodyKwarg)):
-            field_info = FieldInfo(**asdict(parameter.default), kwargs_model=parameter.default)
-            field_info.default = parameter.default.default if parameter.default.default is not Empty else Undefined
-            field_definitions[parameter.name] = (parameter.annotation, field_info)
-        elif ModelFactory.is_constrained_field(parameter.default):
-            field_definitions[parameter.name] = (parameter.default, ...)
-        elif parameter.default_defined:
-            field_definitions[parameter.name] = (parameter.annotation, parameter.default)
-        elif not parameter.optional:
-            field_definitions[parameter.name] = (parameter.annotation, ...)
+        if isinstance(parameter.default, (ParameterKwarg, BodyKwarg)):
+            field_info = FieldInfo(
+                **asdict(parameter.default), kwargs_model=parameter.default, parsed_parameter=parameter
+            )
         else:
-            field_definitions[parameter.name] = (parameter.annotation, None)
+            field_info = FieldInfo(default=..., parsed_parameter=parameter)
+        if parameter.should_skip_validation:
+            field_type = Any
+            if isinstance(parameter.default, DependencyKwarg):
+                field_info.default = parameter.default.default if parameter.default.default is not Empty else None
+        elif isinstance(parameter.default, (ParameterKwarg, BodyKwarg)):
+            field_type = parameter.annotation
+            field_info.default = parameter.default.default if parameter.default.default is not Empty else Undefined
+        elif ModelFactory.is_constrained_field(parameter.default):
+            field_type = parameter.default
+        elif parameter.default_defined:
+            field_type = parameter.annotation
+            field_info.default = parameter.default
+        elif not parameter.optional:
+            field_type = parameter.annotation
+        else:
+            field_type = parameter.annotation
+            field_info.default = None
+
+        field_definitions[parameter.name] = (field_type, field_info)
 
     model: type[PydanticSignatureModel] = create_model(  # type: ignore
         f"{fn_name}_signature_model",

--- a/starlite/handlers/http_handlers/base.py
+++ b/starlite/handlers/http_handlers/base.py
@@ -5,6 +5,7 @@ from inspect import Signature
 from typing import TYPE_CHECKING, AnyStr, Mapping, cast
 
 from starlite._layers.utils import narrow_response_cookies, narrow_response_headers
+from starlite._signature.utils import get_signature_model
 from starlite.constants import REDIRECT_STATUS_CODES
 from starlite.datastructures import Cookie, ResponseHeader
 from starlite.enums import HttpMethod, MediaType
@@ -402,7 +403,8 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
             cookies = self.resolve_response_cookies()
             type_encoders = self.resolve_type_encoders()
 
-            if is_class_and_subclass(self.signature.return_annotation, ResponseContainer):  # type: ignore
+            return_annotation = get_signature_model(self).return_annotation
+            if is_class_and_subclass(return_annotation, ResponseContainer):  # type: ignore
                 handler = create_response_container_handler(
                     after_request=after_request,
                     cookies=cookies,
@@ -411,13 +413,10 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
                     status_code=self.status_code,
                 )
 
-            elif is_class_and_subclass(self.signature.return_annotation, Response):
+            elif is_class_and_subclass(return_annotation, Response):
                 handler = create_response_handler(cookies=cookies, after_request=after_request)
 
-            elif is_async_callable(self.signature.return_annotation) or self.signature.return_annotation in {
-                ASGIApp,
-                "ASGIApp",
-            }:
+            elif is_async_callable(return_annotation) or return_annotation is ASGIApp:
                 handler = create_generic_asgi_response_handler(cookies=cookies, after_request=after_request)
 
             else:
@@ -428,7 +427,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
                     headers=headers,
                     media_type=media_type,
                     response_class=response_class,
-                    return_annotation=self.signature.return_annotation,
+                    return_annotation=return_annotation,
                     status_code=self.status_code,
                     type_encoders=type_encoders,
                 )

--- a/starlite/response/base.py
+++ b/starlite/response/base.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, Mapping, TypeVar, overl
 from starlite.datastructures import Cookie, ETag
 from starlite.enums import MediaType, OpenAPIMediaType
 from starlite.exceptions import ImproperlyConfiguredException
-from starlite.serialization import DEFAULT_TYPE_ENCODERS, default_serializer, encode_json, encode_msgpack
+from starlite.serialization import DEFAULT_TYPE_ENCODERS, default_serializer, encode_for_media_type
 from starlite.status_codes import HTTP_200_OK, HTTP_204_NO_CONTENT, HTTP_304_NOT_MODIFIED
 from starlite.utils.helpers import get_enum_string_value
 
@@ -244,11 +244,7 @@ class Response(Generic[T]):
                     return b""
 
                 return content.encode(self.encoding)  # type: ignore
-
-            if self.media_type == MediaType.MESSAGEPACK:
-                return encode_msgpack(content, self._enc_hook)
-
-            return encode_json(content, self._enc_hook)
+            return encode_for_media_type(self.media_type, content, self._enc_hook)
         except (AttributeError, ValueError, TypeError) as e:
             raise ImproperlyConfiguredException("Unable to serialize response content") from e
 

--- a/starlite/serialization.py
+++ b/starlite/serialization.py
@@ -27,10 +27,19 @@ from pydantic import (
 from pydantic.color import Color
 from pydantic.json import decimal_encoder
 
+from starlite.enums import MediaType
 from starlite.exceptions import SerializationException
 from starlite.types import Empty
 
-__all__ = ("dec_hook", "decode_json", "decode_msgpack", "default_serializer", "encode_json", "encode_msgpack")
+__all__ = (
+    "dec_hook",
+    "decode_json",
+    "decode_msgpack",
+    "default_serializer",
+    "encode_for_media_type",
+    "encode_json",
+    "encode_msgpack",
+)
 
 
 if TYPE_CHECKING:
@@ -240,3 +249,22 @@ def decode_msgpack(raw: bytes, type_: Any = Empty) -> Any:
         return msgspec.msgpack.decode(raw, dec_hook=dec_hook, type=type_)
     except msgspec.DecodeError as msgspec_error:
         raise SerializationException(str(msgspec_error)) from msgspec_error
+
+
+def encode_for_media_type(
+    media_type: MediaType | str, obj: Any, enc_hook: Callable[[Any], Any] | None = default_serializer
+) -> bytes:
+    """Encode ``obj`` into ``media_type``.
+
+    Args:
+        media_type: Serialization format.
+        obj: Object to be serialized.
+        enc_hook: Optional callable to support non-natively supported types (ignored for DTO types).
+
+    Returns:
+        ``media_type`` as bytes.
+    """
+    if media_type == MediaType.MESSAGEPACK:
+        return encode_msgpack(obj, enc_hook)
+
+    return encode_json(obj, enc_hook)

--- a/starlite/types/protocols.py
+++ b/starlite/types/protocols.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Protocol, runtime_checkable
+from typing import Any, ClassVar, Dict, Protocol, runtime_checkable
 
 __all__ = ("DataclassProtocol", "Logger")
 
@@ -84,4 +84,4 @@ class Logger(Protocol):  # pragma: no cover
 class DataclassProtocol(Protocol):
     """Protocol for instance checking dataclasses"""
 
-    __dataclass_fields__: Dict[str, Any]
+    __dataclass_fields__: ClassVar[Dict[str, Any]]

--- a/starlite/utils/pydantic.py
+++ b/starlite/utils/pydantic.py
@@ -38,7 +38,7 @@ def convert_dataclass_to_model(dataclass_or_instance: DataclassClassOrInstance) 
 
     existing = _type_model_map.get(dataclass)
     if not existing:
-        _type_model_map[dataclass] = existing = create_model_from_dataclass(dataclass)
+        _type_model_map[dataclass] = existing = create_model_from_dataclass(dataclass)  # type:ignore[arg-type]
     return existing
 
 


### PR DESCRIPTION
These are various refactors that I've pulled out of the DTO refactor branch in order to keep that more focused.

- uses signature model return annotation for creating response handlers - it has had forward refs resolved.
- adds `serialization.encode_for_media_type()` utility.
- refactor `create_pydantic_signature_model()`, no functional change.
- changes `DataclassProtocol.__dataclass_fields__` to `ClassVar`.
- adds ability to provide extra namespace names to `_signature.utils.get_fn_type_hints()` utility.

# PR Checklist

- [ ] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?
