### PR TITLE
Refactor: dataclass utils

### DIFF
--- a/starlite/app.py
+++ b/starlite/app.py
@@ -46,7 +46,7 @@ from starlite.utils import (
     join_paths,
     unique,
 )
-from starlite.utils.dataclass import extract_dataclass_fields
+from starlite.utils.dataclass import extract_dataclass_items
 
 __all__ = ("HandlerIndex", "Starlite")
 
@@ -489,7 +489,7 @@ class Starlite(Router):
         Returns:
             An instance of ``Starlite`` application.
         """
-        return cls(**dict(extract_dataclass_fields(config)))
+        return cls(**dict(extract_dataclass_items(config)))
 
     def register(self, value: ControllerRouterHandler) -> None:  # type: ignore[override]
         """Register a route handler on the app.

--- a/starlite/middleware/session/client_side.py
+++ b/starlite/middleware/session/client_side.py
@@ -18,7 +18,7 @@ from starlite.exceptions import (
 )
 from starlite.serialization import decode_json, encode_json
 from starlite.types import Empty, Scopes
-from starlite.utils.dataclass import extract_dataclass_fields
+from starlite.utils.dataclass import extract_dataclass_items
 
 from .base import ONE_DAY_IN_SECONDS, BaseBackendConfig, BaseSessionBackend
 
