### PR TITLE
Enhancement: Support setting status codes in `Redirect` container

### DIFF
--- a/starlite/handlers/http_handlers/base.py
+++ b/starlite/handlers/http_handlers/base.py
@@ -8,14 +8,12 @@ from typing_extensions import TypedDict
 
 from starlite._layers.utils import narrow_response_cookies, narrow_response_headers
 from starlite._signature.utils import get_signature_model
-from starlite.constants import REDIRECT_STATUS_CODES
 from starlite.datastructures.cookie import Cookie
 from starlite.datastructures.response_header import ResponseHeader
 from starlite.enums import HttpMethod, MediaType
 from starlite.exceptions import (
     HTTPException,
     ImproperlyConfiguredException,
-    ValidationException,
 )
 from starlite.handlers.base import BaseRouteHandler
 from starlite.handlers.http_handlers._utils import (
@@ -498,15 +496,6 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
             raise ImproperlyConfiguredException(
                 "A status code 204, 304 or in the range below 200 does not support a response body."
                 "If the function should return a value, change the route handler status code to an appropriate value.",
-            )
-
-        if (
-            is_class_and_subclass(self.signature.return_annotation, Redirect)
-            and self.status_code not in REDIRECT_STATUS_CODES
-        ):
-            raise ValidationException(
-                f"Redirect responses should have one of "
-                f"the following status codes: {', '.join([str(s) for s in REDIRECT_STATUS_CODES])}"
             )
 
         if (

--- a/starlite/response_containers.py
+++ b/starlite/response_containers.py
@@ -215,6 +215,8 @@ class Redirect(ResponseContainer[RedirectResponse]):
     """If defined, overrides the media type configured in the route decorator."""
     encoding: str = field(default="utf-8")
     """The encoding to be used for the response headers."""
+    status_code: Literal[301, 302, 303, 307, 308] | None = None
+    """Redirect status code"""
 
     def to_response(  # type: ignore[override]
         self,
@@ -242,7 +244,7 @@ class Redirect(ResponseContainer[RedirectResponse]):
             background=self.background,
             encoding=self.encoding,
             headers=headers,
-            status_code=status_code,
+            status_code=self.status_code or status_code,
             url=self.path,
         )
 

--- a/tests/handlers/http/test_validations.py
+++ b/tests/handlers/http/test_validations.py
@@ -34,18 +34,12 @@ def test_route_handler_validation_http_method() -> None:
         route(http_method=[HttpMethod.GET, "poft"], status_code=HTTP_200_OK)  # type: ignore
 
 
-async def test_function_validation(anyio_backend: str) -> None:
+async def test_function_validation() -> None:
     with pytest.raises(ImproperlyConfiguredException):
 
         @get(path="/")
         def method_with_no_annotation():  # type: ignore
             pass
-
-    with pytest.raises(ValidationException):
-
-        @get(path="/", status_code=HTTP_200_OK)
-        def redirect_method_without_proper_status() -> Redirect:
-            return Redirect(path="/redirected")
 
     with pytest.raises(ImproperlyConfiguredException):
 

--- a/tests/test_response_containers.py
+++ b/tests/test_response_containers.py
@@ -11,7 +11,7 @@ from starlite import get
 from starlite.datastructures import ETag
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.file_system import BaseLocalFileSystem
-from starlite.response_containers import File
+from starlite.response_containers import File, Redirect, ResponseContainer
 from starlite.status_codes import HTTP_200_OK
 from starlite.testing import RequestFactory, create_test_client
 
@@ -155,3 +155,34 @@ def test_file_system_validation(tmpdir: "Path") -> None:
         path=path,
         file_system=ImplementedFS(),
     )
+
+
+@pytest.mark.parametrize(
+    "status_code,expected_status_code",
+    [
+        (301, 301),
+        (302, 302),
+        (303, 303),
+        (307, 307),
+        (308, 308),
+    ],
+)
+def test_redirect_dynamic_status_code(status_code: int | None, expected_status_code: int) -> None:
+    @get("/")
+    def handler() -> ResponseContainer:
+        return Redirect(path="/something-else", status_code=status_code)  # type: ignore[arg-type]
+
+    with create_test_client([handler]) as client:
+        res = client.get("/", follow_redirects=False)
+        assert res.status_code == expected_status_code
+
+
+@pytest.mark.parametrize("handler_status_code", [301, 307, None])
+def test_redirect(handler_status_code: int | None) -> None:
+    @get("/", status_code=handler_status_code)
+    def handler() -> ResponseContainer:
+        return Redirect(path="/something-else", status_code=301)
+
+    with create_test_client([handler]) as client:
+        res = client.get("/", follow_redirects=False)
+        assert res.status_code == 301

--- a/tests/test_response_containers.py
+++ b/tests/test_response_containers.py
@@ -11,7 +11,7 @@ from starlite import get
 from starlite.datastructures import ETag
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.file_system import BaseLocalFileSystem
-from starlite.response_containers import File, Redirect, ResponseContainer
+from starlite.response_containers import File, Redirect
 from starlite.status_codes import HTTP_200_OK
 from starlite.testing import RequestFactory, create_test_client
 
@@ -169,7 +169,7 @@ def test_file_system_validation(tmpdir: "Path") -> None:
 )
 def test_redirect_dynamic_status_code(status_code: int | None, expected_status_code: int) -> None:
     @get("/")
