### PR TITLE
update simple event emitter to use worker pattern

### DIFF
--- a/starlite/_asgi/asgi_router.py
+++ b/starlite/_asgi/asgi_router.py
@@ -205,6 +205,8 @@ class ASGIRouter:
         Calls the ``before_startup`` hook and ``after_startup`` hook handlers respectively before and after calling in
         the lifespan handlers.
         """
+        await self.app.event_emitter.on_startup()
+
         for hook in self.app.before_startup:
             await hook(self.app)
 
@@ -221,6 +223,8 @@ class ASGIRouter:
         Calls the ``before_shutdown`` hook and ``after_shutdown`` hook handlers respectively before and after calling in
         the lifespan handlers.
         """
+        await self.app.event_emitter.on_shutdown()
+
         for hook in self.app.before_shutdown:
             await hook(self.app)
 

--- a/starlite/events/emitter.py
+++ b/starlite/events/emitter.py
@@ -104,7 +104,7 @@ class SimpleEventEmitter(BaseEventEmitterBackend):
         """
         if sniffio.current_async_library() != "asyncio":
             return
-            
+
         self._queue = Queue()
         self._worker_task = create_task(self._worker())
 

--- a/starlite/events/emitter.py
+++ b/starlite/events/emitter.py
@@ -104,6 +104,7 @@ class SimpleEventEmitter(BaseEventEmitterBackend):
         """
         if sniffio.current_async_library() != "asyncio":
             return
+            
         self._queue = Queue()
         self._worker_task = create_task(self._worker())
 
@@ -138,7 +139,7 @@ class SimpleEventEmitter(BaseEventEmitterBackend):
         """
         if not (self._worker_task and self._queue):
             if sniffio.current_async_library() != "asyncio":
-                raise ImproperlyConfiguredException("This backend only supports asyncio")
+                raise ImproperlyConfiguredException("{type(self).__name__} only supports 'asyncio' based event loops")
 
             raise ImproperlyConfiguredException("Worker not running")
 

--- a/starlite/events/listener.py
+++ b/starlite/events/listener.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.utils import AsyncCallable
 
-__all__ = ("EventListener",)
+__all__ = ("EventListener", "listener")
 
 
 if TYPE_CHECKING:

--- a/starlite/events/listener.py
+++ b/starlite/events/listener.py
@@ -26,7 +26,7 @@ class EventListener:
             *event_ids: The id of the event to listen to or a list of
                 event ids to listen to.
         """
