### PR TITLE
Fix (v1.51): Wrong value being passed to cache backend when `cache=True` in route handler

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -171,6 +171,7 @@ repos:
             click,
             cryptography,
             fast-query-parsers,
+            fakeredis,
             freezegun,
             fsspec,
             httpx,

--- a/poetry.lock
+++ b/poetry.lock
@@ -159,7 +159,7 @@ files = [
 name = "attrs"
 version = "22.2.0"
 description = "Classes Without Boilerplate"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -931,7 +931,7 @@ idna = ">=2.0.0"
 name = "exceptiongroup"
 version = "1.1.1"
 description = "Backport of PEP 654 (exception groups)"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1429,7 +1429,7 @@ files = [
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2061,7 +2061,7 @@ attrs = ">=19.2.0"
 name = "packaging"
 version = "23.0"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2176,7 +2176,7 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.2.2)", "pytest-
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -2482,7 +2482,7 @@ files = [
 name = "pytest"
 version = "7.2.2"
 description = "pytest: simple powerful testing with Python"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -2539,6 +2539,21 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
+
+[[package]]
+name = "pytest-lazy-fixture"
+version = "0.6.3"
+description = "It helps to use fixtures in pytest.mark.parametrize"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pytest-lazy-fixture-0.6.3.tar.gz", hash = "sha256:0e7d0c7f74ba33e6e80905e9bfd81f9d15ef9a790de97993e34213deb5ad10ac"},
+    {file = "pytest_lazy_fixture-0.6.3-py3-none-any.whl", hash = "sha256:e0b379f38299ff27a653f03eaa69b08a6fd4484e46fd1c9907d984b9f9daeda6"},
+]
+
+[package.dependencies]
+pytest = ">=3.2.5"
 
 [[package]]
 name = "pytest-mock"
@@ -3438,7 +3453,7 @@ files = [
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -3715,4 +3730,4 @@ tortoise-orm = []
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "f39faddd93e51e7cd218b460dabf00569e8470e4654822ad37954b913bf4cabd"
+content-hash = "f70f506c4adb13b6b5772c0d44d2e8105e3f25d2d53f8af2dd064acced605fe9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ redis = { version = "*", optional = true, extras = ["hiredis"] }
 rich = {version = ">=13.0.0", optional = true}
 structlog = { version = "*", optional = true }
 typing-extensions = "*"
+pytest-lazy-fixture = "^0.6.3"
 
 [tool.poetry.group.dev.dependencies]
 aiomcache = "*"

--- a/starlite/plugins/sql_alchemy/plugin.py
+++ b/starlite/plugins/sql_alchemy/plugin.py
@@ -426,7 +426,7 @@ class SQLAlchemyPlugin(PluginProtocol[DeclarativeMeta]):
         pydantic_model = self._model_namespace_map.get(model_class.__qualname__) or self.to_pydantic_model_class(
             model_class=model_class
         )
-        return pydantic_model.from_orm(model_instance).dict()  # type:ignore[pydantic-unexpected]
+        return pydantic_model.from_orm(model_instance).dict()
 
     def from_dict(self, model_class: "Type[DeclarativeMeta]", **kwargs: Any) -> DeclarativeMeta:
         """Given a dictionary of kwargs, return an instance of the given model_class.

--- a/starlite/routes/http.py
+++ b/starlite/routes/http.py
@@ -251,7 +251,9 @@ class HTTPRoute(BaseRoute):
         await cache.set(
             key=cache_key,
             value=pickle.dumps(response, pickle.HIGHEST_PROTOCOL),
-            expiration=route_handler.cache if isinstance(route_handler.cache, int) else None,
+            expiration=route_handler.cache
+            if isinstance(route_handler.cache, int) and route_handler.cache is not True
+            else None,
         )
 
     def create_options_handler(self, path: str) -> "HTTPRouteHandler":


### PR DESCRIPTION
When setting `cache=True` in a route handler, we are passing the boolean value as the expiration time to the backend as-is. This causes errors when being used with the redis backend.

This PR implements a fix by explicitly checking for `True` before passing along the value.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
