### PR TITLE
Enhancement: Make `BaseEventEmitterBackend.emit` synchronous

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
             uvicorn,
           ]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.299
+    rev: v1.1.300
     hooks:
       - id: pyright
         exclude: "test_apps|tools|docs|_openapi"

--- a/docs/usage/events.rst
+++ b/docs/usage/events.rst
@@ -36,7 +36,7 @@ Starlite supports a simple implementation of the event emitter / listener patter
         # assuming we have now inserted a user, we want to send a welcome email.
         # To do this in a none-blocking fashion, we will emit an event to a listener, which will send the email,
         # using a different async block than the one where we are returning a response.
-        await request.app.emit("user_created", email=data.email)
+        request.app.emit("user_created", email=data.email)
 
 
 
@@ -102,7 +102,7 @@ You can also listen to the same events using multiple listeners:
     @post("/users")
     async def delete_user_handler(data: UserDTO, request: Request) -> None:
         await user_repository.delete({"email": email})
-        await request.app.emit("user_deleted", email=data.email, reason="deleted")
+        request.app.emit("user_deleted", email=data.email, reason="deleted")
 
 
 
@@ -116,7 +116,7 @@ The method :meth:`emit <starlite.events.BaseEventEmitterBackend.emit>` has the f
 
 .. code-block:: python
 
-    async def emit(self, event_id: str, *args: Any, **kwargs: Any) -> None:
+    def emit(self, event_id: str, *args: Any, **kwargs: Any) -> None:
         ...
 
 
@@ -149,7 +149,7 @@ For example, the following would raise an exception in python:
     @post("/users")
     async def delete_user_handler(data: UserDTO, request: Request) -> None:
         await user_repository.delete({"email": email})
-        await request.app.emit("user_deleted", email=data.email, reason="deleted")
+        request.app.emit("user_deleted", email=data.email, reason="deleted")
 
 
 
@@ -191,6 +191,6 @@ using either a DB/Key store that supports events (Redis, Postgres etc.), or a me
 technology.
 
 ..  attention::
-    The :class:`SimpleEventEmitter <starlite.events.SimpleEventEmitter>` works only with ``asyncio`` due to the limitation
-    of ``trio`` on running tasks without awaiting them. If you want to use this functionality with ``trio``, you will need
-    to create a custom implementation for your use case.
+    The :class:`SimpleEventEmitter <starlite.events.SimpleEventEmitter>` works only with ``asyncio`` due to the
+    limitation of ``trio`` (intentionally) not supporting "worker tasks" - i.e. tasks that run in a detached state. If
+    you want to use this functionality with ``trio``, you will need to create a custom implementation for your use case.

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -801,7 +801,7 @@ class Starlite(Router):
                         )
                     operation_ids.append(operation_id)
 
-    async def emit(self, event_id: str, *args: Any, **kwargs: Any) -> None:
+    def emit(self, event_id: str, *args: Any, **kwargs: Any) -> None:
         """Emit an event to all attached listeners.
 
         Args:
@@ -812,4 +812,4 @@ class Starlite(Router):
         Returns:
             None
         """
-        await self.event_emitter.emit(event_id, *args, **kwargs)
+        self.event_emitter.emit(event_id, *args, **kwargs)

--- a/starlite/events/emitter.py
+++ b/starlite/events/emitter.py
@@ -36,7 +36,7 @@ class BaseEventEmitterBackend(ABC):
                 self.listeners[event_id].add(listener)
 
     @abstractmethod
