### PR TITLE
fix: `JSON.parse` fails to parse an Object.  

### DIFF
--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -332,7 +332,7 @@ class OpenAPIController(Controller):
             <div id='swagger-container'/>
             <script type="text/javascript">
             const ui = SwaggerUIBundle({{
-                spec: JSON.parse('{self._dumped_modified_schema}'),
+                spec: {self._dumped_modified_schema},
                 dom_id: '#swagger-container',
                 deepLinking: true,
                 showExtensions: true,
@@ -442,7 +442,7 @@ class OpenAPIController(Controller):
             <div id='redoc-container'/>
             <script type="text/javascript">
                 Redoc.init(
-                    JSON.parse('{self._dumped_schema}'),
+                    {self._dumped_schema},
                     undefined,
                     document.getElementById('redoc-container')
                 )

--- a/starlite/openapi/controller.py
+++ b/starlite/openapi/controller.py
@@ -332,7 +332,7 @@ class OpenAPIController(Controller):
             <div id='swagger-container'/>
             <script type="text/javascript">
             const ui = SwaggerUIBundle({{
-                spec: JSON.parse({self._dumped_modified_schema}),
+                spec: JSON.parse('{self._dumped_modified_schema}'),
                 dom_id: '#swagger-container',
                 deepLinking: true,
                 showExtensions: true,
@@ -442,7 +442,7 @@ class OpenAPIController(Controller):
             <div id='redoc-container'/>
             <script type="text/javascript">
                 Redoc.init(
-                    JSON.parse({self._dumped_schema}),
+                    JSON.parse('{self._dumped_schema}'),
                     undefined,
                     document.getElementById('redoc-container')
                 )


### PR DESCRIPTION
### Pull Request Checklist
This fix wraps the exported OpenAPI JSON with a single quote so that `JSON.parse` does not fail.

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
