### PR TITLE
Modify the `InitPluginProtocol` to interact with `AppConfig`.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import os
+import re
 from functools import partial
 from typing import Any
 
@@ -91,8 +92,6 @@ nitpick_ignore_regex = [
     (r"py:obj", r"typing\..*"),
     (r"py:.*", r"httpx.*"),
     # type vars
-    ("py:.*", r"starlite\.plugins\.ModelT"),
-    ("py:.*", r"starlite\.plugins\.DataContainerT"),
     ("py:.*", r"starlite\.pagination\.C"),
     ("py:.*", r"starlite.middleware.session.base.ConfigT"),
     ("py:.*", r"multidict\..*"),
@@ -113,6 +112,7 @@ ignore_missing_refs = {
     "starlite.openapi.OpenAPIController.security": {"SecurityRequirement"},
     "starlite.contrib.sqlalchemy_1.plugin.SQLAlchemyPlugin.handle_string_type": {"BINARY", "VARBINARY", "LargeBinary"},
     "starlite.contrib.sqlalchemy_1.plugin.SQLAlchemyPlugin.is_plugin_supported_type": {"DeclarativeMeta"},
+    re.compile(r"starlite\.plugins.*"): re.compile(".*(ModelT|DataContainerT)"),
 }
 
 

--- a/starlite/contrib/sqlalchemy_1/plugin.py
+++ b/starlite/contrib/sqlalchemy_1/plugin.py
@@ -41,16 +41,15 @@ from sqlalchemy.sql.type_api import TypeEngine
 
 from .types import SQLAlchemyBinaryType
 
-__all__ = ("SQLAlchemyPlugin",)
-
-
 if TYPE_CHECKING:
     from typing_extensions import TypeGuard
 
-    from starlite.app import Starlite
+    from starlite.config.app import AppConfig
     from starlite.openapi.spec import Schema
 
     from .config import SQLAlchemyConfig
+
+__all__ = ("SQLAlchemyPlugin",)
 
 
 class SQLAlchemyPlugin(InitPluginProtocol, SerializationPluginProtocol[DeclarativeMeta, BaseModel]):
@@ -71,23 +70,24 @@ class SQLAlchemyPlugin(InitPluginProtocol, SerializationPluginProtocol[Declarati
         self._model_namespace_map: Dict[str, "Type[BaseModel]"] = {}
         self._config = config
 
-    def on_app_init(self, app: "Starlite") -> None:
+    def on_app_init(self, app_config: "AppConfig") -> "AppConfig":
         """If config has been passed to the plugin, it will initialize SQLAlchemy and add the dependencies as expected.
 
         Executed on the application's init process.
 
         Args:
-            app: The :class:`Starlite <.app.Starlite>` application instance.
+            app_config: The :class:`AppConfig <.config.app.AppConfig>` instance.
 
         Returns:
-            None
+            App config instance, after modifications.
         """
         if self._config is not None:
-            app.dependencies[self._config.dependency_key] = Provide(self._config.create_db_session_dependency)
-            app.before_send.append(self._config.before_send_handler)  # type: ignore[arg-type]
-            app.on_startup.append(self._config.update_app_state)
-            app.on_shutdown.append(self._config.on_shutdown)
-            self._config.config_sql_alchemy_logging(app.logging_config)
+            app_config.dependencies[self._config.dependency_key] = Provide(self._config.create_db_session_dependency)
+            app_config.before_send.append(self._config.before_send_handler)  # type: ignore[arg-type]
+            app_config.on_startup.append(self._config.update_app_state)
+            app_config.on_shutdown.append(self._config.on_shutdown)
+            self._config.config_sql_alchemy_logging(app_config.logging_config)
+        return app_config
 
     @staticmethod
     def is_plugin_supported_type(value: Any) -> "TypeGuard[DeclarativeMeta]":

--- a/starlite/plugins.py
+++ b/starlite/plugins.py
@@ -56,7 +56,7 @@ class InitPluginProtocol(Protocol):
 
                 @get("/my-path")
                 def my_route_handler(name: str) -> dict[str, str]:
-                    return {"hello": "world"}
+                    return {"hello": name}
 
                 class MyPlugin(InitPluginProtocol):
                     def on_app_init(self, app_config: AppConfig) -> AppConfig:
@@ -72,7 +72,7 @@ class InitPluginProtocol(Protocol):
         Returns:
             The app config object.
         """
-        return app_config
+        return app_config  # pragma: no cover
 
 
 @runtime_checkable

--- a/starlite/plugins.py
+++ b/starlite/plugins.py
@@ -1,15 +1,12 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
 from typing import (
     TYPE_CHECKING,
     Any,
     Awaitable,
-    Dict,
-    List,
     NamedTuple,
-    Optional,
     Protocol,
-    Tuple,
-    Type,
     TypedDict,
     TypeVar,
     Union,
@@ -22,6 +19,10 @@ from typing_extensions import TypeGuard, get_args
 from starlite.types.protocols import DataclassProtocol
 from starlite.utils.predicates import is_class_and_subclass
 
+if TYPE_CHECKING:
+    from starlite.config.app import AppConfig
+    from starlite.openapi.spec import Schema
+
 __all__ = (
     "InitPluginProtocol",
     "OpenAPISchemaPluginProtocol",
@@ -30,11 +31,6 @@ __all__ = (
     "SerializationPluginProtocol",
     "get_plugin_for_value",
 )
-
-
-if TYPE_CHECKING:
-    from starlite.app import Starlite
-    from starlite.openapi.spec import Schema
 
 ModelT = TypeVar("ModelT")
 DataContainerT = TypeVar("DataContainerT", bound=Union[BaseModel, DataclassProtocol, TypedDict])  # type: ignore[valid-type]
@@ -46,51 +42,37 @@ class InitPluginProtocol(Protocol):
 
     __slots__ = ()
 
-    def on_app_init(self, app: "Starlite") -> None:
-        """Receive the Starlite application instance before ``init`` is finalized and allow the plugin to update various
-        attributes.
+    def on_app_init(self, app_config: AppConfig) -> AppConfig:
+        """Receive the :class:`AppConfig<.config.app.AppConfig>` instance after `on_app_init` hooks have been called.
 
         Examples:
             .. code-block: python
                 from starlite import Starlite, get
+                from starlite.di import Provide
                 from starlite.plugins import InitPluginProtocol
 
+                def get_name() -> str:
+                    return "world"
 
                 @get("/my-path")
-                def my_route_handler() -> dict[str, str]:
+                def my_route_handler(name: str) -> dict[str, str]:
                     return {"hello": "world"}
 
-
                 class MyPlugin(InitPluginProtocol):
-                    def on_app_init(self, app: Starlite) -> None:
-                        # update app attributes
+                    def on_app_init(self, app_config: AppConfig) -> AppConfig:
+                        app_config.dependencies["name"] = Provide(get_name)
+                        app_config.route_handlers.append(my_route_handler)
+                        return app_config
 
-                        app.after_request = ...
-                        app.after_response = ...
-                        app.before_request = ...
-                        app.dependencies.update({...})
-                        app.exception_handlers.update({...})
-                        app.guards.extend(...)
-                        app.middleware.extend(...)
-                        app.on_shutdown.extend(...)
-                        app.on_startup.extend(...)
-                        app.parameters.update({...})
-                        app.response_class = ...
-                        app.response_cookies.extend(...)
-                        app.response_headers.update(...)
-                        app.tags.extend(...)
-
-                        # register a route handler
-                        app.register(my_route_handler)
-
+                app = Starlite(plugins=[MyPlugin()])
 
         Args:
-            app: The :class:`Starlite <starlite.app.Starlite>` instance.
+            app_config: The :class:`AppConfig <starlite.config.app.AppConfig>` instance.
 
         Returns:
-            None
+            The app config object.
         """
-        return None  # noqa: R501
+        return app_config
 
 
 @runtime_checkable
@@ -113,7 +95,7 @@ class SerializationPluginProtocol(Protocol[ModelT, DataContainerT]):
         """
         raise NotImplementedError()
 
-    def to_dict(self, model_instance: ModelT) -> Union[Dict[str, Any], Awaitable[Dict[str, Any]]]:
+    def to_dict(self, model_instance: ModelT) -> dict[str, Any] | Awaitable[dict[str, Any]]:
         """Given an instance of a model supported by the plugin, return a dictionary of serializable values.
 
         Args:
@@ -127,7 +109,7 @@ class SerializationPluginProtocol(Protocol[ModelT, DataContainerT]):
         """
         raise NotImplementedError()
 
-    def from_dict(self, model_class: Type[ModelT], **kwargs: Any) -> ModelT:
+    def from_dict(self, model_class: type[ModelT], **kwargs: Any) -> ModelT:
         """Given a class supported by this plugin and a dict of values, create an instance of the class.
 
         Args:
@@ -139,7 +121,7 @@ class SerializationPluginProtocol(Protocol[ModelT, DataContainerT]):
         """
         raise NotImplementedError()
 
-    def to_data_container_class(self, model_class: Type[ModelT], **kwargs: Any) -> Type[DataContainerT]:
+    def to_data_container_class(self, model_class: type[ModelT], **kwargs: Any) -> type[DataContainerT]:
         """Create a data container class corresponding to the given model class.
 
         Args:
@@ -152,7 +134,7 @@ class SerializationPluginProtocol(Protocol[ModelT, DataContainerT]):
         raise NotImplementedError()
 
     def from_data_container_instance(
-        self, model_class: Type[ModelT], data_container_instance: DataContainerT
+        self, model_class: type[ModelT], data_container_instance: DataContainerT
     ) -> ModelT:
         """Create a model instance from the given data container instance.
 
@@ -184,7 +166,7 @@ class OpenAPISchemaPluginProtocol(Protocol[ModelT]):
         """
         raise NotImplementedError()
 
-    def to_openapi_schema(self, model_class: Type[ModelT]) -> "Schema":
+    def to_openapi_schema(self, model_class: type[ModelT]) -> "Schema":
         """Given a model class, transform it into an OpenAPI schema class.
 
         Args:
@@ -196,9 +178,7 @@ class OpenAPISchemaPluginProtocol(Protocol[ModelT]):
         raise NotImplementedError()
 
 
-def get_plugin_for_value(
-    value: Any, plugins: List[SerializationPluginProtocol]
-) -> Optional[SerializationPluginProtocol]:
+def get_plugin_for_value(value: Any, plugins: list[SerializationPluginProtocol]) -> SerializationPluginProtocol | None:
     """Return a plugin for handling the given value, if any plugin supports it.
 
     Args:
@@ -226,7 +206,7 @@ class PluginMapping(NamedTuple):
     model_class: Any
 
     def get_model_instance_for_value(
-        self, value: Union[DataContainerT, List[DataContainerT], Tuple[DataContainerT, ...]]
+        self, value: DataContainerT | list[DataContainerT] | tuple[DataContainerT, ...]
     ) -> Any:
         """Given a value generated by plugin, return an instance of the original class.
 


### PR DESCRIPTION
This PR modifies `InitPluginProtocol.on_app_init()` to receive and return the `AppConfig` instance, as opposed to the application instance itself.

The `Starlite.__init__()` method is modified to call the `on_app_init()` method of all registered `InitPluginProtocol` plugins immediately after calling the `on_app_init` hooks.

This PR supersedes RFC PR #1381 which examined the effects of removing `InitPluginProtocol` in favor of `on_app_init` hooks. From discussion in that PR it was resolved that there is merit in having both `on_app_init` hooks and `InitPluginProtocol`, even if they essentially do the same thing, due to improved ergonomics of the application interface that this affords.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
