### PR TITLE
RFC: Remove `InitPluginProtocol` in favor of `on_app_init` hook.

### DIFF
--- a/docs/examples/plugins/sqlalchemy_plugin/sqlalchemy_async.py
+++ b/docs/examples/plugins/sqlalchemy_plugin/sqlalchemy_async.py
@@ -64,5 +64,5 @@ async def get_company(company_id: int, async_session: AsyncSession) -> Company:
 app = Starlite(
     route_handlers=[create_company, get_company],
     on_startup=[on_startup],
-    plugins=[sqlalchemy_plugin],
+    on_app_init=[sqlalchemy_plugin],
 )

--- a/docs/examples/plugins/sqlalchemy_plugin/sqlalchemy_relationships.py
+++ b/docs/examples/plugins/sqlalchemy_plugin/sqlalchemy_relationships.py
@@ -10,8 +10,6 @@ from starlite.exceptions import HTTPException
 from starlite.status_codes import HTTP_404_NOT_FOUND
 
 engine = create_engine("sqlite+pysqlite://")
-sqlalchemy_config = SQLAlchemyConfig(engine_instance=engine, use_async_engine=False)
-sqlalchemy_plugin = SQLAlchemyPlugin(config=sqlalchemy_config)
 
 Base = declarative_base()
 
@@ -52,8 +50,10 @@ def get_user(user_id: int, db_session: Session) -> User:
     return user
 
 
+sqlalchemy_config = SQLAlchemyConfig(engine_instance=engine, use_async_engine=False)
+
 app = Starlite(
     route_handlers=[get_user],
     on_startup=[on_startup],
-    plugins=[sqlalchemy_plugin],
+    on_app_init=[SQLAlchemyPlugin(config=sqlalchemy_config)],
 )

--- a/docs/examples/plugins/sqlalchemy_plugin/sqlalchemy_relationships_to_many.py
+++ b/docs/examples/plugins/sqlalchemy_plugin/sqlalchemy_relationships_to_many.py
@@ -11,8 +11,6 @@ from starlite.exceptions import HTTPException
 from starlite.status_codes import HTTP_404_NOT_FOUND
 
 engine = create_engine("sqlite+pysqlite:///test.sqlite")
-sqlalchemy_config = SQLAlchemyConfig(engine_instance=engine, use_async_engine=False)
-sqlalchemy_plugin = SQLAlchemyPlugin(config=sqlalchemy_config)
 
 Base = declarative_base()
 
@@ -70,8 +68,10 @@ def get_user(user_id: int, db_session: Session) -> UserModel:
     return UserModel.from_orm(user)
 
 
+sqlalchemy_config = SQLAlchemyConfig(engine_instance=engine, use_async_engine=False)
+
 app = Starlite(
     route_handlers=[get_user],
     on_startup=[on_startup],
-    plugins=[sqlalchemy_plugin],
+    on_app_init=[SQLAlchemyPlugin(config=sqlalchemy_config)],
 )

--- a/docs/examples/plugins/sqlalchemy_plugin/sqlalchemy_sync.py
+++ b/docs/examples/plugins/sqlalchemy_plugin/sqlalchemy_sync.py
@@ -59,5 +59,5 @@ def get_company(company_id: str, db_session: Session) -> Company:
 app = Starlite(
     route_handlers=[create_company, get_company],
     on_startup=[on_startup],
-    plugins=[sqlalchemy_plugin],
+    on_app_init=[sqlalchemy_plugin],
 )

--- a/starlite/app.py
+++ b/starlite/app.py
@@ -27,7 +27,6 @@ from starlite.middleware.cors import CORSMiddleware
 from starlite.openapi.config import OpenAPIConfig
 from starlite.openapi.spec.components import Components
 from starlite.plugins import (
-    InitPluginProtocol,
     OpenAPISchemaPluginProtocol,
     SerializationPluginProtocol,
 )
@@ -407,9 +406,6 @@ class Starlite(Router):
             tags=config.tags,
             type_encoders=config.type_encoders,
         )
-
-        for plugin in (p for p in config.plugins if isinstance(p, InitPluginProtocol)):
-            plugin.on_app_init(app=self)
 
         for route_handler in config.route_handlers:
             self.register(route_handler)

