### PR TITLE
Add TortoiseORM examples for related objects and computed fields

### DIFF
--- a/docs/lib/usage/plugins/tortoise-orm.rst
+++ b/docs/lib/usage/plugins/tortoise-orm.rst
@@ -136,7 +136,13 @@ An example of a Starlite app using the Tortoise ORM plugin with computed fields 
 
 
    app = Starlite(
-       route_handlers=[get_tournament, get_tournaments, create_tournament, create_event],
+       route_handlers=[
+           get_tournament,
+           get_tournaments,
+           create_tournament,
+           get_events,
+           create_event,
+       ],
        on_startup=[init_tortoise],
        on_shutdown=[shutdown_tortoise],
        plugins=[TortoiseORMPlugin()],

--- a/docs/lib/usage/plugins/tortoise-orm.rst
+++ b/docs/lib/usage/plugins/tortoise-orm.rst
@@ -103,6 +103,18 @@ import it and pass it to the :class:`Starlite <starlite.app.Starlite>` class:
        return data
 
 
+   @post("/tournaments/{tournament_id:int}/events")
+   async def create_event(tournament_id: int, data: Event) -> Event:
+       """By default, the tournament_id is not available in the data,
+       so we need to add it manually."""
+       assert isinstance(data, Event)
+       tournament = await Tournament.filter(id=tournament_id).first()
+       data.tournament = tournament
+       await data.save()
+       await data.refresh_from_db()
+       return data
+
+
    app = Starlite(
        route_handlers=[get_tournament, get_tournaments, create_tournament],
        on_startup=[init_tortoise],

--- a/docs/lib/usage/plugins/tortoise-orm.rst
+++ b/docs/lib/usage/plugins/tortoise-orm.rst
@@ -20,10 +20,18 @@ import it and pass it to the :class:`Starlite <starlite.app.Starlite>` class:
        name = fields.TextField()
        created_at = fields.DatetimeField(auto_now_add=True)
        optional = fields.TextField(null=True)
+       # Add the reverse relations so that they can be used for type hinting.
        events: fields.ReverseRelation["Event"]
+
+       def is_medieval(self) -> bool:
+           """Check if the tournament is medieval, to be used as a computed field."""
+           return "medieval" in self.name
 
        class Meta:
            ordering = ["name"]
+
+       class PydanticMeta:
+           computed = ["is_medieval"]
 
 
    class Event(Model):


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ x ] Have you followed the guidelines in the [Starlite Contribution Guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst)?
- [ ? ] Have you got 100% test coverage on new code?
- [ ] Have you updated the prose documentation?
- [ x ] Have you updated the reference documentation?

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"
Added examples for computed fields and creating related objects in TortoiseORM plugin

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
Closes:  #1351 


### Remaining Questions:

Maybe this is for another issue, but if I wanted to return a call with nested objects (Say a tournament and its events), I would then have to create my own DTO, I'm assuming? Might be a nice feature to start including this in the plugin ala https://www.django-rest-framework.org/api-guide/relations/#nested-relationships