### PR TITLE
Adds `async_timeout` as dev dep for py 3.11+.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3431,4 +3431,4 @@ tortoise-orm = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "676ca39dad311c31fa343e6a28c141ad6a9ac4bdb459bc83f32cbb3743b885cb"
+content-hash = "4ed68e51872b0edb9cebe18e5e22f497626f40e79ec3a692bdfe0f49bc93b7f8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ typing-extensions = "*"
 
 [tool.poetry.group.dev.dependencies]
 aiosqlite = "*"
+async_timeout = { version = "*", python = ">=3.11" }
 asyncpg = "*"
 beautifulsoup4 = "*"
 brotli = "*"


### PR DESCRIPTION
This is a workaround for https://github.com/cunla/fakeredis-py/issues/130.

`redis-py`'s latest release removed their dependency on `async_timeout` for python 3.11. `fakeredis-py` is relying on that dependency transitively, so fails on import in 3.11.

This PR adds `async_timeout` to our dependencies to get tests running again, but should be removed once the aforementioned issue is resolved.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] Have you followed the guidelines in the [Starlite Contribution Guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst)?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