--- a/starlite/contrib/piccolo_orm.py
+++ b/starlite/contrib/piccolo_orm.py
@@ -6,8 +6,6 @@ from starlite.exceptions import MissingDependencyException
 from starlite.openapi.spec.schema import SchemaDataContainer
 from starlite.plugins import OpenAPISchemaPluginProtocol, SerializationPluginProtocol
 
-__all__ = ("PiccoloORMPlugin",)
-
 try:
     import piccolo  # noqa: F401
 except ImportError as e:
@@ -19,7 +17,10 @@ from piccolo.utils.pydantic import create_pydantic_model
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
 
+    from starlite.config.app import AppConfig
     from starlite.openapi.spec import Schema
+
+__all__ = ("PiccoloORMPlugin",)
 
 
 class PiccoloORMPlugin(SerializationPluginProtocol[Table, BaseModel], OpenAPISchemaPluginProtocol[Table]):
@@ -27,6 +28,10 @@ class PiccoloORMPlugin(SerializationPluginProtocol[Table, BaseModel], OpenAPISch
 
     _models_map: Dict[Type[Table], Type["BaseModel"]] = {}
     _data_models_map: Dict[Type[Table], Type["BaseModel"]] = {}
+
+    def __call__(self, app_config: "AppConfig") -> "AppConfig":
+        app_config.plugins.append(self)
+        return app_config
 
     def to_data_container_class(self, model_class: Type[Table], **kwargs: Any) -> Type["BaseModel"]:
         """Given a piccolo model_class instance, convert it to a subclass of the piccolo "BaseModel".

--- a/starlite/contrib/sqlalchemy_1/plugin.py
+++ b/starlite/contrib/sqlalchemy_1/plugin.py
@@ -24,7 +24,7 @@ from starlite.exceptions import (
     MissingDependencyException,
 )
 from starlite.openapi.spec.schema import SchemaDataContainer
-from starlite.plugins import InitPluginProtocol, SerializationPluginProtocol
+from starlite.plugins import SerializationPluginProtocol
 
 try:
     import sqlalchemy  # noqa: F401
@@ -41,19 +41,18 @@ from sqlalchemy.sql.type_api import TypeEngine
 
 from .types import SQLAlchemyBinaryType
 
-__all__ = ("SQLAlchemyPlugin",)
-
-
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
 
-    from starlite.app import Starlite
+    from starlite.config.app import AppConfig
     from starlite.openapi.spec import Schema
 
     from .config import SQLAlchemyConfig
 
+__all__ = ("SQLAlchemyPlugin",)
 
-class SQLAlchemyPlugin(InitPluginProtocol, SerializationPluginProtocol[DeclarativeMeta, BaseModel]):
+
+class SQLAlchemyPlugin(SerializationPluginProtocol[DeclarativeMeta, BaseModel]):
     """A Plugin for SQLAlchemy."""
 
     __slots__ = ("_model_namespace_map", "_config")
@@ -71,23 +70,23 @@ class SQLAlchemyPlugin(InitPluginProtocol, SerializationPluginProtocol[Declarati
         self._model_namespace_map: Dict[str, "Type[BaseModel]"] = {}
         self._config = config
 
-    def on_app_init(self, app: "Starlite") -> None:
+    def __call__(self, app_config: "AppConfig") -> None:
         """If config has been passed to the plugin, it will initialize SQLAlchemy and add the dependencies as expected.
 
         Executed on the application's init process.
 
         Args:
-            app: The :class:`Starlite <.app.Starlite>` application instance.
-
-        Returns:
-            None
+            app_config: The :class:`AppConfig <.config.app.AppConfig>` instance used to configure the application
+                instance.
         """
+        app_config.plugins.append(self)
         if self._config is not None:
-            app.dependencies[self._config.dependency_key] = Provide(self._config.create_db_session_dependency)
-            app.before_send.append(self._config.before_send_handler)  # type: ignore[arg-type]
-            app.on_shutdown.append(self._config.on_shutdown)
-            self._config.config_sql_alchemy_logging(app.logging_config)
-            self._config.update_app_state(state=app.state)
+            app_config.dependencies[self._config.dependency_key] = Provide(self._config.create_db_session_dependency)
+            app_config.before_send.append(self._config.before_send_handler)  # type: ignore[arg-type]
+            app_config.on_shutdown.append(self._config.on_shutdown)
+            self._config.config_sql_alchemy_logging(app_config.logging_config)
+            self._config.update_app_state(state=app_config.state)
+        return app_config
 
     @staticmethod
     def is_plugin_supported_type(value: Any) -> "TypeGuard[DeclarativeMeta]":

--- a/starlite/contrib/tortoise_orm.py
+++ b/starlite/contrib/tortoise_orm.py
@@ -7,14 +7,10 @@ from starlite.openapi.spec.schema import SchemaDataContainer
 from starlite.plugins import OpenAPISchemaPluginProtocol, SerializationPluginProtocol
 from starlite.utils import is_pydantic_model_class
 
-__all__ = ("TortoiseORMPlugin",)
-
-
 try:
     import tortoise  # noqa: F401
 except ImportError as e:
     raise MissingDependencyException("tortoise-orm is not installed") from e
-
 
 from tortoise import Model, ModelMeta  # type: ignore[attr-defined]
 from tortoise.contrib.pydantic import (  # type: ignore[attr-defined]
@@ -27,7 +23,10 @@ from tortoise.fields.relational import RelationalField
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
 
+    from starlite.config.app import AppConfig
     from starlite.openapi.spec import Schema
+
+__all__ = ("TortoiseORMPlugin",)
 
 
 class TortoiseORMPlugin(SerializationPluginProtocol[Model, BaseModel], OpenAPISchemaPluginProtocol[Model]):
@@ -35,6 +34,10 @@ class TortoiseORMPlugin(SerializationPluginProtocol[Model, BaseModel], OpenAPISc
 
     _models_map: Dict[Type[Model], Type[PydanticModel]] = {}
     _data_models_map: Dict[Type[Model], Type[PydanticModel]] = {}
+
+    def __call__(self, app_config: "AppConfig") -> "AppConfig":
+        app_config.plugins.append(self)
+        return app_config
 
     @staticmethod
     def _create_pydantic_model(model_class: Type[Model], **kwargs: Any) -> "Type[PydanticModel]":

--- a/starlite/plugins.py
+++ b/starlite/plugins.py
@@ -21,7 +21,6 @@ from typing_extensions import TypeGuard, get_args
 from starlite.types.protocols import DataclassProtocol
 
 __all__ = (
-    "InitPluginProtocol",
     "OpenAPISchemaPluginProtocol",
     "PluginMapping",
     "PluginProtocol",
@@ -31,64 +30,10 @@ __all__ = (
 
 
 if TYPE_CHECKING:
-    from starlite.app import Starlite
     from starlite.openapi.spec import Schema
 
 ModelT = TypeVar("ModelT")
 DataContainerT = TypeVar("DataContainerT", bound=Union[BaseModel, DataclassProtocol, TypedDict])  # type: ignore[valid-type]
-
-
-@runtime_checkable
-class InitPluginProtocol(Protocol):
-    """Protocol used to define plugins that affect the application's init process."""
-
-    __slots__ = ()
-
-    def on_app_init(self, app: "Starlite") -> None:
-        """Receive the Starlite application instance before ``init`` is finalized and allow the plugin to update various
-        attributes.
-
-        Examples:
-            .. code-block: python
-                from starlite import Starlite, get
-                from starlite.plugins import InitPluginProtocol
-
-
-                @get("/my-path")
-                def my_route_handler() -> dict[str, str]:
-                    return {"hello": "world"}
-
-
-                class MyPlugin(InitPluginProtocol):
-                    def on_app_init(self, app: Starlite) -> None:
-                        # update app attributes
-
-                        app.after_request = ...
-                        app.after_response = ...
-                        app.before_request = ...
-                        app.dependencies.update({...})
-                        app.exception_handlers.update({...})
-                        app.guards.extend(...)
-                        app.middleware.extend(...)
-                        app.on_shutdown.extend(...)
-                        app.on_startup.extend(...)
-                        app.parameters.update({...})
-                        app.response_class = ...
-                        app.response_cookies.extend(...)
-                        app.response_headers.update(...)
-                        app.tags.extend(...)
-
-                        # register a route handler
-                        app.register(my_route_handler)
-
-
-        Args:
-            app: The :class:`Starlite <starlite.app.Starlite>` instance.
-
-        Returns:
-            None
-        """
-        return None  # noqa: R501
 
 
 @runtime_checkable
@@ -241,4 +186,4 @@ class PluginMapping(NamedTuple):
         return self.plugin.from_data_container_instance(self.model_class, value)
 
 
-PluginProtocol = Union[SerializationPluginProtocol, InitPluginProtocol, OpenAPISchemaPluginProtocol]
+PluginProtocol = Union[SerializationPluginProtocol, OpenAPISchemaPluginProtocol]

--- a/tests/contrib/piccolo_orm/test_piccolo_orm_plugin_integration.py
+++ b/tests/contrib/piccolo_orm/test_piccolo_orm_plugin_integration.py
@@ -12,14 +12,14 @@ from .tables import Band, Concert, Manager, RecordingStudio, Venue
 
 
 def test_serializing_single_piccolo_table(scaffold_piccolo: Callable) -> None:
-    with create_test_client(route_handlers=[retrieve_studio], plugins=[PiccoloORMPlugin()]) as client:
+    with create_test_client(route_handlers=[retrieve_studio], on_app_init=[PiccoloORMPlugin()]) as client:
         response = client.get("/studio")
         assert response.status_code == HTTP_200_OK
         assert str(RecordingStudio(**response.json()).querystring) == str(studio.querystring)
 
 
 def test_serializing_multiple_piccolo_tables(scaffold_piccolo: Callable) -> None:
-    with create_test_client(route_handlers=[retrieve_venues], plugins=[PiccoloORMPlugin()]) as client:
+    with create_test_client(route_handlers=[retrieve_venues], on_app_init=[PiccoloORMPlugin()]) as client:
         response = client.get("/venues")
         assert response.status_code == HTTP_200_OK
         assert [str(Venue(**value).querystring) for value in response.json()] == [str(v.querystring) for v in venues]
@@ -34,7 +34,7 @@ async def test_create_piccolo_table_instance(scaffold_piccolo: Callable, anyio_b
         Concert, persist=False, defaults={Concert.band_1: band_1, Concert.band_2: band_2, Concert.venue: venue}
     )
 
-    with create_test_client(route_handlers=[create_concert], plugins=[PiccoloORMPlugin()]) as client:
+    with create_test_client(route_handlers=[create_concert], on_app_init=[PiccoloORMPlugin()]) as client:
         data = concert.to_dict()
         data["band_1"] = band_1.id  # type: ignore[attr-defined]
         data["band_2"] = band_2.id  # type: ignore[attr-defined]

--- a/tests/contrib/piccolo_orm/test_piccolo_orm_plugin_openapi_specs.py
+++ b/tests/contrib/piccolo_orm/test_piccolo_orm_plugin_openapi_specs.py
@@ -11,7 +11,7 @@ from tests.contrib.piccolo_orm.endpoints import (
 
 
 def test_piccolo_orm_plugin_openapi_spec_generation() -> None:
-    app = Starlite(route_handlers=[retrieve_studio, retrieve_venues, create_concert], plugins=[PiccoloORMPlugin()])
+    app = Starlite(route_handlers=[retrieve_studio, retrieve_venues, create_concert], on_app_init=[PiccoloORMPlugin()])
     schema: Any = app.openapi_schema
     assert schema
     assert schema.paths

--- a/tests/contrib/tortoise_orm/test_tortoise_orm_plugin_integration.py
+++ b/tests/contrib/tortoise_orm/test_tortoise_orm_plugin_integration.py
@@ -16,7 +16,7 @@ async def test_serializing_single_tortoise_model_instance(anyio_backend: str) ->
         route_handlers=[get_tournament],
         on_startup=[init_tortoise],
         on_shutdown=[cleanup],
-        plugins=[TortoiseORMPlugin()],
+        on_app_init=[TortoiseORMPlugin()],
     ) as client:
         response = client.get("/tournaments/1")
         assert response.status_code == HTTP_200_OK
@@ -37,7 +37,7 @@ async def test_serializing_list_of_tortoise_models(anyio_backend: str) -> None:
         route_handlers=[get_tournaments],
         on_startup=[init_tortoise],
         on_shutdown=[cleanup],
-        plugins=[TortoiseORMPlugin()],
+        on_app_init=[TortoiseORMPlugin()],
     ) as client:
         response = client.get("/tournaments")
         assert response.status_code == HTTP_200_OK