-    async def emit(self, event_id: str, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
+    def emit(self, event_id: str, *args: Any, **kwargs: Any) -> None:  # pragma: no cover
         """Emit an event to all attached listeners.
 
         Args:
@@ -126,7 +126,7 @@ class SimpleEventEmitter(BaseEventEmitterBackend):
         self._worker_task = None
         self._queue = None
 
-    async def emit(self, event_id: str, *args: Any, **kwargs: Any) -> None:
+    def emit(self, event_id: str, *args: Any, **kwargs: Any) -> None:
         """Emit an event to all attached listeners.
 
         Args:

--- a/tests/events/test_listener.py
+++ b/tests/events/test_listener.py
@@ -1,4 +1,4 @@
-from asyncio import sleep
+from time import sleep
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -10,7 +10,7 @@ from starlite.events.emitter import SimpleEventEmitter
 from starlite.events.listener import EventListener, listener
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.status_codes import HTTP_200_OK
-from starlite.testing import create_async_test_client, create_test_client
+from starlite.testing import create_test_client
 
 
 @pytest.fixture()
@@ -37,17 +37,17 @@ def async_listener(mock: MagicMock) -> EventListener:
 
 
 @pytest.mark.parametrize("listener", [lazy_fixture("sync_listener"), lazy_fixture("async_listener")])
-async def test_event_listener(mock: MagicMock, listener: EventListener) -> None:
+def test_event_listener(mock: MagicMock, listener: EventListener) -> None:
     test_value = {"key": "123"}
 
     @get("/")
-    async def route_handler(request: Request[Any, Any, Any]) -> None:
-        await request.app.emit("test_event", test_value)
+    def route_handler(request: Request[Any, Any, Any]) -> None:
+        request.app.emit("test_event", test_value)
 
     with create_test_client(route_handlers=[route_handler], listeners=[listener]) as client:
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
-        await sleep(0.01)
+        sleep(0.01)
         mock.assert_called_with(test_value)
 
 
@@ -56,50 +56,46 @@ async def test_shutdown_awaits_pending(async_listener: EventListener, mock: Magi
     await emitter.on_startup()
 
     for _ in range(100):
-        await emitter.emit("test_event")
+        emitter.emit("test_event")
 
     await emitter.on_shutdown()
 
     assert mock.call_count == 100
 
 
-async def test_multiple_event_listeners(
-    async_listener: EventListener, sync_listener: EventListener, mock: MagicMock
-) -> None:
+def test_multiple_event_listeners(async_listener: EventListener, sync_listener: EventListener, mock: MagicMock) -> None:
     @get("/")
-    async def route_handler(request: Request[Any, Any, Any]) -> None:
-        await request.app.emit("test_event")
+    def route_handler(request: Request[Any, Any, Any]) -> None:
+        request.app.emit("test_event")
 
-    async with create_async_test_client(
-        route_handlers=[route_handler], listeners=[async_listener, sync_listener]
-    ) as client:
-        response = await client.get("/")
-        await sleep(0.01)
+    with create_test_client(route_handlers=[route_handler], listeners=[async_listener, sync_listener]) as client:
+        response = client.get("/")
+        sleep(0.01)
         assert response.status_code == HTTP_200_OK
         assert mock.call_count == 2
 
 
-async def test_multiple_event_ids(mock: MagicMock) -> None:
+def test_multiple_event_ids(mock: MagicMock) -> None:
     @listener("test_event_1", "test_event_2")
     def event_handler() -> None:
         mock()
 
     @get("/{event_id:int}")
-    async def route_handler(request: Request[Any, Any, Any], event_id: int) -> None:
-        await request.app.emit(f"test_event_{event_id}")
+    def route_handler(request: Request[Any, Any, Any], event_id: int) -> None:
+        request.app.emit(f"test_event_{event_id}")
 
-    async with create_async_test_client(route_handlers=[route_handler], listeners=[event_handler]) as client:
-        response = await client.get("/1")
-        await sleep(0.01)
+    with create_test_client(route_handlers=[route_handler], listeners=[event_handler]) as client:
+        response = client.get("/1")
+        sleep(0.01)
         assert response.status_code == HTTP_200_OK
         assert mock.call_count == 1
-        response = await client.get("/2")
-        await sleep(0.01)
+        response = client.get("/2")
+        sleep(0.01)
         assert response.status_code == HTTP_200_OK
         assert mock.call_count == 2
 
 
-def test_raises_when_decorator_called_without_callable() -> None:
+async def test_raises_when_decorator_called_without_callable() -> None:
     with pytest.raises(ImproperlyConfiguredException):
         listener("test_even")(True)  # type: ignore
 
@@ -108,18 +104,18 @@ async def test_raises_when_not_initialized() -> None:
     app = Starlite([])
 
     with pytest.raises(ImproperlyConfiguredException):
-        await app.emit("x")
+        app.emit("x")
 
 
 async def test_raises_for_wrong_async_backend(async_listener: EventListener) -> None:
-    async with create_async_test_client([], listeners=[async_listener], backend="trio") as client:
+    with create_test_client([], listeners=[async_listener], backend="trio") as client:
         assert not client.app.event_emitter._queue
         assert not client.app.event_emitter._worker_task
         with pytest.raises(ImproperlyConfiguredException):
-            await client.app.emit("test_event")
+            client.app.emit("test_event")
 
 
 async def test_raises_when_not_listener_are_registered_for_an_event_id(async_listener: EventListener) -> None:
-    async with create_async_test_client(route_handlers=[], listeners=[async_listener]) as client:
+    with create_test_client(route_handlers=[], listeners=[async_listener]) as client:
         with pytest.raises(ImproperlyConfiguredException):
-            await client.app.emit("x")
+            client.app.emit("x")


### PR DESCRIPTION
Change the `BaseEventEmitterBackend.emit` to be synchronous. Also update 

- `Starlite.emit`
- `SimpleEventEmitter.emit` accordingly

### Rationale

This change allows events to be emitted from synchronous handlers. Performance won't be impacted, and this method simply enqueues an event in a non-blocking way. This can be implemented for any future backends as well.


### Pull Request Checklist

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [x] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