-    def handler() -> ResponseContainer:
+    def handler() -> Redirect:
         return Redirect(path="/something-else", status_code=status_code)  # type: ignore[arg-type]
 
     with create_test_client([handler]) as client:
@@ -180,7 +180,7 @@ def test_redirect_dynamic_status_code(status_code: int | None, expected_status_c
 @pytest.mark.parametrize("handler_status_code", [301, 307, None])
 def test_redirect(handler_status_code: int | None) -> None:
     @get("/", status_code=handler_status_code)
-    def handler() -> ResponseContainer:
+    def handler() -> Redirect:
         return Redirect(path="/something-else", status_code=301)
 
     with create_test_client([handler]) as client:

--- a/tests/test_response_containers.py
+++ b/tests/test_response_containers.py
@@ -2,7 +2,7 @@ import os
 from inspect import iscoroutine
 from os import stat
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import pytest
 from fsspec.implementations.local import LocalFileSystem
@@ -167,7 +167,7 @@ def test_file_system_validation(tmpdir: "Path") -> None:
         (308, 308),
     ],
 )
-def test_redirect_dynamic_status_code(status_code: int | None, expected_status_code: int) -> None:
+def test_redirect_dynamic_status_code(status_code: Optional[int], expected_status_code: int) -> None:
     @get("/")
     def handler() -> Redirect:
         return Redirect(path="/something-else", status_code=status_code)  # type: ignore[arg-type]
@@ -178,7 +178,7 @@ def test_redirect_dynamic_status_code(status_code: int | None, expected_status_c
 
 
 @pytest.mark.parametrize("handler_status_code", [301, 307, None])
-def test_redirect(handler_status_code: int | None) -> None:
+def test_redirect(handler_status_code: Optional[int]) -> None:
     @get("/", status_code=handler_status_code)
     def handler() -> Redirect:
         return Redirect(path="/something-else", status_code=301)


### PR DESCRIPTION
Fixes #1371.

We currently only allow "static" redirects, i.e. setting a redirect status code on the handler, and then returning a `Redirect`. This does not support use cases where a redirect may be returned conditionally, see #1371.

This issue runs into a larger underlying problem with how we handle status codes in HTTP handlers, since we generally lack support of setting them dynamically / multiple, therefore I had to remove validation logic that checked if the status code on the handler was in the accepted range for redirects if a handler returns a `Redirect`, as this validation would fail if no status code was set on the handler.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)
