### PR TITLE
chore: fix a small typo in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -73,7 +73,7 @@ Writing and running tests
 
 Tests are contained within the ``tests`` directory, and follow the same directory structure as the ``starlite`` module.
 If you are adding a test case, it should be located within the correct submodule of ``tests``. E.g. tests for
-``starlite/utils./sync.py`` reside in ``tests/utils/test_sync.py``.
+``starlite/utils/sync.py`` reside in ``tests/utils/test_sync.py``.
 
 The ``Makefile`` includes several commands for running tests:
 


### PR DESCRIPTION
### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

Hi, I was taking a look at the contributing guides to see if and how to contribute to the project and I found a small typo, which this pr should correct. Maybe a PR for just a dot is overkill, so no problems if you want to close/ignore this and batch the work later down the line into a meatier PR!