### PR TITLE
Ensure openapi responses generated from de-stringized return annotation.

### DIFF
--- a/starlite/_signature/parsing.py
+++ b/starlite/_signature/parsing.py
@@ -183,7 +183,7 @@ def parse_fn_signature(
 
         parsed_params.append(parameter)
 
-    return parsed_params, signature.return_annotation, field_plugin_mappings, dependency_names
+    return parsed_params, fn_type_hints.get("return", Signature.empty), field_plugin_mappings, dependency_names
 
 
 def create_signature_model(


### PR DESCRIPTION
Ensures that the signature model return annotation is retrieved from de-referenced type hints.

Uses the signature model's `return_annotation` for generation of success responses.

Closes #1409

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
