### PR TITLE
fix: adds SQL Alchemy UUID map

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,7 @@ repos:
           [
             aiosqlite,
             asyncpg,
+            async_timeout,
             beanie,
             beautifulsoup4,
             brotli,
@@ -104,6 +105,7 @@ repos:
           [
             aiosqlite,
             asyncpg,
+            async_timeout,
             beanie,
             beautifulsoup4,
             brotli,

--- a/starlite/contrib/sqlalchemy_1/plugin.py
+++ b/starlite/contrib/sqlalchemy_1/plugin.py
@@ -223,6 +223,8 @@ class SQLAlchemyPlugin(InitPluginProtocol, SerializationPluginProtocol[Declarati
             sqlalchemy_type.TupleType: self.handle_tuple_type,  # pyright: ignore
             sqlalchemy_type.Unicode: self.handle_string_type,
             sqlalchemy_type.UnicodeText: self.handle_string_type,
+            sqlalchemy_type.Uuid: lambda x: UUID,
+            sqlalchemy_type.UUID: lambda x: UUID,
             sqlalchemy_type.VARBINARY: self.handle_string_type,
             sqlalchemy_type.VARCHAR: self.handle_string_type,
             # mssql


### PR DESCRIPTION
You would get an error when using the SQL Alchemy plugin with a `Uuid` type from SQLAlchemy.  This enhancement adds it to the provider map to prevent this error.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] Have you followed the guidelines in the [Starlite Contribution Guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst)?
- [ ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ ] Have you updated the reference documentation?

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
