### PR TITLE
Fix `get_plugin_for_value()` for arbitrary generic types.

### DIFF
--- a/starlite/plugins.py
+++ b/starlite/plugins.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -19,6 +20,7 @@ from pydantic import BaseModel
 from typing_extensions import TypeGuard, get_args
 
 from starlite.types.protocols import DataclassProtocol
+from starlite.utils.predicates import is_class_and_subclass
 
 __all__ = (
     "InitPluginProtocol",
@@ -209,8 +211,8 @@ def get_plugin_for_value(
     if plugins:
         if value and isinstance(value, (list, tuple)):
             value = value[0]
-        if get_args(value):
-            value = get_args(value)[0]
+        if is_class_and_subclass(value, Iterable) and (args := get_args(value)):  # type:ignore[type-abstract]
+            value = args[0]
         for plugin in plugins:
             if plugin.is_plugin_supported_type(value):
                 return plugin


### PR DESCRIPTION
`get_plugin_for_value()` unconditionally checks the first value returned from `get_args()`, which I've presumed is to detect if an annotation is for a homogeneous iterable of a plugin supported type, e.g., `List[User]`.

This PR ensures that the type _is_ an iterable type before inspecting the args so that arbitrary non-iterable generic types are tested against their outer type, not the type of their first generic arg, e.g, `Request[User, ...]` would be checked against `Request` not `user`.

Closes #1388

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
