### PR TITLE
Fix generating schemas for models with annotated attributes.

### DIFF
--- a/tests/openapi/test_schema.py
+++ b/tests/openapi/test_schema.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Literal
+from typing import TYPE_CHECKING, Dict, Literal
 
 import pytest
 from pydantic import BaseModel
@@ -11,6 +11,9 @@ from starlite._openapi.schema_generation.schema import (
     _process_schema_result,
     create_schema,
     create_schema_for_annotation,
+    create_schema_for_dataclass,
+    create_schema_for_pydantic_model,
+    create_schema_for_typed_dict,
 )
 from starlite._signature.models import PydanticSignatureModel, SignatureField
 from starlite.app import DEFAULT_OPENAPI_CONFIG
@@ -23,6 +26,10 @@ from starlite.openapi.spec.schema import Schema
 from starlite.params import BodyKwarg, Parameter, ParameterKwarg
 from starlite.testing import create_test_client
 from tests import Person, Pet
+
+if TYPE_CHECKING:
+    from types import ModuleType
+    from typing import Callable
 
 
 def test_process_schema_result() -> None:
@@ -177,3 +184,63 @@ def test_title_validation() -> None:
             plugins=[],
             schemas=schemas,
         )
+
+
+@pytest.mark.parametrize("with_future_annotations", [True, False])
+def test_create_schema_for_pydantic_model_with_annotated_model_attribute(
+    with_future_annotations: bool, create_module: "Callable[[str], ModuleType]"
+) -> None:
+    """Test that a model with an annotated attribute is correctly handled."""
+    module = create_module(
+        f"""
+{'from __future__ import annotations' if with_future_annotations else ''}
+from typing_extensions import Annotated
+from pydantic import BaseModel
+
+class Foo(BaseModel):
+    foo: Annotated[int, "Foo description"]
+"""
+    )
+    schema = create_schema_for_pydantic_model(module.Foo, generate_examples=False, plugins=[], schemas={})
+    assert schema.properties and "foo" in schema.properties
+
+
+@pytest.mark.parametrize("with_future_annotations", [True, False])
+def test_create_schema_for_dataclass_with_annotated_model_attribute(
+    with_future_annotations: bool, create_module: "Callable[[str], ModuleType]"
+) -> None:
+    """Test that a model with an annotated attribute is correctly handled."""
+    module = create_module(
+        f"""
+{'from __future__ import annotations' if with_future_annotations else ''}
+from typing_extensions import Annotated
+from dataclasses import dataclass
+
+@dataclass
+class Foo:
+    foo: Annotated[int, "Foo description"]
+"""
+    )
+    schema = create_schema_for_dataclass(module.Foo, generate_examples=False, plugins=[], schemas={})
+    assert schema.properties and "foo" in schema.properties
+
+
+@pytest.mark.parametrize("with_future_annotations", [True, False])
+def test_create_schema_for_typedict_with_annotated_required_and_not_required_model_attributes(
+    with_future_annotations: bool, create_module: "Callable[[str], ModuleType]"
+) -> None:
+    """Test that a model with an annotated attribute is correctly handled."""
+    module = create_module(
+        f"""
+{'from __future__ import annotations' if with_future_annotations else ''}
+from typing_extensions import Annotated, Required, NotRequired
+from typing import TypedDict
+
+class Foo(TypedDict):
+    foo: Annotated[int, "Foo description"]
+    bar: Annotated[Required[int], "Bar description"]
+    baz: Annotated[NotRequired[int], "Baz description"]
+"""
+    )
+    schema = create_schema_for_typed_dict(module.Foo, generate_examples=False, plugins=[], schemas={})
+    assert schema.properties and all(key in schema.properties for key in ("foo", "bar", "baz"))


### PR DESCRIPTION
From inspecting annotations directly via `__annotations__` when generating parameters for model openapi fields, openapi schema generation would fail for those fields when the type was wrapped with `Annotated`, `Required` and `NotRequired`.

This PR uses `get_type_hints(obj, include_extras=False)` to access the object annotations, ensuring that the types we use to generate the openapi schemas have had those "wrapper" types removed first.

Closes #1372

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
