### PR TITLE
Adds `signature_namespace` layered parameter.

### DIFF
--- a/docs/examples/signature_namespace/app.py
+++ b/docs/examples/signature_namespace/app.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from starlite import Starlite
+
+from .controller import MyController
+from .domain import Model
+
+app = Starlite(route_handlers=[MyController], signature_namespace={"Model": Model})

--- a/docs/examples/signature_namespace/controller.py
+++ b/docs/examples/signature_namespace/controller.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from starlite import Controller, post
+
+if TYPE_CHECKING:
+    from .domain import Model
+
+
+class MyController(Controller):
+    @post()
+    def post_handler(self, data: Model) -> Model:
+        return data

--- a/docs/examples/signature_namespace/domain.py
+++ b/docs/examples/signature_namespace/domain.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Model:
+    a: int
+    b: str

--- a/docs/examples/tests/test_signature_namespace.py
+++ b/docs/examples/tests/test_signature_namespace.py
@@ -1,0 +1,10 @@
+from examples.signature_namespace.app import app
+from starlite.testing import TestClient
+
+
+def test_msgpack_app() -> None:
+    test_data = {"a": 1, "b": "two"}
+
+    with TestClient(app=app) as client:
+        response = client.post("/", json=test_data)
+        assert response.json() == test_data

--- a/docs/usage/the-starlite-app.rst
+++ b/docs/usage/the-starlite-app.rst
@@ -379,6 +379,7 @@ develop third-party application configuration systems.
     :language: python
 
 
+.. _layered-architecture:
 
 Layered architecture
 --------------------

