### PR TITLE
Better websockets

### DIFF
--- a/docs/examples/websockets/dependency_injection_simple.py
+++ b/docs/examples/websockets/dependency_injection_simple.py
@@ -1,5 +1,5 @@
-from starlite import Starlite, websocket_listener
-from starlite.di import Provide
+from litestar import Starlite, websocket_listener
+from litestar.di import Provide
 
 
 def some_dependency() -> str:

--- a/docs/examples/websockets/dependency_injection_simple.py
+++ b/docs/examples/websockets/dependency_injection_simple.py
@@ -1,0 +1,14 @@
+from starlite import Starlite, websocket_listener
+from starlite.di import Provide
+
+
+def some_dependency() -> str:
+    return "hello"
+
+
+@websocket_listener("/", dependencies={"some": Provide(some_dependency)})
+async def handler(data: str, some: str) -> str:
+    return data + some
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/dependency_injection_yield.py
+++ b/docs/examples/websockets/dependency_injection_yield.py
@@ -1,8 +1,8 @@
 from typing import TypedDict
 
-from starlite import Starlite, websocket_listener
-from starlite.datastructures import State
-from starlite.di import Provide
+from litestar import Starlite, websocket_listener
+from litestar.datastructures import State
+from litestar.di import Provide
 
 
 class Message(TypedDict):

--- a/docs/examples/websockets/dependency_injection_yield.py
+++ b/docs/examples/websockets/dependency_injection_yield.py
@@ -1,0 +1,27 @@
+from typing import TypedDict
+
+from starlite import Starlite, websocket_listener
+from starlite.datastructures import State
+from starlite.di import Provide
+
+
+class Message(TypedDict):
+    message: str
+    client_count: int
+
+
+def socket_client_count(state: State) -> int:
+    if not hasattr(state, "count"):
+        state.count = 0
+
+    state.count += 1
+    yield state.count
+    state.count -= 1
+
+
+@websocket_listener("/", dependencies={"client_count": Provide(socket_client_count)})
+async def handler(data: str, client_count: int) -> Message:
+    return Message(message=data, client_count=client_count)
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/listener_class_based.py
+++ b/docs/examples/websockets/listener_class_based.py
@@ -1,0 +1,18 @@
+from starlite import Starlite, WebSocket
+from starlite.handlers import WebsocketListener
+
+
+class Handler(WebsocketListener):
+    path = "/"
+
+    def on_accept(self, socket: WebSocket) -> None:
+        print("Connection accepted")
+
+    def on_disconnect(self, socket: WebSocket) -> None:
+        print("Connection closed")
+
+    def on_receive(self, data: str) -> str:
+        return data
+
+
+app = Starlite([Handler])

--- a/docs/examples/websockets/listener_class_based.py
+++ b/docs/examples/websockets/listener_class_based.py
@@ -1,5 +1,5 @@
-from starlite import Starlite, WebSocket
-from starlite.handlers import WebsocketListener
+from litestar import Starlite, WebSocket
+from litestar.handlers import WebsocketListener
 
 
 class Handler(WebsocketListener):

--- a/docs/examples/websockets/listener_class_based_async.py
+++ b/docs/examples/websockets/listener_class_based_async.py
@@ -1,0 +1,18 @@
+from starlite import Starlite, WebSocket
+from starlite.handlers import WebsocketListener
+
+
+class Handler(WebsocketListener):
+    path = "/"
+
+    async def on_accept(self, socket: WebSocket) -> None:
+        print("Connection accepted")
+
+    async def on_disconnect(self, socket: WebSocket) -> None:
+        print("Connection closed")
+
+    async def on_receive(self, data: str) -> str:
+        return data
+
+
+app = Starlite([Handler])

--- a/docs/examples/websockets/listener_class_based_async.py
+++ b/docs/examples/websockets/listener_class_based_async.py
@@ -1,5 +1,5 @@
-from starlite import Starlite, WebSocket
-from starlite.handlers import WebsocketListener
+from litestar import Starlite, WebSocket
+from litestar.handlers import WebsocketListener
 
 
 class Handler(WebsocketListener):

--- a/docs/examples/websockets/mode_receive_binary.py
+++ b/docs/examples/websockets/mode_receive_binary.py
@@ -1,4 +1,4 @@
-from starlite import Starlite, websocket_listener
+from litestar import Starlite, websocket_listener
 
 
 @websocket_listener("/", receive_mode="binary")

--- a/docs/examples/websockets/mode_receive_binary.py
+++ b/docs/examples/websockets/mode_receive_binary.py
@@ -1,0 +1,9 @@
+from starlite import Starlite, websocket_listener
+
+
+@websocket_listener("/", receive_mode="binary")
+async def handler(data: str) -> str:
+    return data
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/mode_receive_text.py
+++ b/docs/examples/websockets/mode_receive_text.py
@@ -1,0 +1,9 @@
+from starlite import Starlite, websocket_listener
+
+
+@websocket_listener("/", receive_mode="text")
+async def handler(data: str) -> str:
+    return data
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/mode_receive_text.py
+++ b/docs/examples/websockets/mode_receive_text.py
@@ -1,4 +1,4 @@
-from starlite import Starlite, websocket_listener
+from litestar import Starlite, websocket_listener
 
 
 @websocket_listener("/", receive_mode="text")

--- a/docs/examples/websockets/mode_send_binary.py
+++ b/docs/examples/websockets/mode_send_binary.py
@@ -1,4 +1,4 @@
-from starlite import Starlite, websocket_listener
+from litestar import Litestar, websocket_listener
 
 
 @websocket_listener("/", send_mode="binary")
@@ -6,4 +6,4 @@ async def handler(data: str) -> str:
     return data
 
 
-app = Starlite([handler])
+app = Litestar([handler])

--- a/docs/examples/websockets/mode_send_binary.py
+++ b/docs/examples/websockets/mode_send_binary.py
@@ -1,0 +1,9 @@
+from starlite import Starlite, websocket_listener
+
+
+@websocket_listener("/", send_mode="binary")
+async def handler(data: str) -> str:
+    return data
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/mode_send_text.py
+++ b/docs/examples/websockets/mode_send_text.py
@@ -1,0 +1,9 @@
+from starlite import Starlite, websocket_listener
+
+
+@websocket_listener("/", send_mode="text")
+async def handler(data: str) -> str:
+    return data
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/mode_send_text.py
+++ b/docs/examples/websockets/mode_send_text.py
@@ -1,4 +1,4 @@
-from starlite import Starlite, websocket_listener
+from litestar import Litestar, websocket_listener
 
 
 @websocket_listener("/", send_mode="text")
