### PR TITLE
Fix `ResponseCacheConfig` default store name

### DIFF
--- a/docs/examples/stores/registry_configure_integrations.py
+++ b/docs/examples/stores/registry_configure_integrations.py
@@ -8,7 +8,7 @@ from starlite.stores.redis import RedisStore
 app = Starlite(
     stores={
         "sessions": RedisStore.with_client(),
-        "request_cache": FileStore(Path("request-cache")),
+        "response_cache": FileStore(Path("response-cache")),
     },
     middleware=[ServerSideSessionConfig().middleware],
 )

--- a/docs/examples/stores/registry_default_factory_namespacing.py
+++ b/docs/examples/stores/registry_default_factory_namespacing.py
@@ -9,7 +9,7 @@ root_store = RedisStore.with_client()
 
 @get(cache=True)
 def cached_handler() -> str:
-    # this will use app.stores.get("request_cache")
+    # this will use app.stores.get("response_cache")
     return "Hello, world!"
 
 

--- a/docs/examples/tests/test_stores.py
+++ b/docs/examples/tests/test_stores.py
@@ -97,7 +97,7 @@ async def test_configure_integrations(mock_redis: MagicMock) -> None:
 
     assert isinstance(session_store, RedisStore)
     assert isinstance(cache_store, FileStore)
-    assert cache_store.path == Path("request-cache")
+    assert cache_store.path == Path("response-cache")
 
 
 async def test_registry_default_factory() -> None:

--- a/docs/usage/stores.rst
+++ b/docs/usage/stores.rst
@@ -235,7 +235,7 @@ This mechanism also allows to control the stores used by various integrations, s
     :language: python
 
 
-In this example, the registry is being set up with stores using the ``sessions`` and ``request_cache`` keys. These are
+In this example, the registry is being set up with stores using the ``sessions`` and ``response_cache`` keys. These are
 not magic constants, but instead configuration values that can be changed. Those names just happen to be their default
 values. Adjusting those default values allows to easily re-use stores, without the need for a more complex setup:
 

--- a/starlite/config/response_cache.py
+++ b/starlite/config/response_cache.py
@@ -40,7 +40,7 @@ class ResponseCacheConfig:
     """Default cache expiration in seconds."""
     key_builder: CacheKeyBuilder = field(default=default_cache_key_builder)
     """:class:`CacheKeyBuilder <.types.CacheKeyBuilder>`. Defaults to :func:`default_cache_key_builder`."""
-    store: str = "request_cache"
+    store: str = "response_cache"
     """Name of the :class:`Store <.stores.base.Store>` to use."""
 
     def get_store_from_app(self, app: Starlite) -> Store:

--- a/tests/test_response_caching.py
+++ b/tests/test_response_caching.py
@@ -101,7 +101,7 @@ async def test_custom_cache_key(sync_to_thread: bool, anyio_backend: str, mock: 
 
     with TestClient(app) as client:
         client.get("/cached")
-        store = app.stores.get("request_cache")
+        store = app.stores.get("response_cache")
         assert await store.exists("/cached:::cached")
 
 
@@ -131,7 +131,7 @@ async def test_with_stores(store: Store, mock: MagicMock) -> None:
     def handler() -> str:
         return mock()  # type: ignore[no-any-return]
 
-    app = Starlite([handler], stores={"request_cache": store})
+    app = Starlite([handler], stores={"response_cache": store})
 
     with TestClient(app=app) as client:
         response_one = client.get("/")


### PR DESCRIPTION
Fix a typo in the default value of `ResponseCacheConfig.store`.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
