### PR TITLE
Fix SimpleEventEmitter kwarg handling

### DIFF
--- a/starlite/events/emitter.py
+++ b/starlite/events/emitter.py
@@ -93,7 +93,7 @@ class SimpleEventEmitter(BaseEventEmitterBackend):
         """
         while self._queue:
             fn, args, kwargs = await self._queue.get()
-            await fn(*args, *kwargs)
+            await fn(*args, **kwargs)
             self._queue.task_done()
 
     async def on_startup(self) -> None:

--- a/tests/events/test_listener.py
+++ b/tests/events/test_listener.py
@@ -38,17 +38,15 @@ def async_listener(mock: MagicMock) -> EventListener:
 
 @pytest.mark.parametrize("listener", [lazy_fixture("sync_listener"), lazy_fixture("async_listener")])
 def test_event_listener(mock: MagicMock, listener: EventListener) -> None:
-    test_value = {"key": "123"}
-
     @get("/")
     def route_handler(request: Request[Any, Any, Any]) -> None:
-        request.app.emit("test_event", test_value)
+        request.app.emit("test_event", "positional", keyword="keyword-value")
 
     with create_test_client(route_handlers=[route_handler], listeners=[listener]) as client:
         response = client.get("/")
         assert response.status_code == HTTP_200_OK
         sleep(0.01)
-        mock.assert_called_with(test_value)
+        mock.assert_called_with("positional", keyword="keyword-value")
 
 
 async def test_shutdown_awaits_pending(async_listener: EventListener, mock: MagicMock) -> None:


### PR DESCRIPTION
With the PR #1346 introduced a bug to `SimpleEventEmitter` where keyword arguments would not be handled correctly. This adds missing tests covering this case and implements a fix.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