@@ -6,4 +6,4 @@ async def handler(data: str) -> str:
     return data
 
 
-app = Starlite([handler])
+app = Litestar([handler])

--- a/docs/examples/websockets/receive_bytes.py
+++ b/docs/examples/websockets/receive_bytes.py
@@ -1,4 +1,4 @@
-from starlite import Starlite, websocket_listener
+from litestar import Litestar, websocket_listener
 
 
 @websocket_listener("/")
@@ -6,4 +6,4 @@ async def handler(data: bytes) -> str:
     return data.decode("utf-8")
 
 
-app = Starlite([handler])
+app = Litestar([handler])

--- a/docs/examples/websockets/receive_bytes.py
+++ b/docs/examples/websockets/receive_bytes.py
@@ -1,0 +1,9 @@
+from starlite import Starlite, websocket_listener
+
+
+@websocket_listener("/")
+async def handler(data: bytes) -> str:
+    return data.decode("utf-8")
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/receive_json.py
+++ b/docs/examples/websockets/receive_json.py
@@ -1,0 +1,11 @@
+from typing import Dict
+
+from starlite import Starlite, websocket_listener
+
+
+@websocket_listener("/")
+async def handler(data: Dict[str, str]) -> Dict[str, str]:
+    return data
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/receive_json.py
+++ b/docs/examples/websockets/receive_json.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from starlite import Starlite, websocket_listener
+from litestar import Litestar, websocket_listener
 
 
 @websocket_listener("/")
@@ -8,4 +8,4 @@ async def handler(data: Dict[str, str]) -> Dict[str, str]:
     return data
 
 
-app = Starlite([handler])
+app = Litestar([handler])

--- a/docs/examples/websockets/receive_str.py
+++ b/docs/examples/websockets/receive_str.py
@@ -1,0 +1,9 @@
+from starlite import Starlite, websocket_listener
+
+
+@websocket_listener("/")
+async def handler(data: str) -> str:
+    return data
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/receive_str.py
+++ b/docs/examples/websockets/receive_str.py
@@ -1,4 +1,4 @@
-from starlite import Starlite, websocket_listener
+from litestar import Litestar, websocket_listener
 
 
 @websocket_listener("/")
@@ -6,4 +6,4 @@ async def handler(data: str) -> str:
     return data
 
 
-app = Starlite([handler])
+app = Litestar([handler])

--- a/docs/examples/websockets/sending_bytes.py
+++ b/docs/examples/websockets/sending_bytes.py
@@ -1,0 +1,9 @@
+from starlite import Starlite, websocket_listener
+
+
+@websocket_listener("/")
+async def handler(data: str) -> bytes:
+    return data.encode("utf-8")
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/sending_bytes.py
+++ b/docs/examples/websockets/sending_bytes.py
@@ -1,4 +1,4 @@
-from starlite import Starlite, websocket_listener
+from litestar import Litestar, websocket_listener
 
 
 @websocket_listener("/")
@@ -6,4 +6,4 @@ async def handler(data: str) -> bytes:
     return data.encode("utf-8")
 
 
-app = Starlite([handler])
+app = Litestar([handler])

--- a/docs/examples/websockets/sending_json_dataclass.py
+++ b/docs/examples/websockets/sending_json_dataclass.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from datetime import datetime
+
+from starlite import Starlite, websocket_listener
+
+
+@dataclass
+class Message:
+    message: str
+    timestamp: float
+
+
+@websocket_listener("/")
+async def handler(data: str) -> Message:
+    return Message(message=data, timestamp=datetime.now().timestamp())
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/sending_json_dataclass.py
+++ b/docs/examples/websockets/sending_json_dataclass.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from datetime import datetime
 
-from starlite import Starlite, websocket_listener
+from litestar import Litestar, websocket_listener
 
 
 @dataclass
@@ -15,4 +15,4 @@ async def handler(data: str) -> Message:
     return Message(message=data, timestamp=datetime.now().timestamp())
 
 
-app = Starlite([handler])
+app = Litestar([handler])

--- a/docs/examples/websockets/sending_json_dict.py
+++ b/docs/examples/websockets/sending_json_dict.py
@@ -1,0 +1,11 @@
+from typing import Dict
+
+from starlite import Starlite, websocket_listener
+
+
+@websocket_listener("/")
+async def handler(data: str) -> Dict[str, str]:
+    return {"message": data}
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/sending_json_dict.py
+++ b/docs/examples/websockets/sending_json_dict.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from starlite import Starlite, websocket_listener
+from litestar import Litestar, websocket_listener
 
 
 @websocket_listener("/")
@@ -8,4 +8,4 @@ async def handler(data: str) -> Dict[str, str]:
     return {"message": data}
 
 
-app = Starlite([handler])
+app = Litestar([handler])

--- a/docs/examples/websockets/sending_str.py
+++ b/docs/examples/websockets/sending_str.py
@@ -1,0 +1,9 @@
+from starlite import Starlite, websocket_listener
+
+
+@websocket_listener("/")
+async def handler(data: str) -> str:
+    return data
+
+
+app = Starlite([handler])

--- a/docs/examples/websockets/sending_str.py
+++ b/docs/examples/websockets/sending_str.py
@@ -1,4 +1,4 @@
-from starlite import Starlite, websocket_listener
+from litestar import Litestar, websocket_listener
 
 
 @websocket_listener("/")
@@ -6,4 +6,4 @@ async def handler(data: str) -> str:
     return data
 
 
-app = Starlite([handler])
+app = Litestar([handler])

--- a/docs/examples/websockets/socket_access.py
+++ b/docs/examples/websockets/socket_access.py
@@ -1,4 +1,4 @@
-from starlite import Starlite, WebSocket, websocket_listener
+from litestar import Litestar, WebSocket, websocket_listener
 
 
 @websocket_listener("/")
@@ -9,4 +9,4 @@ async def handler(data: str, socket: WebSocket) -> str:
     return data
 
 
-app = Starlite([handler])
+app = Litestar([handler])

--- a/docs/examples/websockets/socket_access.py
+++ b/docs/examples/websockets/socket_access.py
@@ -1,0 +1,12 @@
+from starlite import Starlite, WebSocket, websocket_listener
+
+
+@websocket_listener("/")
+async def handler(data: str, socket: WebSocket) -> str:
+    if data == "goodbye":
+        await socket.close()
+
+    return data
+
+
+app = Starlite([handler])

--- a/docs/usage/dependency-injection.rst
+++ b/docs/usage/dependency-injection.rst
@@ -80,6 +80,8 @@ The ``controller_dependency`` is available only for route handlers on that speci
 dependencies are available only to the route handlers registered on that particular router. Only the ``app_dependencies``
 are available to all route handlers.
 