@@ -111,8 +111,10 @@ class ClientSideSessionBackend(BaseSessionBackend["CookieBackendConfig"]):
         """Create a list of cookies containing the session data."""
         if cookie_params is None:
             cookie_params = dict(
-                extract_dataclass_fields(
-                    self.config, exclude_none=True, include=(f for f in Cookie.__dict__ if f not in ("key", "secret"))
+                extract_dataclass_items(
+                    self.config,
+                    exclude_none=True,
+                    include={f for f in Cookie.__dict__ if f not in ("key", "secret")},
                 )
             )
         return [
@@ -148,8 +150,10 @@ class ClientSideSessionBackend(BaseSessionBackend["CookieBackendConfig"]):
         if scope_session and scope_session is not Empty:
             data = self.dump_data(scope_session, scope=scope)
             cookie_params = dict(
-                extract_dataclass_fields(
-                    self.config, exclude_none=True, include=(f for f in Cookie.__dict__ if f not in ("key", "secret"))
+                extract_dataclass_items(
+                    self.config,
+                    exclude_none=True,
+                    include={f for f in Cookie.__dict__ if f not in ("key", "secret")},
                 )
             )
             for cookie in self._create_session_cookies(data, cookie_params):
@@ -164,10 +168,10 @@ class ClientSideSessionBackend(BaseSessionBackend["CookieBackendConfig"]):
 
         for cookie_key in cookies_to_clear:
             cookie_params = dict(
-                extract_dataclass_fields(
+                extract_dataclass_items(
                     self.config,
                     exclude_none=True,
-                    include=(f for f in Cookie.__dict__ if f not in ("key", "secret", "max_age")),
+                    include={f for f in Cookie.__dict__ if f not in ("key", "secret", "max_age")},
                 )
             )
             headers.add(

--- a/starlite/middleware/session/server_side.py
+++ b/starlite/middleware/session/server_side.py
@@ -9,7 +9,7 @@ from starlite.enums import ScopeType
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.middleware.session.base import ONE_DAY_IN_SECONDS, BaseBackendConfig, BaseSessionBackend
 from starlite.types import Empty, Message, Scopes, ScopeSession
-from starlite.utils.dataclass import extract_dataclass_fields
+from starlite.utils.dataclass import extract_dataclass_items
 
 __all__ = ("ServerSideSessionBackend", "ServerSideSessionConfig")
 
@@ -110,7 +110,7 @@ class ServerSideSessionBackend(BaseSessionBackend["ServerSideSessionConfig"]):
         if not session_id or session_id == "null":
             session_id = self.generate_session_id()
 
-        cookie_params = dict(extract_dataclass_fields(self.config, exclude_none=True, include=Cookie.__dict__))
+        cookie_params = dict(extract_dataclass_items(self.config, exclude_none=True, include=Cookie.__dict__.keys()))
 
         if scope_session is Empty:
             await self.delete(session_id, store=store)

--- a/starlite/utils/dataclass.py
+++ b/starlite/utils/dataclass.py
@@ -1,30 +1,104 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable, cast
+from dataclasses import Field, fields
+from typing import TYPE_CHECKING
 
-__all__ = ("extract_dataclass_fields",)
-
+from starlite.types import Empty
+from starlite.types.protocols import DataclassProtocol
 
 if TYPE_CHECKING:
-    from starlite.types import DataclassProtocol
+    from typing import AbstractSet, Any, Iterable
+
+__all__ = (
+    "extract_dataclass_fields",
+    "extract_dataclass_items",
+)
 
 
 def extract_dataclass_fields(
-    dt: Any, exclude_none: bool = False, include: Iterable[str] | None = None
-) -> tuple[tuple[str, Any], ...]:
-    """Extract dataclass fields. Unlike the 'asdict' method exports by the stlib, this function does not pickle values.
+    dt: DataclassProtocol,
+    exclude_none: bool = False,
+    exclude_empty: bool = False,
+    include: AbstractSet[str] | None = None,
+    exclude: AbstractSet[str] | None = None,
+) -> tuple[Field, ...]:
+    """Extract dataclass fields.
 
     Args:
         dt: A dataclass instance.
         exclude_none: Whether to exclude None values.
+        exclude_empty: Whether to exclude Empty values.
         include: An iterable of fields to include.
+        exclude: An iterable of fields to exclude.
+
+
+    Returns:
+        A tuple of dataclass fields.
+    """
+    include = include or set()
+    exclude = exclude or set()
+
+    if common := (include & exclude):
+        raise ValueError(f"Fields {common} are both included and excluded.")
+
+    dataclass_fields: Iterable[Field] = fields(dt)
+    if exclude_none:
+        dataclass_fields = (field for field in dataclass_fields if getattr(dt, field.name) is not None)
+    if exclude_empty:
+        dataclass_fields = (field for field in dataclass_fields if getattr(dt, field.name) is not Empty)
+    if include:
+        dataclass_fields = (field for field in dataclass_fields if field.name in include)
+    if exclude:
+        dataclass_fields = (field for field in dataclass_fields if field.name not in exclude)
+
+    return tuple(dataclass_fields)
+
+
+def extract_dataclass_items(
+    dt: DataclassProtocol,
+    exclude_none: bool = False,
+    exclude_empty: bool = False,
+    include: AbstractSet[str] | None = None,
+    exclude: AbstractSet[str] | None = None,
+) -> tuple[tuple[str, Any], ...]:
+    """Extract dataclass name, value pairs.
+
+    Unlike the 'asdict' method exports by the stlib, this function does not pickle values.
+
+    Args:
+        dt: A dataclass instance.
+        exclude_none: Whether to exclude None values.
+        exclude_empty: Whether to exclude Empty values.
+        include: An iterable of fields to include.
+        exclude: An iterable of fields to exclude.
 
     Returns:
         A tuple of key/value pairs.
     """
-    return tuple(
-        (field_name, getattr(dt, field_name))
-        for field_name in cast("DataclassProtocol", dt).__dataclass_fields__
-        if (not exclude_none or getattr(dt, field_name) is not None)
-        and ((include is not None and field_name in include) or include is None)
-    )
+    dataclass_fields = extract_dataclass_fields(dt, exclude_none, exclude_empty, include, exclude)
+    return tuple((field.name, getattr(dt, field.name)) for field in dataclass_fields)
+
+
+def simple_asdict(obj: DataclassProtocol, exclude_none: bool = False, exclude_empty: bool = False) -> dict[str, Any]:
+    """Convert a dataclass to a dictionary.
+
+    This method has important differences to the standard library version:
+    - it does not deepcopy values
+    - it does not recurse into collections
+
+    Args:
+        obj: A dataclass instance.
+        exclude_none: Whether to exclude None values.
+        exclude_empty: Whether to exclude Empty values.
+
+    Returns:
+        A dictionary of key/value pairs.
+    """
+    ret = {}
+    for field in extract_dataclass_fields(obj, exclude_none, exclude_empty):
+        value = getattr(obj, field.name)
+        if isinstance(value, DataclassProtocol):
+            ret[field.name] = simple_asdict(value, exclude_none, exclude_empty)
+        else:
+            ret[field.name] = getattr(obj, field.name)
+    return ret

--- a/tests/utils/test_dataclass.py
+++ b/tests/utils/test_dataclass.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from starlite.types import Empty, EmptyType
+from starlite.utils.dataclass import extract_dataclass_fields, extract_dataclass_items, simple_asdict
+
+
+def test_extract_dataclass_fields_exclude_none() -> None:
+    """Test extract_dataclass_fields with exclude_none."""
+
+    @dataclass
+    class Foo:
+        """A Foo model."""
+
+        bar: str | None = None
+
+    assert extract_dataclass_fields(Foo(), exclude_none=True) == ()
+
+
+def test_extract_dataclass_fields_exclude_empty() -> None:
+    """Test extract_dataclass_fields with exclude_empty."""
+
+    @dataclass
+    class Foo:
+        """A Foo model."""
+
+        bar: str | EmptyType = Empty
+
+    assert extract_dataclass_fields(Foo(), exclude_empty=True) == ()
+
+
+def test_extract_dataclass_fields_include() -> None:
+    """Test extract_dataclass_items with include."""
+
+    @dataclass
+    class Foo:
+        """A Foo model."""
+
+        bar: str = "bar"
+        baz: str = "baz"
+
+    fields = extract_dataclass_fields(Foo(), include={"bar"})
+    assert len(fields) == 1
+    assert fields[0].name == "bar"
+    assert fields[0].default == "bar"
+
+
+def test_extract_dataclass_fields_exclude() -> None:
+    """Test extract_dataclass_items with exclude."""
+
+    @dataclass
+    class Foo:
+        """A Foo model."""
+
+        bar: str = "bar"
+        baz: str = "baz"
+
+    fields = extract_dataclass_fields(Foo(), exclude={"bar"})
+    assert len(fields) == 1
+    assert fields[0].name == "baz"
+    assert fields[0].default == "baz"
+
+
+def test_extract_dataclass_fields_raises_for_common_include_exclude() -> None:
+    """Test extract_dataclass_items raises for common include and exclude."""
+
+    @dataclass
+    class Foo:
+        """A Foo model."""
+
+        bar: str = "bar"
+
+    with pytest.raises(ValueError):
+        extract_dataclass_fields(Foo(), include={"bar"}, exclude={"bar"})
+
+
+def test_extract_dataclass_items_returns_name_value_pairs() -> None:
+    """Test extract_dataclass_items returns name, value pairs."""
+
+    @dataclass
+    class Foo:
+        """A Foo model."""
+
+        bar: str = "bar"
+        baz: str = "baz"
+
+    assert extract_dataclass_items(Foo()) == (("bar", "bar"), ("baz", "baz"))
+
+
+def test_simple_asdict_returns_dict() -> None:
+    """Test simple_asdict returns a dict."""
+
+    @dataclass
+    class Foo:
+        """A Foo model."""
+
+        bar: str = "bar"
+        baz: str = "baz"
+
+    assert simple_asdict(Foo()) == {"bar": "bar", "baz": "baz"}
+
+
+def test_simple_asdict_recursive() -> None:
+    """Test simple_asdict recursive."""
+
+    @dataclass
+    class Foo:
+        """A Foo model."""
+
+        bar: str = "bar"
+        baz: str = "baz"
+
+    @dataclass
+    class Bar:
+        """A Bar model."""
+
+        foo: Foo
+
+    assert simple_asdict(Bar(foo=Foo())) == {"foo": {"bar": "bar", "baz": "baz"}}
+
+
+def test_simple_asdict_does_not_recurse_into_collections() -> None:
+    """Test simple_asdict does not recurse into collections."""
+
+    @dataclass
+    class Foo:
+        """A Foo model."""
+
+        bar: str = "bar"
+        baz: str = "baz"
+
+    @dataclass
+    class Bar:
+        """A Bar model."""
+
+        foo: list[Foo]
+
+    foo = Foo()
+
+    assert simple_asdict(Bar(foo=[foo])) == {"foo": [foo]}


### PR DESCRIPTION
Renames `extract_dataclass_fields` to `extract_dataclass_items`. I chose "items" as it returns name/value pairs like `dict.items()`.
Broadens the api to include `exclude_empty` and `exclude` params.

Adds `extract_dataclass_fields` which embellishes the standard lib `fields()` function with various filtering parameters.

Adds `simple_asdict()` as an alternative to the stdlib `asdict()` function. It does not deepcopy values and does not recurse into collections.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
