### PR TITLE
fix: pin poetry to 1.4.0 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: 1.4.0
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: 1.4.0
           virtualenvs-create: false
           installer-parallel: true
       - name: Install App Dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,6 +19,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: 1.4.0
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
@@ -43,6 +44,8 @@ jobs:
           python-version: "3.11"
       - name: Install Poetry
         uses: snok/install-poetry@v1
+        with:
+          version: 1.4.0
       - name: Install dependencies
         run: poetry install --no-interaction --no-root --no-dev
       - name: publish

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
+          version: 1.4.0
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true


### PR DESCRIPTION
it is good practice to pin poetry so poetry updates don't break ci

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] Have you followed the guidelines in the [Starlite Contribution Guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst)?
- [x] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
Pin poetry to 1.4.0 in CI.

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
fixes https://github.com/starlite-api/starlite/actions/runs/4462113125/jobs/7836421937