+.. _yield_dependencies:
+
 Dependencies with yield (cleanup step)
 --------------------------------------
 

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -11,6 +11,7 @@ Usage
     request-data
     responses
     dependency-injection
+    websockets
     middleware/index
     security/index
     stores

--- a/docs/usage/route-handlers.rst
+++ b/docs/usage/route-handlers.rst
@@ -278,7 +278,13 @@ should not use the ``sync_to_thread`` option.
 Websocket route handlers
 ------------------------
 
-Litestar supports Websockets via the :func:`websocket <litestar.handlers.WebsocketRouteHandler>` decorator:
+A WebSocket connection can be handled with a :func:`websocket <litestar.handlers.WebsocketRouteHandler>` route handler.
+
+.. note::
+    The websocket handler is a low level approach, requiring to handle the socket directly,
+    and dealing with keeping it open, exceptions, client disconnects and content negotiation.
+
+    For a more high level approach to handling WebSockets, see :doc:`/usage/websockets`
 
 .. code-block:: python
 

--- a/docs/usage/websockets.rst
+++ b/docs/usage/websockets.rst
@@ -5,7 +5,7 @@ WebSockets
 Handling WebSocket in an application often involves dealing with low level constructs
 such as the socket itself, setting up a loop and listening for incoming data, handling
 exceptions and parsing incoming and serializing outgoing data. In addition to the
-low-level :class:`websocket route handler <.handlers.websocket>`, Starlite offers two
+low-level :class:`websocket route handler <.handlers.websocket>`, Litestar offers two
 high level interfaces:
 
 - :class:`websocket_listener <.handlers.websocket_listener>`
@@ -19,8 +19,8 @@ sent over the connection. The low level details will be handled behind the curta
 
 .. code-block:: python
 
-    from starlite import Starlite
-    from starlite.handlers.websocket_handlers import websocket_listener
+    from litestar import Litestar
+    from litestar.handlers.websocket_handlers import websocket_listener
 
 
     @websocket_listener("/")
@@ -28,7 +28,7 @@ sent over the connection. The low level details will be handled behind the curta
         return data
 
 
-    app = Starlite([handler])
+    app = Litestar([handler])
 
 
 This handler will accept connections on ``/``, and wait to receive data. Once a message
@@ -82,7 +82,7 @@ Sending data is done by simply returning the value to be sent from the handler f
 Similar to receiving data, type annotations configure how the data is being handled.
 Values are are not :class:`str` or :class:`bytes` are assumed to be JSON encodable and
 will be serialized accordingly before being sent. This serialization is available for
