### PR TITLE
Fix inconsistent parsed parameter annotations.

### DIFF
--- a/starlite/_signature/utils.py
+++ b/starlite/_signature/utils.py
@@ -75,4 +75,4 @@ def get_fn_type_hints(fn: Any, namespace: dict[str, Any] | None = None) -> dict[
         **vars(sys.modules[fn_to_inspect.__module__]),
         **(namespace or {}),
     }
-    return get_type_hints(fn_to_inspect, globalns=namespace)
+    return get_type_hints(fn_to_inspect, globalns=namespace, include_extras=True)


### PR DESCRIPTION
Params with `Annotated` types in handler signatures are parsed inconsistently, depending on whether the annotation is stringized.

If the type annotation is a string, it is passed to `get_type_annotations()` which unwraps any `Annotated` types. If the annotation is not a string, it remains as-is, with `Annotated` in place.

This PR ensures that we parse `Annotated` types the same, irrespective of whether the user has `__future__.annotations` imported, or not, by setting `include_extras=True` on the call to `get_type_annotations()`.

We could consider explicitly unwrapping the annotated types and storing any metadata on the `ParsedSignatureParameter` in a future PR.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