--- a/starlite/_signature/parsing.py
+++ b/starlite/_signature/parsing.py
@@ -125,7 +125,10 @@ def get_type_annotation_from_plugin(
 
 
 def parse_fn_signature(
-    fn: AnyCallable, plugins: list[SerializationPluginProtocol], dependency_name_set: set[str]
+    fn: AnyCallable,
+    plugins: list[SerializationPluginProtocol],
+    dependency_name_set: set[str],
+    signature_namespace: dict[str, Any],
 ) -> tuple[list[ParsedSignatureParameter], Any, dict[str, PluginMapping], set[str]]:
     """Parse a function signature into data used for the generation of a signature model.
 
@@ -133,6 +136,7 @@ def parse_fn_signature(
         fn: A callable.
         plugins: A list of plugins.
         dependency_name_set: A set of dependency names
+        signature_namespace: mapping of names to types for forward reference resolution
 
     Returns:
         A tuple containing the following values for generating a signature model: a mapping of field definitions, the
@@ -144,7 +148,7 @@ def parse_fn_signature(
     field_plugin_mappings: dict[str, PluginMapping] = {}
     parsed_params: list[ParsedSignatureParameter] = []
     dependency_names: set[str] = set()
-    fn_type_hints = get_fn_type_hints(fn)
+    fn_type_hints = get_fn_type_hints(fn, namespace=signature_namespace)
 
     parameters = (
         ParsedSignatureParameter.from_parameter(
@@ -183,7 +187,10 @@ def parse_fn_signature(
 
 
 def create_signature_model(
-    fn: AnyCallable, plugins: list[SerializationPluginProtocol], dependency_name_set: set[str]
+    fn: AnyCallable,
+    plugins: list[SerializationPluginProtocol],
+    dependency_name_set: set[str],
+    signature_namespace: dict[str, Any],
 ) -> type[SignatureModel]:
     """Create a model for a callable's signature. The model can than be used to parse and validate before passing it to
     the callable.
@@ -192,6 +199,7 @@ def create_signature_model(
         fn: A callable.
         plugins: A list of plugins.
         dependency_name_set: A set of dependency names
+        signature_namespace: mapping of names to types for forward reference resolution
 
     Returns:
         A _signature model.
@@ -205,6 +213,7 @@ def create_signature_model(
         fn=unwrapped_fn,
         plugins=plugins,
         dependency_name_set=dependency_name_set,
+        signature_namespace=signature_namespace,
     )
 
     # TODO: we will implement logic here to determine what kind of SignatureModel we are creating.

--- a/starlite/config/app.py
+++ b/starlite/config/app.py
@@ -172,6 +172,8 @@ class AppConfig:
     """A list of dictionaries that will be added to the schema of all route handlers in the application. See
     :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>` for details.
     """
+    signature_namespace: dict[str, Any] = field(default_factory=dict)
+    """A mapping of names to types for use in forward reference resolution during signature modelling."""
     state: State = field(default_factory=State)
     """A :class:`State` <.datastructures.State>` instance holding application state."""
     static_files_config: list[StaticFilesConfig] = field(default_factory=list)

--- a/starlite/controller.py
+++ b/starlite/controller.py
@@ -59,6 +59,7 @@ class Controller:
         "response_cookies",
         "response_headers",
         "security",
+        "signature_namespace",
         "tags",
         "type_encoders",
     )
@@ -126,6 +127,8 @@ class Controller:
     """A sequence of string tags that will be appended to the schema of all route handlers under the controller."""
     security: OptionalSequence[SecurityRequirement]
     """A sequence of dictionaries that to the schema of all route handlers under the controller."""
+    signature_namespace: dict[str, Any]
+    """A mapping of names to types for use in forward reference resolution during signature modelling."""
     type_encoders: TypeEncodersMap | None
     """A mapping of types to callables that transform them into types supported for serialization."""
 
@@ -150,6 +153,7 @@ class Controller:
 
         self.response_cookies = narrow_response_cookies(self.response_cookies)
         self.response_headers = narrow_response_headers(self.response_headers)
+        self.signature_namespace = self.signature_namespace or {}
 
         self.path = normalize_path(self.path or "/")
         self.owner = owner

--- a/starlite/handlers/asgi_handlers.py
+++ b/starlite/handlers/asgi_handlers.py
@@ -37,6 +37,7 @@ class ASGIRouteHandler(BaseRouteHandler["ASGIRouteHandler"]):
         opt: Mapping[str, Any] | None = None,
         is_mount: bool = False,
         is_static: bool = False,
+        signature_namespace: Mapping[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize ``ASGIRouteHandler``.
@@ -56,12 +57,21 @@ class ASGIRouteHandler(BaseRouteHandler["ASGIRouteHandler"]):
                 ``/some-path/sub-path/`` etc.
             is_static: A boolean dictating whether the handler's paths should be regarded as static paths. Static paths
                 are used to deliver static files.
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """
         self.is_mount = is_mount or is_static
         self.is_static = is_static
-        super().__init__(path, exception_handlers=exception_handlers, guards=guards, name=name, opt=opt, **kwargs)
+        super().__init__(
+            path,
+            exception_handlers=exception_handlers,
+            guards=guards,
+            name=name,
+            opt=opt,
+            signature_namespace=signature_namespace,
+            **kwargs,
+        )
 
     def __call__(self, fn: AsyncAnyCallable) -> ASGIRouteHandler:
         """Replace a function with itself."""

--- a/starlite/handlers/base.py
+++ b/starlite/handlers/base.py
@@ -230,8 +230,8 @@ class BaseRouteHandler(Generic[T]):
     def resolve_opts(self) -> None:
         """Build the route handler opt dictionary by going from top to bottom.
 
-        If multiple layers define the same key, the value from the closest layer to the response handler will take
-        precedence.
+        When merging keys from multiple layers, if the same key is defined by multiple layers, the value from the
+        layer closest to the response handler will take precedence.
         """
 
         opt: dict[str, Any] = {}
@@ -243,8 +243,8 @@ class BaseRouteHandler(Generic[T]):
     def resolve_signature_namespace(self) -> dict[str, Any]:
         """Build the route handler signature namespace dictionary by going from top to bottom.
 
-        Names from layers are merged, if multiple layers define the same key, the value from the closest layer to the
-        response handler takes precedence.
+        When merging keys from multiple layers, if the same key is defined by multiple layers, the value from the
+        layer closest to the response handler will take precedence.
         """
         if self._resolved_layered_parameters is Empty:
             ns: dict[str, Any] = {}

--- a/starlite/handlers/base.py
+++ b/starlite/handlers/base.py
@@ -40,6 +40,7 @@ class BaseRouteHandler(Generic[T]):
         "_resolved_dependencies",
         "_resolved_guards",
         "_resolved_layered_parameters",
+        "_resolved_signature_namespace",
         "_resolved_type_encoders",
         "dependencies",
         "exception_handlers",
@@ -52,6 +53,7 @@ class BaseRouteHandler(Generic[T]):
         "paths",
         "signature",
         "signature_model",
+        "signature_namespace",
         "type_encoders",
     )
 
@@ -65,6 +67,7 @@ class BaseRouteHandler(Generic[T]):
         middleware: Sequence[Middleware] | None = None,
         name: str | None = None,
         opt: Mapping[str, Any] | None = None,
+        signature_namespace: Mapping[str, Any] | None = None,
         type_encoders: TypeEncodersMap | None = None,
         **kwargs: Any,
     ) -> None:
@@ -81,12 +84,14 @@ class BaseRouteHandler(Generic[T]):
             opt: A string keyed mapping of arbitrary values that can be accessed in :class:`Guards <.types.Guard>` or
                 wherever you have access to :class:`Request <.connection.Request>` or
                 :class:`ASGI Scope <.types.Scope>`.
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """
         self._resolved_dependencies: dict[str, Provide] | EmptyType = Empty
         self._resolved_guards: list[Guard] | EmptyType = Empty
         self._resolved_layered_parameters: dict[str, SignatureField] | EmptyType = Empty
+        self._resolved_signature_namespace: dict[str, Any] | EmptyType = Empty
         self._resolved_type_encoders: TypeEncodersMap | EmptyType = Empty
 
         self.dependencies = dependencies
@@ -97,6 +102,7 @@ class BaseRouteHandler(Generic[T]):
         self.opt = dict(opt or {})
         self.owner: Controller | Router | None = None
         self.signature_model: type[SignatureModel] | None = None
+        self.signature_namespace = signature_namespace or {}
         self.paths = (
             {normalize_path(p) for p in path}
             if path and isinstance(path, list)
@@ -233,6 +239,20 @@ class BaseRouteHandler(Generic[T]):
             opt.update(layer.opt or {})
 
         self.opt = opt
+
+    def resolve_signature_namespace(self) -> dict[str, Any]:
+        """Build the route handler signature namespace dictionary by going from top to bottom.
+
+        Names from layers are merged, if multiple layers define the same key, the value from the closest layer to the
+        response handler takes precedence.
+        """
+        if self._resolved_layered_parameters is Empty:
+            ns: dict[str, Any] = {}
+            for layer in self.ownership_layers:
+                ns.update(layer.signature_namespace)
+
+            self._resolved_signature_namespace = ns
+        return cast("dict[str, Any]", self._resolved_signature_namespace)
 
     async def authorize_connection(self, connection: "ASGIConnection") -> None:
         """Ensure the connection is authorized by running all the route guards in scope."""

--- a/starlite/handlers/http_handlers/base.py
+++ b/starlite/handlers/http_handlers/base.py
@@ -149,6 +149,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         raises: Sequence[type[HTTPException]] | None = None,
         response_description: str | None = None,
         responses: Mapping[int, ResponseSpec] | None = None,
+        signature_namespace: Mapping[str, Any] | None = None,
         security: Sequence[SecurityRequirement] | None = None,
         summary: str | None = None,
         tags: Sequence[str] | None = None,
@@ -198,6 +199,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
                 instances.
             responses: A mapping of additional status codes and a description of their expected content.
                 This information will be included in the OpenAPI schema
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
             status_code: An http status code for the response. Defaults to ``200`` for mixed method or ``GET``, ``PUT`` and
                 ``PATCH``, ``201`` for ``POST`` and ``204`` for ``DELETE``.
             sync_to_thread: A boolean dictating whether the handler function will be executed in a worker thread or the
@@ -232,6 +234,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
             middleware=middleware,
             name=name,
             opt=opt,
+            signature_namespace=signature_namespace,
             type_encoders=type_encoders,
             **kwargs,
         )

--- a/starlite/handlers/http_handlers/decorators.py
+++ b/starlite/handlers/http_handlers/decorators.py
@@ -11,7 +11,7 @@ from starlite.utils import is_class_and_subclass
 from .base import HTTPRouteHandler
 
 if TYPE_CHECKING:
-    from typing import Any
+    from typing import Any, Mapping
 
     from starlite.background_tasks import BackgroundTask, BackgroundTasks
     from starlite.datastructures import CacheControlHeader, ETag
@@ -65,6 +65,7 @@ class delete(HTTPRouteHandler):
         response_class: ResponseType | None = None,
         response_cookies: ResponseCookies | None = None,
         response_headers: ResponseHeaders | None = None,
+        signature_namespace: Mapping[str, Any] | None = None,
         status_code: int | None = None,
         sync_to_thread: bool = False,
         # OpenAPI related attributes
@@ -125,6 +126,7 @@ class delete(HTTPRouteHandler):
                 instances.
             responses: A mapping of additional status codes and a description of their expected content.
                 This information will be included in the OpenAPI schema
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
             status_code: An http status code for the response. Defaults to ``200`` for mixed method or ``GET``, ``PUT``
                 and ``PATCH``, ``201`` for ``POST`` and ``204`` for ``DELETE``.
             sync_to_thread: A boolean dictating whether the handler function will be executed in a worker thread or the
@@ -178,6 +180,7 @@ class delete(HTTPRouteHandler):
             response_headers=response_headers,
             responses=responses,
             security=security,
+            signature_namespace=signature_namespace,
             status_code=status_code,
             summary=summary,
             sync_to_thread=sync_to_thread,
@@ -215,6 +218,7 @@ class get(HTTPRouteHandler):
         response_class: ResponseType | None = None,
         response_cookies: ResponseCookies | None = None,
         response_headers: ResponseHeaders | None = None,
+        signature_namespace: Mapping[str, Any] | None = None,
         status_code: int | None = None,
         sync_to_thread: bool = False,
         # OpenAPI related attributes
@@ -275,6 +279,7 @@ class get(HTTPRouteHandler):
                 instances.
             responses: A mapping of additional status codes and a description of their expected content.
                 This information will be included in the OpenAPI schema
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
             status_code: An http status code for the response. Defaults to ``200`` for mixed method or ``GET``, ``PUT`` and
                 ``PATCH``, ``201`` for ``POST`` and ``204`` for ``DELETE``.
             sync_to_thread: A boolean dictating whether the handler function will be executed in a worker thread or the
@@ -329,6 +334,7 @@ class get(HTTPRouteHandler):
             response_headers=response_headers,
             responses=responses,
             security=security,
+            signature_namespace=signature_namespace,
             status_code=status_code,
             summary=summary,
             sync_to_thread=sync_to_thread,
@@ -366,6 +372,7 @@ class head(HTTPRouteHandler):
         response_class: ResponseType | None = None,
         response_cookies: ResponseCookies | None = None,
         response_headers: ResponseHeaders | None = None,
+        signature_namespace: Mapping[str, Any] | None = None,
         status_code: int | None = None,
         sync_to_thread: bool = False,
         # OpenAPI related attributes
@@ -430,6 +437,7 @@ class head(HTTPRouteHandler):
                 instances.
             responses: A mapping of additional status codes and a description of their expected content.
                 This information will be included in the OpenAPI schema
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
             status_code: An http status code for the response. Defaults to ``200`` for mixed method or ``GET``, ``PUT`` and
                 ``PATCH``, ``201`` for ``POST`` and ``204`` for ``DELETE``.
             sync_to_thread: A boolean dictating whether the handler function will be executed in a worker thread or the
@@ -484,6 +492,7 @@ class head(HTTPRouteHandler):
             response_headers=response_headers,
             responses=responses,
             security=security,
+            signature_namespace=signature_namespace,
             status_code=status_code,
             summary=summary,
             sync_to_thread=sync_to_thread,
@@ -535,6 +544,7 @@ class patch(HTTPRouteHandler):
         response_class: ResponseType | None = None,
         response_cookies: ResponseCookies | None = None,
         response_headers: ResponseHeaders | None = None,
+        signature_namespace: Mapping[str, Any] | None = None,
         status_code: int | None = None,
         sync_to_thread: bool = False,
         # OpenAPI related attributes
@@ -595,6 +605,7 @@ class patch(HTTPRouteHandler):
                 instances.
             responses: A mapping of additional status codes and a description of their expected content.
                 This information will be included in the OpenAPI schema
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
             status_code: An http status code for the response. Defaults to ``200`` for mixed method or ``GET``, ``PUT`` and
                 ``PATCH``, ``201`` for ``POST`` and ``204`` for ``DELETE``.
             sync_to_thread: A boolean dictating whether the handler function will be executed in a worker thread or the
@@ -648,6 +659,7 @@ class patch(HTTPRouteHandler):
             response_headers=response_headers,
             responses=responses,
             security=security,
+            signature_namespace=signature_namespace,
             status_code=status_code,
             summary=summary,
             sync_to_thread=sync_to_thread,
@@ -685,6 +697,7 @@ class post(HTTPRouteHandler):
         response_class: ResponseType | None = None,
         response_cookies: ResponseCookies | None = None,
         response_headers: ResponseHeaders | None = None,
+        signature_namespace: Mapping[str, Any] | None = None,
         status_code: int | None = None,
         sync_to_thread: bool = False,
         # OpenAPI related attributes
@@ -745,6 +758,7 @@ class post(HTTPRouteHandler):
                 instances.
             responses: A mapping of additional status codes and a description of their expected content.
                 This information will be included in the OpenAPI schema
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
             status_code: An http status code for the response. Defaults to ``200`` for mixed method or ``GET``, ``PUT`` and
                 ``PATCH``, ``201`` for ``POST`` and ``204`` for ``DELETE``.
             sync_to_thread: A boolean dictating whether the handler function will be executed in a worker thread or the
@@ -797,6 +811,7 @@ class post(HTTPRouteHandler):
             response_description=response_description,
             response_headers=response_headers,
             responses=responses,
+            signature_namespace=signature_namespace,
             security=security,
             status_code=status_code,
             summary=summary,
@@ -835,6 +850,7 @@ class put(HTTPRouteHandler):
         response_class: ResponseType | None = None,
         response_cookies: ResponseCookies | None = None,
         response_headers: ResponseHeaders | None = None,
+        signature_namespace: Mapping[str, Any] | None = None,
         status_code: int | None = None,
         sync_to_thread: bool = False,
         # OpenAPI related attributes
@@ -895,6 +911,7 @@ class put(HTTPRouteHandler):
                 instances.
             responses: A mapping of additional status codes and a description of their expected content.
                 This information will be included in the OpenAPI schema
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
             status_code: An http status code for the response. Defaults to ``200`` for mixed method or ``GET``, ``PUT`` and
                 ``PATCH``, ``201`` for ``POST`` and ``204`` for ``DELETE``.
             sync_to_thread: A boolean dictating whether the handler function will be executed in a worker thread or the
@@ -948,6 +965,7 @@ class put(HTTPRouteHandler):
             response_headers=response_headers,
             responses=responses,
             security=security,
+            signature_namespace=signature_namespace,
             status_code=status_code,
             summary=summary,
             sync_to_thread=sync_to_thread,

--- a/starlite/handlers/websocket_handlers.py
+++ b/starlite/handlers/websocket_handlers.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from inspect import Signature
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.handlers.base import BaseRouteHandler
@@ -11,6 +11,8 @@ __all__ = ("WebsocketRouteHandler", "websocket")
 
 
 if TYPE_CHECKING:
+    from typing import Any, Mapping
+
     from starlite.types import (
         AsyncAnyCallable,
         Dependencies,
@@ -37,6 +39,7 @@ class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):
         middleware: list[Middleware] | None = None,
         name: str | None = None,
         opt: dict[str, Any] | None = None,
+        signature_namespace: Mapping[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize ``WebsocketRouteHandler``
@@ -52,6 +55,7 @@ class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):
             opt: A string keyed mapping of arbitrary values that can be accessed in :class:`Guards <.types.Guard>` or
                 wherever you have access to :class:`Request <.connection.Request>` or
                 :class:`ASGI Scope <.types.Scope>`.
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
             **kwargs: Any additional kwarg - will be set in the opt dictionary.
         """
@@ -63,6 +67,7 @@ class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):
             middleware=middleware,
             name=name,
             opt=opt,
+            signature_namespace=signature_namespace,
             **kwargs,
         )
 

--- a/starlite/router.py
+++ b/starlite/router.py
@@ -67,6 +67,7 @@ class Router:
         "response_headers",
         "routes",
         "security",
+        "signature_namespace",
         "tags",
         "type_encoders",
     )
@@ -91,6 +92,7 @@ class Router:
         response_headers: ResponseHeaders | None = None,
         route_handlers: Sequence[ControllerRouterHandler],
         security: Sequence[SecurityRequirement] | None = None,
+        signature_namespace: Mapping[str, Any] | None = None,
         tags: Sequence[str] | None = None,
         type_encoders: TypeEncodersMap | None = None,
     ) -> None:
@@ -131,6 +133,7 @@ class Router:
             security: A sequence of dicts that will be added to the schema of all route handlers in the application.
                 See :data:`SecurityRequirement <.openapi.spec.SecurityRequirement>`
                 for details.
+            signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
             tags: A sequence of string tags that will be appended to the schema of all route handlers under the
                 application.
             type_encoders: A mapping of types to callables that transform them into types supported for serialization.
@@ -154,6 +157,7 @@ class Router:
         self.response_headers = narrow_response_headers(response_headers)
         self.routes: list[HTTPRoute | ASGIRoute | WebSocketRoute] = []
         self.security = list(security or [])
+        self.signature_namespace = signature_namespace or {}
         self.tags = list(tags or [])
         self.registered_route_handler_ids: set[int] = set()
         self.type_encoders = dict(type_encoders) if type_encoders is not None else None

--- a/starlite/testing/helpers.py
+++ b/starlite/testing/helpers.py
@@ -81,6 +81,7 @@ def create_test_client(
     response_class: ResponseType | None = None,
     root_path: str = "",
     session_config: BaseBackendConfig | None = None,
+    signature_namespace: Mapping[str, Any] | None = None,
     state: State | None = None,
     static_files_config: OptionalSequence[StaticFilesConfig] = None,
     template_config: TemplateConfig | None = None,
@@ -171,6 +172,7 @@ def create_test_client(
         response_class: A custom subclass of :class:`Response <.response.Response>` to be used as the app's default
             response.
         root_path: Path prefix for requests.
+        signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
         state: An optional :class:`State <.datastructures.State>` for application state.
         static_files_config: A sequence of :class:`StaticFilesConfig <.static_files.StaticFilesConfig>`
         session_config: Configuration for Session Middleware class to create raw session cookies for request to the
@@ -219,6 +221,7 @@ def create_test_client(
             request_class=request_class,
             response_class=response_class,
             route_handlers=route_handlers,
+            signature_namespace=signature_namespace,
             state=state,
             static_files_config=static_files_config,
             template_config=template_config,
@@ -271,6 +274,7 @@ def create_async_test_client(
     response_class: ResponseType | None = None,
     root_path: str = "",
     session_config: BaseBackendConfig | None = None,
+    signature_namespace: Mapping[str, Any] | None = None,
     state: State | None = None,
     static_files_config: OptionalSequence[StaticFilesConfig] = None,
     template_config: TemplateConfig | None = None,
@@ -365,6 +369,7 @@ def create_async_test_client(
         static_files_config: A sequence of :class:`StaticFilesConfig <.static_files.StaticFilesConfig>`
         session_config: Configuration for Session Middleware class to create raw session cookies for request to the
             route handlers.
+        signature_namespace: A mapping of names to types for use in forward reference resolution during signature modelling.
         template_config: An instance of :class:`TemplateConfig <.template.TemplateConfig>`
         websocket_class: An optional subclass of :class:`WebSocket <starlite.connection.websocket.WebSocket>` to use for
             websocket connections.
@@ -409,6 +414,7 @@ def create_async_test_client(
             request_class=request_class,
             response_class=response_class,
             route_handlers=route_handlers,
+            signature_namespace=signature_namespace,
             state=state,
             static_files_config=static_files_config,
             template_config=template_config,

--- a/tests/handlers/http/test_signature_namespace.py
+++ b/tests/handlers/http/test_signature_namespace.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from starlite import Controller, Router, delete, get, patch, post, put
+from starlite.testing import create_test_client
+
+
+@pytest.mark.parametrize(
+    ("method", "decorator"), [("GET", get), ("PUT", put), ("POST", post), ("PATCH", patch), ("DELETE", delete)]
+)
+def test_websocket_signature_namespace(method: str, decorator: type[get | put | post | patch | delete]) -> None:
+    class MyController(Controller):
+        path = "/"
+        signature_namespace = {"c": float}
+
+        @decorator(path="/", signature_namespace={"d": List[str], "dict": Dict}, status_code=200)
+        async def simple_handler(
+            self, a: a, b: b, c: c, d: d  # type:ignore[name-defined]  # noqa: F821
+        ) -> dict[str, Any]:
+            return {"a": a, "b": b, "c": c, "d": d}
+
+    router = Router("/", route_handlers=[MyController], signature_namespace={"b": str})
+
+    with create_test_client(route_handlers=[router], signature_namespace={"a": int}) as client:
+        response = client.request(method=method, url="/?a=1&b=two&c=3.0&d=d")
+        assert response.json() == {"a": 1, "b": "two", "c": 3.0, "d": ["d"]}

--- a/tests/handlers/http/test_to_response.py
+++ b/tests/handlers/http/test_to_response.py
@@ -90,7 +90,7 @@ async def test_to_response_async_await(anyio_backend: str) -> None:
         return data
 
     person_instance = PersonFactory.build()
-    test_function.signature_model = create_signature_model(test_function.fn.value, [], set())
+    test_function.signature_model = create_signature_model(test_function.fn.value, [], set(), signature_namespace={})
 
     response = await test_function.to_response(
         data=test_function.fn.value(data=person_instance),

--- a/tests/handlers/websocket/test_handle_websocket.py
+++ b/tests/handlers/websocket/test_handle_websocket.py
@@ -1,4 +1,6 @@
-from starlite import WebSocket, websocket
+from typing import List
+
+from starlite import Controller, Router, WebSocket, websocket
 from starlite.testing import create_test_client
 
 
@@ -17,3 +19,28 @@ def test_handle_websocket() -> None:
         ws.send_json({"data": "123"})
         data = ws.receive_json()
         assert data
+
+
+def test_websocket_signature_namespace() -> None:
+    class MyController(Controller):
+        path = "/ws"
+        signature_namespace = {"c": float}
+
+        @websocket(path="/", signature_namespace={"d": List[str]})
+        async def simple_websocket_handler(
+            self, socket: WebSocket, a: "a", b: "b", c: "c", d: "d"  # type:ignore[name-defined]  # noqa: F821
+        ) -> None:
+            await socket.accept()
+            data = await socket.receive_json()
+            assert data
+            await socket.send_json({"a": a, "b": b, "c": c, "d": d})
+            await socket.close()
+
+    router = Router("/", route_handlers=[MyController], signature_namespace={"b": str})
+
+    client = create_test_client(route_handlers=[router], signature_namespace={"a": int})
+
+    with client.websocket_connect("/ws?a=1&b=two&c=3.0&d=d") as ws:
+        ws.send_json({"data": "123"})
+        data = ws.receive_json()
+        assert data == {"a": 1, "b": "two", "c": 3.0, "d": ["d"]}

--- a/tests/openapi/test_parameters.py
+++ b/tests/openapi/test_parameters.py
@@ -28,7 +28,9 @@ def _create_parameters(app: Starlite, path: str) -> List["OpenAPIParameter"]:
     handler = route_handler.fn.value
     assert callable(handler)
 
-    handler_fields = create_signature_model(fn=handler, plugins=[], dependency_name_set=set()).fields
+    handler_fields = create_signature_model(
+        fn=handler, plugins=[], dependency_name_set=set(), signature_namespace={}
+    ).fields
     return create_parameter_for_handler(
         route_handler=route_handler,
         handler_fields=handler_fields,


### PR DESCRIPTION
When we parse the signature models for handlers, names of the parameter types must be available. However, when using linters, names that are only referenced in type annotations will be flagged as being unnecessary at runtime and suggested to move into an `if TYPE_CHECKING` block.

This parameter will allow names to be declared outside the scope that handlers are defined, allowing modules defining handlers and dependencies to better integrate with tooling.

For example:

```py
# router.py
from starlite import Router

from domain.thing import Thing
from .controller import ThingController

router = Router("/", route_handlers=[ThingController], signature_namespace={"Thing": Thing})
```

```py
# controller.py
from __future__ import annotations
from typing import TYPE_CHECKING

from starlite import Controller, post

if TYPE_CHECKING:
    from domain.thing import Thing

class ThingController(Controller):
    @post()
    def create_thing(data: Thing) -> Thing:
        return data
```

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