-all data types currently supported by Starlite (
+all data types currently supported by Litestar (
 :doc:`dataclasses <python:library/dataclasses>`\ es, :class:`TypedDict <typing.TypedDict>`,
 :class:`NamedTuple <typing.NamedTuple>`,  :class:`msgspec.Struct`, etc.).
 

--- a/docs/usage/websockets.rst
+++ b/docs/usage/websockets.rst
@@ -1,0 +1,240 @@
+WebSockets
+==========
+
+
+Handling WebSocket in an application often involves dealing with low level constructs
+such as the socket itself, setting up a loop and listening for incoming data, handling
+exceptions and parsing incoming and serializing outgoing data. In addition to the
+low-level :class:`websocket route handler <.handlers.websocket>`, Starlite offers two
+high level interfaces:
+
+- :class:`websocket_listener <.handlers.websocket_listener>`
+- :class:`WebSocketListener <.handlers.WebsocketListener>`
+
+
+These treat a WebSocket handler like any other route handler; As a callable that takes
+in incoming data in an already pre-processed form and returns data to be serialized and
+sent over the connection. The low level details will be handled behind the curtains.
+
+
+.. code-block:: python
+
+    from starlite import Starlite
+    from starlite.handlers.websocket_handlers import websocket_listener
+
+
+    @websocket_listener("/")
+    async def handler(data: str) -> str:
+        return data
+
+
+    app = Starlite([handler])
+
+
+This handler will accept connections on ``/``, and wait to receive data. Once a message
+has been received, it will be passed into the handler function defined, via the ``data``
+parameter. This works like a regular route handler, so it's possible to specify the
+type of data which should be received, and it will be converted accordingly.
+
+.. note::
+    Contrary to websocket route handlers, function decorated with
+    :class:`websocket_listener <.handlers.websocket_listener>` don't have to be
+    asynchronous.
+
+
+
+Receiving data
+--------------
+
+Data can be received in listener via the ``data`` parameter. The data passed to this
+will be converted / parsed according to the given type annotation and supports
+:class:`str`, :class:`bytes` or arbitrary :class:`dict`\ s / or :class:`list`\ s in the
+form of JSON.
+
+.. tab-set::
+
+    .. tab-item:: JSON
+
+        .. literalinclude:: /examples/websockets/receive_json.py
+            :language: python
+
+
+    .. tab-item:: Text
+
+        .. literalinclude:: /examples/websockets/receive_str.py
+
+
+    .. tab-item:: Bytes
+
+        .. literalinclude:: /examples/websockets/receive_bytes.py
+
+
+.. important::
+
+    Contrary to route handlers, JSON data will only be parsed but not validated. This
+    is a currently limitation of the implementation and will change in future versions.
+
+
+Sending data
+------------
+
+Sending data is done by simply returning the value to be sent from the handler function.
+Similar to receiving data, type annotations configure how the data is being handled.
+Values are are not :class:`str` or :class:`bytes` are assumed to be JSON encodable and
+will be serialized accordingly before being sent. This serialization is available for
+all data types currently supported by Starlite (
+:doc:`dataclasses <python:library/dataclasses>`\ es, :class:`TypedDict <typing.TypedDict>`,
+:class:`NamedTuple <typing.NamedTuple>`,  :class:`msgspec.Struct`, etc.).
+
+
+.. tab-set::
+
+    .. tab-item:: Text
+
+        .. literalinclude:: /examples/websockets/sending_str.py
+            :language: python
+
+    .. tab-item:: Bytes
+
+        .. literalinclude:: /examples/websockets/sending_bytes.py
+            :language: python
+
+    .. tab-item:: Dict as JSON
+
+        .. literalinclude:: /examples/websockets/sending_json_dict.py
+            :language: python
+
+
+    .. tab-item:: Dataclass as JSON
+
+        .. literalinclude:: /examples/websockets/sending_json_dataclass.py
+            :language: python
+
+
+Transport modes
+---------------
+
+WebSockets have two transport modes: Text and binary. These can be specified
+individually for receiving and sending data.
+
+.. note::
+    It may seem intuitive that ``text`` and ``binary`` should map to :class:`str` and
+    :class:`bytes` respectively, but this is not the case. Listeners can receive and
+    send data in any format, independently of the mode. The mode only affects how
+    data is encoded during transport (i.e. on the protocol level). In most cases the
+    default mode - ``text`` - is all that's needed. Binary transport is usually employed
+    when sending binary blobs that don't have a meaningful string representation, such
+    as images.
+
+
+
+Setting the receive mode
+++++++++++++++++++++++++
+
+.. tab-set::
+
+    .. tab-item:: Text mode
+
+        ``text`` is the default mode and is appropriate for most messages, including
+        structured data such as JSON.
+
+        .. literalinclude:: /examples/websockets/mode_receive_text.py
+            :language: python
+
+
+    .. tab-item:: Binary mode
+
+        .. literalinclude:: /examples/websockets/mode_receive_binary.py
+            :language: python
+
+
+.. important::
+    Once configured with a mode, a listener will only listen to socket events of the
+    appropriate type. This means if a listener is configured to use ``binary`` mode,
+    it will not respond to websocket events sending data in the text channel
+
+
+Setting the send mode
+++++++++++++++++++++++
+
+.. tab-set::
+
+    .. tab-item:: Text mode
+
+        ``text`` is the default mode and is appropriate for most messages, including
+        structured data such as JSON.
+
+        .. literalinclude:: /examples/websockets/mode_send_text.py
+            :language: python
+
+
+    .. tab-item:: Binary mode
+
+        .. literalinclude:: /examples/websockets/mode_send_binary.py
+            :language: python
+
+
+
+
+Dependency injection
+--------------------
+
+:doc:`dependency-injection` is available as well and generally works the same as with
+regular route handlers:
+
+.. literalinclude:: /examples/websockets/dependency_injection_simple.py
+    :language: python
+
+
+.. important::
+    Injected dependencies work on the level of the underlying **route handler**. This
+    means they won't be re-evaluated every time the listener function is called.
+
+The following example makes use of :ref:`yield dependencies <yield_dependencies>` and
+the fact that dependencies are only evaluated once for every connection; The step after
+the ``yield`` will only be executed after the connection has been closed.
+
+
+.. literalinclude:: /examples/websockets/dependency_injection_yield.py
+    :language: python
+
+
+
+Interacting with the WebSocket directly
+---------------------------------------
+
+Sometimes access to the socket instance is needed, in which case the
+:class:`WebSocket <.connection.WebSocket>` instance can be injected into the handler
+function via the ``socket`` argument:
+
+.. literalinclude:: /examples/websockets/socket_access.py
+    :language: python
+
+
+.. important::
+    Since websockets are inherently asynchronous, to interact with the asynchronous
+    methods on :class:`WebSocket <.connection.WebSocket>`, the handler function needs
+    to be asynchronous.
+
+
+Class based WebSocket handling
+------------------------------
+
+In addition to using a simple function as in the examples above, a class based approach
+is made possible by extending the
+:class:`WebSocketListener <.handlers.WebsocketListener>`. This provides
+convenient access to socket events such as connect and disconnect, and can be used to
+encapsulate more complex logic.
+
+
+.. tab-set::
+
+    .. tab-item:: Sync
+
+        .. literalinclude:: /examples/websockets/listener_class_based.py
+            :language: python
+
+    .. tab-item:: Async
+
+        .. literalinclude:: /examples/websockets/listener_class_based_async.py
+            :language: python

--- a/litestar/__init__.py
+++ b/litestar/__init__.py
@@ -2,17 +2,7 @@ from litestar.app import Litestar
 from litestar.connection import Request, WebSocket
 from litestar.controller import Controller
 from litestar.enums import HttpMethod, MediaType
-from litestar.handlers import (
-    asgi,
-    delete,
-    get,
-    head,
-    patch,
-    post,
-    put,
-    route,
-    websocket,
-)
+from litestar.handlers import asgi, delete, get, head, patch, post, put, route, websocket, websocket_listener
 from litestar.response import Response
 from litestar.router import Router
 from litestar.utils.version import get_version
@@ -38,5 +28,6 @@ __all__ = (
     "put",
     "route",
     "websocket",
+    "websocket_listener",
     "__version__",
 )

--- a/litestar/handlers/__init__.py
+++ b/litestar/handlers/__init__.py
@@ -1,7 +1,7 @@
 from .asgi_handlers import ASGIRouteHandler, asgi
 from .base import BaseRouteHandler
 from .http_handlers import HTTPRouteHandler, delete, get, head, patch, post, put, route
-from .websocket_handlers import WebsocketRouteHandler, websocket
+from .websocket_handlers import WebsocketListener, WebsocketRouteHandler, websocket, websocket_listener
 
 __all__ = (
     "asgi",
@@ -16,5 +16,7 @@ __all__ = (
     "put",
     "route",
     "websocket",
+    "websocket_listener",
+    "WebsocketListener",
     "WebsocketRouteHandler",
 )

--- a/litestar/handlers/websocket_handlers.py
+++ b/litestar/handlers/websocket_handlers.py
@@ -181,6 +181,8 @@ class websocket_listener(WebsocketRouteHandler):
 
     def _validate_handler_function(self) -> None:
         """Validate the route handler function once it's set by inspecting its return annotations."""
+        # since none of the validation rules of WebsocketRouteHandler apply here, this is let empty. Validation of the
+        # user supplied method happens at init time of this handler instead in __call__
 
     def _create_listener_fn(  # noqa: C901
         self,

--- a/litestar/handlers/websocket_handlers.py
+++ b/litestar/handlers/websocket_handlers.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import inspect
+from abc import ABC, abstractmethod
 from inspect import Signature
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Callable, Literal
 
 from litestar.exceptions import ImproperlyConfiguredException, WebSocketDisconnect
 from litestar.handlers.base import BaseRouteHandler
@@ -10,7 +11,7 @@ from litestar.types.builtin_types import NoneType
 from litestar.types.empty import Empty
 from litestar.utils import AsyncCallable, Ref, is_async_callable
 
-__all__ = ("WebsocketRouteHandler", "websocket", "websocket_listener")
+__all__ = ("WebsocketRouteHandler", "websocket", "websocket_listener", "WebsocketListener")
 
 if TYPE_CHECKING:
     from typing import Any, Mapping
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
         Guard,
         MaybePartial,  # noqa: F401
         Middleware,
+        SyncOrAsyncUnion,
     )
 
 __all__ = ("WebsocketRouteHandler", "websocket")
@@ -125,10 +127,15 @@ class websocket_listener(WebsocketRouteHandler):
         opt: dict[str, Any] | None = None,
         signature_namespace: Mapping[str, Any] | None = None,
         mode: Literal["text", "binary"] = "text",
+        on_accept: Callable[[WebSocket], SyncOrAsyncUnion[None]] | None = None,
+        on_disconnect: Callable[[WebSocket], SyncOrAsyncUnion[None]] | None = None,
         **kwargs: Any,
     ) -> None:
         self.mode = mode
         self._pass_socket = False
+        self._on_accept = AsyncCallable(on_accept) if on_accept else None
+        self._on_disconnect = AsyncCallable(on_disconnect) if on_disconnect else None
+
         super().__init__(
             path=path,
             dependencies=dependencies,
@@ -151,6 +158,8 @@ class websocket_listener(WebsocketRouteHandler):
 
         async def listener_fn(socket: WebSocket, **kwargs: Any) -> None:
             await socket.accept()
+            if self._on_accept:
+                await self._on_accept(socket)
             if self._pass_socket:
                 kwargs["socket"] = socket
             while True:
@@ -158,6 +167,8 @@ class websocket_listener(WebsocketRouteHandler):
                     data = await socket.receive_data(mode=self.mode)  # pyright: ignore
                     await listener_callback(data=data, **kwargs)
                 except WebSocketDisconnect:
+                    if self._on_disconnect:
+                        await self._on_disconnect(socket)
                     break
 
         # make our listener_fn look like the callback, so we get a correct signature model
@@ -187,3 +198,40 @@ class websocket_listener(WebsocketRouteHandler):
         for param in ("request", "body"):
             if param in signature.parameters:
                 raise ImproperlyConfiguredException(f"The {param} kwarg is not supported with websocket listeners")
+
+
+class WebsocketListener(ABC):
+    path: str | None | list[str] | None = None
+    dependencies: Dependencies | None = None
+    exception_handlers: dict[int | type[Exception], ExceptionHandler] | None = None
+    guards: list[Guard] | None = None
+    middleware: list[Middleware] | None = None
+    name: str | None = None
+    opt: dict[str, Any] | None = None
+    signature_namespace: Mapping[str, Any] | None = None
+    mode: Literal["text", "binary"] = "text"
+
+    def __init__(self) -> None:
+        self._handler = websocket_listener(
+            path=self.path,
+            dependencies=self.dependencies,
+            exception_handlers=self.exception_handlers,
+            guards=self.guards,
+            middleware=self.middleware,
+            name=self.name,
+            opt=self.opt,
+            signature_namespace=self.signature_namespace,
+            mode=self.mode,
+            on_accept=self.on_accept,
+            on_disconnect=self.on_disconnect,
+        )(self.on_receive)
+
+    def on_accept(self, socket: WebSocket) -> SyncOrAsyncUnion[None]:  # noqa: B027
+        pass
+
+    @abstractmethod
+    def on_receive(self, *args: Any, **kwargs: Any) -> SyncOrAsyncUnion[None]:
+        raise NotImplementedError
+
+    def on_disconnect(self, socket: WebSocket) -> SyncOrAsyncUnion[None]:  # noqa: B027
+        pass

--- a/litestar/handlers/websocket_handlers.py
+++ b/litestar/handlers/websocket_handlers.py
@@ -1,18 +1,25 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import inspect
+from inspect import Signature
+from typing import TYPE_CHECKING, Literal
 
-from litestar.exceptions import ImproperlyConfiguredException
+from litestar.exceptions import ImproperlyConfiguredException, WebSocketDisconnect
 from litestar.handlers.base import BaseRouteHandler
 from litestar.types.builtin_types import NoneType
 from litestar.types.empty import Empty
-from litestar.utils import is_async_callable
+from litestar.utils import AsyncCallable, Ref, is_async_callable
+
+__all__ = ("WebsocketRouteHandler", "websocket", "websocket_listener")
 
 if TYPE_CHECKING:
     from typing import Any, Mapping
 
     from litestar.dto.interface import DTOInterface
+    from litestar.connection import WebSocket
     from litestar.types import (
+        AnyCallable,
+        AsyncAnyCallable,
         Dependencies,
         EmptyType,
         ExceptionHandler,
@@ -99,3 +106,84 @@ class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):
 
 
 websocket = WebsocketRouteHandler
+
+
+class websocket_listener(WebsocketRouteHandler):
+    """A websocket listener that automatically accepts a connection, handles disconnects,
+    and invokes a callback function every time new data is received.
+    """
+
+    def __init__(
+        self,
+        path: str | None | list[str] | None = None,
+        *,
+        dependencies: Dependencies | None = None,
+        exception_handlers: dict[int | type[Exception], ExceptionHandler] | None = None,
+        guards: list[Guard] | None = None,
+        middleware: list[Middleware] | None = None,
+        name: str | None = None,
+        opt: dict[str, Any] | None = None,
+        signature_namespace: Mapping[str, Any] | None = None,
+        mode: Literal["text", "binary"] = "text",
+        **kwargs: Any,
+    ) -> None:
+        self.mode = mode
+        self._pass_socket = False
+        super().__init__(
+            path=path,
+            dependencies=dependencies,
+            exception_handlers=exception_handlers,
+            guards=guards,
+            middleware=middleware,
+            name=name,
+            opt=opt,
+            signature_namespace=signature_namespace,
+            **kwargs,
+        )
+
+    def __call__(self, listener_callback: AnyCallable) -> websocket_listener:
+        self._validate_listener_callback(listener_callback)
+
+        listener_callback_signature = inspect.signature(listener_callback)
+
+        if not is_async_callable(listener_callback):
+            listener_callback = AsyncCallable(listener_callback)
+
+        async def listener_fn(socket: WebSocket, **kwargs: Any) -> None:
+            await socket.accept()
+            if self._pass_socket:
+                kwargs["socket"] = socket
+            while True:
+                try:
+                    data = await socket.receive_data(mode=self.mode)  # pyright: ignore
+                    await listener_callback(data=data, **kwargs)
+                except WebSocketDisconnect:
+                    break
+
+        # make our listener_fn look like the callback, so we get a correct signature model
+        new_params = [p for p in listener_callback_signature.parameters.values() if p.name not in {"data"}]
+        if "socket" not in listener_callback_signature.parameters:
+            new_params.append(
+                inspect.Parameter(name="socket", kind=inspect.Parameter.KEYWORD_ONLY, annotation="WebSocket")
+            )
+        else:
+            self._pass_socket = True
+
+        listener_fn.__signature__ = listener_callback_signature.replace(parameters=new_params)  # type: ignore[attr-defined]
+
+        self.fn = Ref(listener_fn)
+        self.signature = Signature.from_callable(listener_fn)
+        return self
+
+    @staticmethod
+    def _validate_listener_callback(fn: AnyCallable) -> None:
+        """Validate the route handler function once it's set by inspecting its return annotations."""
+        signature = inspect.signature(fn)
+
+        if signature.return_annotation not in {None, "None"}:
+            raise ImproperlyConfiguredException("Websocket listeners should return 'None'")
+        if "data" not in signature.parameters:
+            raise ImproperlyConfiguredException("Websocket listeners must accept a 'data' parameter")
+        for param in ("request", "body"):
+            if param in signature.parameters:
+                raise ImproperlyConfiguredException(f"The {param} kwarg is not supported with websocket listeners")

--- a/litestar/handlers/websocket_handlers.py
+++ b/litestar/handlers/websocket_handlers.py
@@ -20,6 +20,8 @@ __all__ = ("WebsocketRouteHandler", "websocket", "websocket_listener", "Websocke
 if TYPE_CHECKING:
     from typing import Any, Mapping
 
+    from litestar.types.asgi_types import WebSocketMode
+
     from litestar.connection import WebSocket
     from litestar.dto.interface import DTOInterface
     from litestar.types import (
@@ -33,7 +35,6 @@ if TYPE_CHECKING:
         SyncOrAsyncUnion,
         TypeEncodersMap,
     )
-    from starlite.types.asgi_types import WebSocketMode
 
 
 class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):

--- a/litestar/router.py
+++ b/litestar/router.py
@@ -9,7 +9,7 @@ from litestar.controller import Controller
 from litestar.exceptions import ImproperlyConfiguredException
 from litestar.handlers.asgi_handlers import ASGIRouteHandler
 from litestar.handlers.http_handlers import HTTPRouteHandler
-from litestar.handlers.websocket_handlers import WebsocketRouteHandler
+from litestar.handlers.websocket_handlers import WebsocketListener, WebsocketRouteHandler
 from litestar.routes import ASGIRoute, HTTPRoute, WebSocketRoute
 from litestar.types.empty import Empty
 from litestar.utils import find_index, is_class_and_subclass, join_paths, normalize_path, unique
@@ -288,6 +288,10 @@ class Router:
         """Ensure values passed to the register method are supported."""
         if is_class_and_subclass(value, Controller):
             return value(owner=self)
+
+        # this narrows down to an ABC, but we assume a non-abstract subclass of the ABC superclass
+        if is_class_and_subclass(value, WebsocketListener):  # type: ignore[type-abstract]
+            return value()._handler  # pyright: ignore
 
         if isinstance(value, Router):
             if value.owner:

--- a/litestar/types/asgi_types.py
+++ b/litestar/types/asgi_types.py
@@ -84,6 +84,7 @@ __all__ = (
     "WebSocketCloseEvent",
     "WebSocketConnectEvent",
     "WebSocketDisconnectEvent",
+    "WebSocketMode",
     "WebSocketReceiveEvent",
     "WebSocketReceiveMessage",
     "WebSocketResponseBodyEvent",
@@ -338,3 +339,4 @@ Send = Callable[[Message], Awaitable[None]]
 ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
 RawHeaders = Iterable[Tuple[bytes, bytes]]
 RawHeadersList = List[Tuple[bytes, bytes]]
+WebSocketMode = Literal["text", "binary"]

--- a/litestar/types/parsed_signature.py
+++ b/litestar/types/parsed_signature.py
@@ -203,11 +203,7 @@ class ParsedSignature:
     The only post-processing that occurs is the conversion of any forward referenced type annotations.
     """
 
-    __slots__ = (
-        "parameters",
-        "return_type",
-        "original_signature"
-    )
+    __slots__ = ("parameters", "return_type", "original_signature")
 
     parameters: dict[str, ParsedParameter]
     """A mapping of parameter names to ParsedSignatureParameter instances."""
@@ -238,5 +234,5 @@ class ParsedSignature:
         return ParsedSignature(
             parameters={p.name: p for p in parameters},
             return_type=ParsedType.from_annotation(fn_type_hints.get("return", Empty)),
-            original_signature=signature
+            original_signature=signature,
         )

--- a/litestar/types/parsed_signature.py
+++ b/litestar/types/parsed_signature.py
@@ -206,12 +206,15 @@ class ParsedSignature:
     __slots__ = (
         "parameters",
         "return_type",
+        "original_signature"
     )
 
     parameters: dict[str, ParsedParameter]
     """A mapping of parameter names to ParsedSignatureParameter instances."""
     return_type: ParsedType
     """The return annotation of the callable."""
+    original_signature: Signature
+    """The raw signature as returned by :func:`inspect.signature`"""
 
     @classmethod
     def from_fn(cls, fn: AnyCallable, signature_namespace: dict[str, Any]) -> ParsedSignature:
@@ -235,4 +238,5 @@ class ParsedSignature:
         return ParsedSignature(
             parameters={p.name: p for p in parameters},
             return_type=ParsedType.from_annotation(fn_type_hints.get("return", Empty)),
+            original_signature=signature
         )

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -1,0 +1,108 @@
+from typing import Type
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_lazyfixture import lazy_fixture
+
+from starlite.handlers.websocket_handlers import WebsocketListener, websocket_listener
+from starlite.testing import create_test_client
+
+
+@pytest.fixture
+def mock() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture
+def listener_class(mock: MagicMock) -> Type[WebsocketListener]:
+    class Listener(WebsocketListener):
+        def on_receive(self, data: str) -> str:
+            mock(data)
+            return data
+
+    return Listener
+
+
+@pytest.fixture
+def sync_listener_callable(mock: MagicMock) -> websocket_listener:
+    def listener(data: str) -> str:
+        mock(data)
+        return data
+
+    return websocket_listener("/")(listener)
+
+
+@pytest.fixture
+def async_listener_callable(mock: MagicMock) -> websocket_listener:
+    async def listener(data: str) -> str:
+        mock(data)
+        return data
+
+    return websocket_listener("/")(listener)
+
+
+@pytest.mark.parametrize(
+    "listener",
+    [
+        lazy_fixture("sync_listener_callable"),
+        lazy_fixture("async_listener_callable"),
+        lazy_fixture("listener_class"),
+    ],
+)
+def test_basic_listener(mock: MagicMock, listener: websocket_listener | Type[WebsocketListener]) -> None:
+    client = create_test_client([listener])
+    with client.websocket_connect("/") as ws:
+        ws.send_text("foo")
+        assert ws.receive_text() == "foo"
+        ws.send_text("bar")
+        assert ws.receive_text() == "bar"
+
+    assert mock.call_count == 2
+    mock.assert_any_call("foo")
+    mock.assert_any_call("bar")
+
+
+def test_listener_receive_bytes(mock: MagicMock) -> None:
+    @websocket_listener("/", mode="binary")
+    def handler(data: bytes) -> None:
+        mock(data)
+
+    client = create_test_client([handler])
+    with client.websocket_connect("/") as ws:
+        ws.send_bytes(b"foo")
+
+    mock.assert_called_once_with(b"foo")
+
+
+def test_listener_receive_json(mock: MagicMock) -> None:
+    @websocket_listener("/")
+    def handler(data: list[str]) -> None:
+        mock(data)
+
+    client = create_test_client([handler])
+    with client.websocket_connect("/") as ws:
+        ws.send_json(["foo", "bar"])
+
+    mock.assert_called_once_with(["foo", "bar"])
+
+
+def test_listener_send_bytes() -> None:
+    @websocket_listener("/")
+    def handler(data: str) -> bytes:
+        return data.encode("utf-8")
+
+    client = create_test_client([handler])
+    with client.websocket_connect("/") as ws:
+        ws.send_text("foo")
+        assert ws.receive_bytes() == b"foo"
+
+
+def test_listener_send_json() -> None:
+    @websocket_listener("/")
+    def handler(data: str) -> dict[str, str]:
+        return {"data": data}
+
+    client = create_test_client([handler])
+    with client.websocket_connect("/") as ws:
+        ws.send_text("foo")
+        assert ws.receive_json() == {"data": "foo"}

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -1,4 +1,5 @@
-from typing import Type
+from __future__ import annotations
+
 from unittest.mock import MagicMock
 
 import pytest
@@ -14,7 +15,7 @@ def mock() -> MagicMock:
 
 
 @pytest.fixture
-def listener_class(mock: MagicMock) -> Type[WebsocketListener]:
+def listener_class(mock: MagicMock) -> type[WebsocketListener]:
     class Listener(WebsocketListener):
         def on_receive(self, data: str) -> str:
             mock(data)
@@ -49,7 +50,7 @@ def async_listener_callable(mock: MagicMock) -> websocket_listener:
         lazy_fixture("listener_class"),
     ],
 )
-def test_basic_listener(mock: MagicMock, listener: websocket_listener | Type[WebsocketListener]) -> None:
+def test_basic_listener(mock: MagicMock, listener: websocket_listener | type[WebsocketListener]) -> None:
     client = create_test_client([listener])
     with client.websocket_connect("/") as ws:
         ws.send_text("foo")

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -131,7 +132,7 @@ def test_listener_pass_additional_dependencies(mock: MagicMock) -> None:
         if not hasattr(state, "foo"):
             state.foo = 0
         state.foo += 1
-        return state.foo
+        return cast("int", state.foo)
 
     @websocket_listener("/", dependencies={"foo": Provide(foo_dependency)})
     def handler(data: str, foo: int) -> dict[str, str | int]:

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -4,13 +4,13 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_lazyfixture import lazy_fixture
 
-from starlite import Request, WebSocket
-from starlite.datastructures import State
-from starlite.di import Provide
-from starlite.exceptions import ImproperlyConfiguredException
-from starlite.handlers.websocket_handlers import WebsocketListener, websocket_listener
-from starlite.testing import create_test_client
-from starlite.types.asgi_types import WebSocketMode
+from litestar import Request, WebSocket
+from litestar.datastructures import State
+from litestar.di import Provide
+from litestar.exceptions import ImproperlyConfiguredException
+from litestar.handlers.websocket_handlers import WebsocketListener, websocket_listener
+from litestar.testing import create_test_client
+from litestar.types.asgi_types import WebSocketMode
 
 
 @pytest.fixture

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -4,9 +4,10 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_lazyfixture import lazy_fixture
 
-from starlite import WebSocket
+from starlite import Request, WebSocket
 from starlite.datastructures import State
 from starlite.di import Provide
+from starlite.exceptions import ImproperlyConfiguredException
 from starlite.handlers.websocket_handlers import WebsocketListener, websocket_listener
 from starlite.testing import create_test_client
 from starlite.types.asgi_types import WebSocketMode
@@ -186,3 +187,25 @@ def test_listener_pass_additional_dependencies(mock: MagicMock) -> None:
         ws.send_text("something")
         ws.send_text("something")
         assert ws.receive_json() == {"data": "something", "foo": 1}
+
+
+def test_listener_callback_no_data_arg_raises() -> None:
+    with pytest.raises(ImproperlyConfiguredException):
+
+        @websocket_listener("/")
+        def handler() -> None:
+            ...
+
+
+def test_listener_callback_request_and_body_arg_raises() -> None:
+    with pytest.raises(ImproperlyConfiguredException):
+
+        @websocket_listener("/")
+        def handler_request(data: str, request: Request) -> None:
+            ...
+
+    with pytest.raises(ImproperlyConfiguredException):
+
+        @websocket_listener("/")
+        def handler_body(data: str, body: bytes) -> None:
+            ...

--- a/tests/handlers/websocket/test_listeners.py
+++ b/tests/handlers/websocket/test_listeners.py
@@ -11,6 +11,7 @@ from starlite.datastructures import State
 from starlite.di import Provide
 from starlite.handlers.websocket_handlers import WebsocketListener, websocket_listener
 from starlite.testing import create_test_client
+from starlite.types.asgi_types import WebSocketMode
 
 
 @pytest.fixture
@@ -67,50 +68,94 @@ def test_basic_listener(mock: MagicMock, listener: websocket_listener | type[Web
     mock.assert_any_call("bar")
 
 
-def test_listener_receive_bytes(mock: MagicMock) -> None:
-    @websocket_listener("/", mode="binary")
+@pytest.mark.parametrize("receive_mode", ["text", "binary"])
+def test_listener_receive_bytes(receive_mode: WebSocketMode, mock: MagicMock) -> None:
+    @websocket_listener("/", receive_mode=receive_mode)
     def handler(data: bytes) -> None:
         mock(data)
 
     client = create_test_client([handler])
     with client.websocket_connect("/") as ws:
-        ws.send_bytes(b"foo")
+        ws.send("foo", mode=receive_mode)
 
     mock.assert_called_once_with(b"foo")
 
 
-def test_listener_receive_json(mock: MagicMock) -> None:
-    @websocket_listener("/")
+@pytest.mark.parametrize("receive_mode", ["text", "binary"])
+def test_listener_receive_string(receive_mode: WebSocketMode, mock: MagicMock) -> None:
+    @websocket_listener("/", receive_mode=receive_mode)
+    def handler(data: str) -> None:
+        mock(data)
+
+    client = create_test_client([handler])
+    with client.websocket_connect("/") as ws:
+        ws.send("foo", mode=receive_mode)
+
+    mock.assert_called_once_with("foo")
+
+
+@pytest.mark.parametrize("receive_mode", ["text", "binary"])
+def test_listener_receive_json(receive_mode: WebSocketMode, mock: MagicMock) -> None:
+    @websocket_listener("/", receive_mode=receive_mode)
     def handler(data: list[str]) -> None:
         mock(data)
 
     client = create_test_client([handler])
     with client.websocket_connect("/") as ws:
-        ws.send_json(["foo", "bar"])
+        ws.send_json(["foo", "bar"], mode=receive_mode)
 
     mock.assert_called_once_with(["foo", "bar"])
 
 
-def test_listener_send_bytes() -> None:
-    @websocket_listener("/")
+@pytest.mark.parametrize("send_mode", ["text", "binary"])
+def test_listener_return_bytes(send_mode: WebSocketMode) -> None:
+    @websocket_listener("/", send_mode=send_mode)
     def handler(data: str) -> bytes:
         return data.encode("utf-8")
 
     client = create_test_client([handler])
     with client.websocket_connect("/") as ws:
         ws.send_text("foo")
-        assert ws.receive_bytes() == b"foo"
+        if send_mode == "text":
+            assert ws.receive_text() == "foo"
+        else:
+            assert ws.receive_bytes() == b"foo"
 
 
-def test_listener_send_json() -> None:
-    @websocket_listener("/")
+@pytest.mark.parametrize("send_mode", ["text", "binary"])
+def test_listener_send_json(send_mode: WebSocketMode) -> None:
+    @websocket_listener("/", send_mode=send_mode)
     def handler(data: str) -> dict[str, str]:
         return {"data": data}
 
     client = create_test_client([handler])
     with client.websocket_connect("/") as ws:
         ws.send_text("foo")
-        assert ws.receive_json() == {"data": "foo"}
+        assert ws.receive_json(mode=send_mode) == {"data": "foo"}
+
+
+def test_listener_return_none() -> None:
+    @websocket_listener("/")
+    def handler(data: str) -> None:
+        return data  # type: ignore[return-value]
+
+    client = create_test_client([handler])
+    with client.websocket_connect("/") as ws:
+        ws.send_text("foo")
+
+
+def test_listener_return_optional_none() -> None:
+    @websocket_listener("/")
+    def handler(data: str) -> str | None:
+        if data == "hello":
+            return "world"
+        return None
+
+    client = create_test_client([handler])
+    with client.websocket_connect("/") as ws:
+        ws.send_text("hello")
+        assert ws.receive_text() == "world"
+        ws.send_text("goodbye")
 
 
 def test_listener_pass_socket(mock: MagicMock) -> None:

--- a/tests/types/test_parsed_signature.py
+++ b/tests/types/test_parsed_signature.py
@@ -1,6 +1,7 @@
 # ruff: noqa: UP006,UP007
 from __future__ import annotations
 
+import inspect
 from inspect import Parameter
 from typing import Any, List, Optional, Union
 
@@ -206,3 +207,4 @@ def test_parsed_signature() -> None:
     assert parsed_sig.parameters["bar"].parsed_type.args == (List[int], NoneType)
     assert parsed_sig.parameters["bar"].parsed_type.annotation == Union[List[int], NoneType]
     assert parsed_sig.parameters["bar"].default is None
+    assert parsed_sig.original_signature == inspect.signature(fn)


### PR DESCRIPTION
Add enhanced websocket support, making websocket handling a lot easier and feel more "Starlite".

The main features are two new classes:

1. The `websocket_listener`: A special websocket handler, listening and sending incoming data in a loop
2. `WebsocketListener`: An abstract base class building upon `websocket_listener` and allowing to define things in a more OOP way


<hr>

## Examples


```python
from starlite.handlers.websocket_handlers import websocket_listener

@websocket_listener("/")
async def handler(data: str) -> str:
  return data
```


this is equivalent to:

```python
from starlite import websocket, WebSocket
from starlite.exceptions import WebSocketDisconnect


@websocket("/")
async def handler(socket: WebSocket) -> str:
  await socket.accept()
  while True:
    try:
      data = await socket.receive_text()
      await socket.send_text(data)
    except WebSocketDisconnect:
      break
```

It allows to send and receive either bytes, text or json, all configure by the type annotations of the handler function:


```python
from starlite.handlers.websocket_handlers import websocket_listener

@websocket_listener("/")
async def handler(data: list[str]) -> dict[str, str]:
  return {"message": data}
```

### Dependencies

Dependencies are handled on the route handler level, and passed into the listener function, so this works as expected:

```python
from starlite.di import Provide
from starlite.handlers.websocket_handlers import websocket_listener


@websocket_listener("/", dependencies={"foo": Provide(lambda: "foo")})
async def handler(data: str, foo: str) -> str:
  return data
```

And since this uses the regular signature/kwargs modelling, we can still inject things like `socket` or `state`:


```python
from starlite.handlers.websocket_handlers import websocket_listener
from starlite.datastructures import State

@websocket_listener("/")
async def handler(data: str, socket: WebSocket, state: State) -> str:
  return data
```

### Handling websockets synchronously

Since we don't need to handle the socket directly anymore, it's possible to use synchronous functions as well and this "just works":

```python
from starlite.handlers.websocket_handlers import websocket_listener

@websocket_listener("/")
def handler(data: str) -> str:
  return data
```

### Class based listeners

The class based listener build upon the `websocket_listener`, by providing an OOP way to handle websocket events, using synchronous or asynchronous methods as well:

```python
from starlite.handlers.websocket_handlers import WebsocketListener

class MyListener(WebsocketListener):
  path = "/"

  def on_connect(self, socket: WebSocket) -> None:
    print("socket connected")

  def on_receive(self, data: str) -> str:
    return "hello, world!"
  
  def on_disconnect(self, socket: WebSocket) -> None:
    print("socket disconnected")
```

## Todo

Ideally we want to integrate similar functionalities to route handlers in regards of data (de)serialisation. This is probably best done once #1295 is merged, as it would greatly simplify this. 

This is not a blocker though, and from a functionality standpoint this can be released as-is. 