@@ -59,7 +59,7 @@ async def test_creating_a_tortoise_model(anyio_backend: str) -> None:
         route_handlers=[create_tournament],
         on_startup=[init_tortoise],
         on_shutdown=[cleanup],
-        plugins=[TortoiseORMPlugin()],
+        on_app_init=[TortoiseORMPlugin()],
     ) as client:
         response = client.post(
             "/tournaments",

--- a/tests/contrib/tortoise_orm/test_tortoise_orm_plugin_openapi_specs.py
+++ b/tests/contrib/tortoise_orm/test_tortoise_orm_plugin_openapi_specs.py
@@ -13,7 +13,7 @@ from tests.contrib.tortoise_orm import (
 def test_tortoise_orm_plugin_openapi_spec_generation(scaffold_tortoise: Callable) -> None:
     app = Starlite(
         route_handlers=[create_tournament, get_tournament, get_tournaments],
-        plugins=[TortoiseORMPlugin()],
+        on_app_init=[TortoiseORMPlugin()],
     )
     schema = app.openapi_schema
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -3,18 +3,14 @@ from typing import TYPE_CHECKING, Any, Dict, Type
 import pytest
 from pydantic import BaseModel
 
-from starlite import MediaType, Starlite, get
+from starlite import MediaType, get
 from starlite.plugins import (
-    InitPluginProtocol,
     PluginMapping,
     SerializationPluginProtocol,
 )
-from starlite.testing import create_test_client
 
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
-
-    from starlite.datastructures import State
 
 
 class AModel:
@@ -69,23 +65,3 @@ def test_plugin_mapping_value_to_model_instance(input_value: Any, output_value: 
 @get("/", media_type=MediaType.TEXT)
 def greet() -> str:
     return "hello world"
-
-
-def test_plugin_on_app_init() -> None:
-    tag = "on_app_init_called"
-
-    def on_startup(state: "State") -> None:
-        state.called = True
-
-    class PluginWithInitOnly(InitPluginProtocol):
-        def on_app_init(self, app: "Starlite") -> None:
-            app.tags.append(tag)
-            app.on_startup.append(on_startup)
-            app.register(greet)
-
-    with create_test_client(plugins=[PluginWithInitOnly()]) as client:
-        response = client.get("/")
-        assert response.text == "hello world"
-
-        assert tag in client.app.tags
-        assert client.app.state.called


### PR DESCRIPTION
We have two methods for automated app configuration, `on_app_init` hook, and `InitPluginProtocol`. This PR attempts to simplify this by refactoring plugins to utilise the `on_app_init` hook, and therefore removing the `InitPluginProtocol`.

In this PR, passing a plugin instance to `on_app_init` both adds the plugin to `AppConfig.plugins` and performs any application configuration, such as that which is done by the SQLAlchemy plugin.

The `on_app_init` approach for pre-baked app config is desirable due to it interacting with the `AppConfig` object. Plugin development is an area that we should encourage the community to participate in, and encouraging that work to interact with the `AppConfig` _before_ the majority of application configuration has taken place is more desirable than passing through an application object to the plugin at some arbitrary point inside the app's own `__init__()` method.

Additionally, the app configuration is something that may be desired independent of a serialization plugin. So it makes sense for that functionality to be defined separate from the serialization plugin, and leveraged by it. For example, if a user doesn't wish to leverage the serialization plugin functionality, they can use `on_app_init=[SQLAlchemyInit()]`. However if they want the serialization behavior _and_ the app initialization, should that be `on_app_init=[SQLAlchemyPlugin()]` or `plugins=[SQLAlchemyPlugin()]`, or `on_app_init=[SQLAlchemyInit()], plugins=[SQLAlchemyPlugin()]`?

In this PR, the `plugins` kwarg to app remains, so there is still two ways for a plugin to be registered, e.g., by either passing `on_app_init=[plugin_instance]` or `plugins=[plugin_instance]`. This isn't ideal, and definitely a downside of this approach.

Discussion points:
- is having plugin instances register themselves via `on_app_init` intuitive enough?
- does app configuration _have_ to be associated with serialization plugin behavior?
- an alternative would be to redefine `InitPluginProtocol.on_app_init()` to receive the app config object and call these immediately after `on_app_init` is called.
- other??

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
