### PR TITLE
Call SQLAlchemyConfig.update_app_state in `on_startup` hook.

### DIFF
--- a/starlite/contrib/sqlalchemy_1/plugin.py
+++ b/starlite/contrib/sqlalchemy_1/plugin.py
@@ -85,9 +85,9 @@ class SQLAlchemyPlugin(InitPluginProtocol, SerializationPluginProtocol[Declarati
         if self._config is not None:
             app.dependencies[self._config.dependency_key] = Provide(self._config.create_db_session_dependency)
             app.before_send.append(self._config.before_send_handler)  # type: ignore[arg-type]
+            app.on_startup.append(self._config.update_app_state)
             app.on_shutdown.append(self._config.on_shutdown)
             self._config.config_sql_alchemy_logging(app.logging_config)
-            self._config.update_app_state(state=app.state)
 
     @staticmethod
     def is_plugin_supported_type(value: Any) -> "TypeGuard[DeclarativeMeta]":

--- a/tests/contrib/sqlalchemy_1/sql_alchemy_plugin/test_sql_alchemy_config.py
+++ b/tests/contrib/sqlalchemy_1/sql_alchemy_plugin/test_sql_alchemy_config.py
@@ -24,17 +24,17 @@ from starlite.types import Scope
 @pytest.mark.parametrize("connection_string", ["sqlite+aiosqlite://", "sqlite://"])
 def test_sets_engine_and_session_maker(connection_string: str) -> None:
     config = SQLAlchemyConfig(connection_string=connection_string, use_async_engine="+aiosqlite" in connection_string)
-    app = Starlite(plugins=[SQLAlchemyPlugin(config=config)])
-    assert app.state.get(config.engine_app_state_key)
-    assert app.state.get(config.session_maker_app_state_key)
+    with create_test_client([], plugins=[SQLAlchemyPlugin(config=config)]) as client:
+        assert client.app.state.get(config.engine_app_state_key)
+        assert client.app.state.get(config.session_maker_app_state_key)
 
 
 @pytest.mark.parametrize("connection_string", ["sqlite+aiosqlite://", "sqlite://"])
 def test_dependency_creates_session(connection_string: str) -> None:
     config = SQLAlchemyConfig(connection_string=connection_string, use_async_engine="+aiosqlite" in connection_string)
-    app = Starlite(plugins=[SQLAlchemyPlugin(config=config)])
-    request = RequestFactory().get()
-    session = config.create_db_session_dependency(state=app.state, scope=request.scope)
+    with create_test_client([], plugins=[SQLAlchemyPlugin(config=config)]) as client:
+        request = RequestFactory().get()
+        session = config.create_db_session_dependency(state=client.app.state, scope=request.scope)
     assert session
     assert request.scope[SESSION_SCOPE_KEY]  # type: ignore
 


### PR DESCRIPTION
When using the SQLAlchemy 1 plugin, repeatedly running through the application lifecycle (as done when testing an application not provided by a factory function), causes a KeyError on the second pass.

This is caused be the plugin's on_shutdown handler deleting the engine_app_state_key from the application's state on application shutdown, but only adding it on application init.

This PR adds `SQLAlchemyConfig.update_app_state` to application `on_startup` hooks so that state removed in `on_shutdown` is reset for each test.

Closes #1368

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