-        self.event_ids: list[str] = list(event_ids)
+        self.event_ids: frozenset[str] = frozenset(event_ids)
 
     def __call__(self, fn: AnyCallable) -> EventListener:
         """Decorate a callable by wrapping it inside an instance of EventListener.
@@ -43,6 +43,9 @@ class EventListener:
         self.fn = AsyncCallable(fn)
 
         return self
+
+    def __hash__(self) -> int:
+        return hash(self.event_ids) + hash(self.fn)
 
 
 listener = EventListener

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,11 +81,11 @@ async def scaffold_tortoise() -> AsyncGenerator:
 @pytest.fixture()
 async def scaffold_piccolo() -> AsyncGenerator:
     """Scaffolds Piccolo ORM and performs cleanup."""
-    TABLES = Finder().get_table_classes()
-    await drop_db_tables(*TABLES)
-    await create_db_tables(*TABLES)
+    tables = Finder().get_table_classes()
+    await drop_db_tables(*tables)
+    await create_db_tables(*tables)
     yield
-    await drop_db_tables(*TABLES)
+    await drop_db_tables(*tables)
 
 
 @pytest.fixture(

--- a/tests/events/test_listener.py
+++ b/tests/events/test_listener.py
@@ -1,88 +1,88 @@
 from asyncio import sleep
-from typing import Any, Dict, Optional
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
+from pytest_lazyfixture import lazy_fixture
 
 from starlite import Request, Starlite, get
-from starlite.events.listener import listener
+from starlite.events.emitter import SimpleEventEmitter
+from starlite.events.listener import EventListener, listener
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.status_codes import HTTP_200_OK
 from starlite.testing import create_async_test_client, create_test_client
 
 
-async def test_event_listener_works_for_sync_callable(anyio_backend: str) -> None:
-    test_value = {"key": "123"}
-    received_event: Optional[Dict[str, Any]] = None
+@pytest.fixture()
+def mock() -> MagicMock:
+    return MagicMock()
 
+
+@pytest.fixture()
+def sync_listener(mock: MagicMock) -> EventListener:
     @listener("test_event")
-    def event_handler(event: Dict[str, Any]) -> None:
-        nonlocal received_event
-        received_event = event
+    def listener_fn(*args: Any, **kwargs: Any) -> None:
+        mock(*args, **kwargs)
+
+    return listener_fn
+
+
+@pytest.fixture()
+def async_listener(mock: MagicMock) -> EventListener:
+    @listener("test_event")
+    async def listener_fn(*args: Any, **kwargs: Any) -> None:
+        mock(*args, **kwargs)
+
+    return listener_fn
+
+
+@pytest.mark.parametrize("listener", [lazy_fixture("sync_listener"), lazy_fixture("async_listener")])
+async def test_event_listener(mock: MagicMock, listener: EventListener) -> None:
+    test_value = {"key": "123"}
 
     @get("/")
     async def route_handler(request: Request[Any, Any, Any]) -> None:
         await request.app.emit("test_event", test_value)
 
-    with create_test_client(route_handlers=[route_handler], listeners=[event_handler]) as client:
+    with create_test_client(route_handlers=[route_handler], listeners=[listener]) as client:
         response = client.get("/")
-        await sleep(0.1)
         assert response.status_code == HTTP_200_OK
-        assert received_event == test_value
+        await sleep(0.01)
+        mock.assert_called_with(test_value)
 
 
-async def test_event_listener_works_for_async_callable(anyio_backend: str) -> None:
-    test_value = {"key": "123"}
-    received_event: Optional[Dict[str, Any]] = None
+async def test_shutdown_awaits_pending(async_listener: EventListener, mock: MagicMock) -> None:
+    emitter = SimpleEventEmitter([async_listener])
+    await emitter.on_startup()
 
-    @listener("test_event")
-    async def event_handler(event: Dict[str, Any]) -> None:
-        nonlocal received_event
-        received_event = event
+    for _ in range(100):
+        await emitter.emit("test_event")
 
-    @get("/")
-    async def route_handler(request: Request[Any, Any, Any]) -> None:
-        await request.app.emit("test_event", test_value)
+    await emitter.on_shutdown()
 
-    with create_test_client(route_handlers=[route_handler], listeners=[event_handler]) as client:
-        response = client.get("/")
-        await sleep(0.1)
-        assert response.status_code == HTTP_200_OK
-        assert received_event == test_value
+    assert mock.call_count == 100
 
 
-async def test_multiple_event_listeners(anyio_backend: str) -> None:
-    received_events: int = 0
-
-    @listener("test_event")
-    def sync_event_handler() -> None:
-        nonlocal received_events
-        received_events += 1
-
-    @listener("test_event")
-    async def async_event_handler() -> None:
-        nonlocal received_events
-        received_events += 1
-
+async def test_multiple_event_listeners(
+    async_listener: EventListener, sync_listener: EventListener, mock: MagicMock
+) -> None:
     @get("/")
     async def route_handler(request: Request[Any, Any, Any]) -> None:
         await request.app.emit("test_event")
 
     async with create_async_test_client(
-        route_handlers=[route_handler], listeners=[sync_event_handler, async_event_handler]
+        route_handlers=[route_handler], listeners=[async_listener, sync_listener]
     ) as client:
         response = await client.get("/")
-        await sleep(0.1)
+        await sleep(0.01)
         assert response.status_code == HTTP_200_OK
-        assert received_events == 2
+        assert mock.call_count == 2
 
 
-async def test_multiple_event_ids(anyio_backend: str) -> None:
-    received_events: int = 0
-
-    @listener(*["test_event_1", "test_event_2"])
+async def test_multiple_event_ids(mock: MagicMock) -> None:
+    @listener("test_event_1", "test_event_2")
     def event_handler() -> None:
-        nonlocal received_events
-        received_events += 1
+        mock()
 
     @get("/{event_id:int}")
     async def route_handler(request: Request[Any, Any, Any], event_id: int) -> None:
@@ -90,16 +90,16 @@ async def test_multiple_event_ids(anyio_backend: str) -> None:
 
     async with create_async_test_client(route_handlers=[route_handler], listeners=[event_handler]) as client:
         response = await client.get("/1")
-        await sleep(0.1)
+        await sleep(0.01)
         assert response.status_code == HTTP_200_OK
-        assert received_events == 1
+        assert mock.call_count == 1
         response = await client.get("/2")
-        await sleep(0.1)
+        await sleep(0.01)
         assert response.status_code == HTTP_200_OK
-        assert received_events == 2
+        assert mock.call_count == 2
 
 
-def test_raises_when_decorator_called_without_callable(anyio_backend: str) -> None:
+def test_raises_when_decorator_called_without_callable() -> None:
     with pytest.raises(ImproperlyConfiguredException):
         listener("test_even")(True)  # type: ignore
 
@@ -111,11 +111,7 @@ async def test_raises_when_not_initialized() -> None:
         await app.emit("x")
 
 
-async def test_raises_when_not_listener_are_registered_for_an_event_id() -> None:
-    @listener("test_event")
-    async def async_event_handler() -> None:
-        pass
-
-    async with create_async_test_client(route_handlers=[], listeners=[async_event_handler]) as client:
+async def test_raises_when_not_listener_are_registered_for_an_event_id(async_listener: EventListener) -> None:
+    async with create_async_test_client(route_handlers=[], listeners=[async_listener]) as client:
         with pytest.raises(ImproperlyConfiguredException):
             await client.app.emit("x")

--- a/tests/events/test_listener.py
+++ b/tests/events/test_listener.py
@@ -111,6 +111,14 @@ async def test_raises_when_not_initialized() -> None:
         await app.emit("x")
 
 
+async def test_raises_for_wrong_async_backend(async_listener: EventListener) -> None:
+    async with create_async_test_client([], listeners=[async_listener], backend="trio") as client:
+        assert not client.app.event_emitter._queue
+        assert not client.app.event_emitter._worker_task
+        with pytest.raises(ImproperlyConfiguredException):
+            await client.app.emit("test_event")
+
+
 async def test_raises_when_not_listener_are_registered_for_an_event_id(async_listener: EventListener) -> None:
     async with create_async_test_client(route_handlers=[], listeners=[async_listener]) as client:
         with pytest.raises(ImproperlyConfiguredException):


### PR DESCRIPTION
# PR Checklist

- [x] Have you followed the guidelines in `CONTRIBUTING.rst`?
- [x] Have you got 100% test coverage on new code?
- [x] Have you updated the prose documentation?
- [x] Have you updated the reference documentation?

This PR updates the `EventEmitterBackend` abstract class and the `SimpleEventEmitter` concrete implementation to be more useful. I used the `Broadcaster` library from encode as a source of inspiration for the implementation, which uses the worker pattern. It appears to be working with trio, without an issue. 