### PR TITLE
Enhancement: Add sentinel value to support caching responses indefinitely.

### DIFF
--- a/docs/usage/caching.rst
+++ b/docs/usage/caching.rst
@@ -31,6 +31,20 @@ Alternatively you can specify the number of seconds to cache the responses from 
        ...
 
 
+If you want the response to be cached indefinitely, you can pass the :class:`.config.response_cache.CACHE_FOREVER`
+sentinel instead:
+
+.. code-block:: python
+
+   from starlite import get
+   from starlite.config.response_cache import CACHE_FOREVER
+
+
+   @get("/cached-path", cache=CACHE_FOREVER)  # seconds
+   def my_cached_handler() -> str:
+       ...
+
+
 Configuration
 -------------
 

--- a/starlite/config/response_cache.py
+++ b/starlite/config/response_cache.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 
-__all__ = ("ResponseCacheConfig", "default_cache_key_builder")
+__all__ = ("ResponseCacheConfig", "default_cache_key_builder", "CACHE_FOREVER")
 
 
 if TYPE_CHECKING:
@@ -12,6 +12,12 @@ if TYPE_CHECKING:
     from starlite.connection import Request
     from starlite.stores.base import Store
     from starlite.types import CacheKeyBuilder
+
+
+class CACHE_FOREVER:  # noqa: N801
+    """Sentinel value indicating that a cached response should be stored without an expiration, explicitly skipping the
+    default expiration
+    """
 
 
 def default_cache_key_builder(request: Request[Any, Any, Any]) -> str:

--- a/starlite/handlers/http_handlers/base.py
+++ b/starlite/handlers/http_handlers/base.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
 
     from starlite.app import Starlite
     from starlite.background_tasks import BackgroundTask, BackgroundTasks
+    from starlite.config.response_cache import CACHE_FOREVER
     from starlite.connection import Request
     from starlite.datastructures import CacheControlHeader, ETag
     from starlite.datastructures.headers import Header
@@ -60,6 +61,7 @@ if TYPE_CHECKING:
     from starlite.openapi.spec import SecurityRequirement
     from starlite.plugins import SerializationPluginProtocol
     from starlite.types import MaybePartial  # noqa: F401
+
 
 __all__ = ("HTTPRouteHandler", "route")
 
@@ -120,7 +122,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
         after_response: AfterResponseHookHandler | None = None,
         background: BackgroundTask | BackgroundTasks | None = None,
         before_request: BeforeRequestHookHandler | None = None,
-        cache: bool | int = False,
+        cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
         dependencies: Mapping[str, Provide] | None = None,

--- a/starlite/handlers/http_handlers/decorators.py
+++ b/starlite/handlers/http_handlers/decorators.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from typing import Any, Mapping
 
     from starlite.background_tasks import BackgroundTask, BackgroundTasks
+    from starlite.config.response_cache import CACHE_FOREVER
     from starlite.datastructures import CacheControlHeader, ETag
     from starlite.di import Provide
     from starlite.openapi.datastructures import ResponseSpec
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
         ResponseType,
         TypeEncodersMap,
     )
+
 
 __all__ = ("get", "head", "post", "put", "patch", "delete")
 
@@ -51,7 +53,7 @@ class delete(HTTPRouteHandler):
         after_response: AfterResponseHookHandler | None = None,
         background: BackgroundTask | BackgroundTasks | None = None,
         before_request: BeforeRequestHookHandler | None = None,
-        cache: bool | int = False,
+        cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
         dependencies: dict[str, Provide] | None = None,
@@ -204,7 +206,7 @@ class get(HTTPRouteHandler):
         after_response: AfterResponseHookHandler | None = None,
         background: BackgroundTask | BackgroundTasks | None = None,
         before_request: BeforeRequestHookHandler | None = None,
-        cache: bool | int = False,
+        cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
         dependencies: dict[str, Provide] | None = None,
@@ -358,7 +360,7 @@ class head(HTTPRouteHandler):
         after_response: AfterResponseHookHandler | None = None,
         background: BackgroundTask | BackgroundTasks | None = None,
         before_request: BeforeRequestHookHandler | None = None,
-        cache: bool | int = False,
+        cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
         dependencies: dict[str, Provide] | None = None,
@@ -530,7 +532,7 @@ class patch(HTTPRouteHandler):
         after_response: AfterResponseHookHandler | None = None,
         background: BackgroundTask | BackgroundTasks | None = None,
         before_request: BeforeRequestHookHandler | None = None,
-        cache: bool | int = False,
+        cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
         dependencies: dict[str, Provide] | None = None,
@@ -683,7 +685,7 @@ class post(HTTPRouteHandler):
         after_response: AfterResponseHookHandler | None = None,
         background: BackgroundTask | BackgroundTasks | None = None,
         before_request: BeforeRequestHookHandler | None = None,
-        cache: bool | int = False,
+        cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
         dependencies: dict[str, Provide] | None = None,
@@ -836,7 +838,7 @@ class put(HTTPRouteHandler):
         after_response: AfterResponseHookHandler | None = None,
         background: BackgroundTask | BackgroundTasks | None = None,
         before_request: BeforeRequestHookHandler | None = None,
-        cache: bool | int = False,
+        cache: bool | int | type[CACHE_FOREVER] = False,
         cache_control: CacheControlHeader | None = None,
         cache_key_builder: CacheKeyBuilder | None = None,
         dependencies: dict[str, Provide] | None = None,


### PR DESCRIPTION
Closes #1365 by adding a `CACHE_FOREVER` sentinel value, that, when passed to a route handlers `cache` argument, will cause it to be cached forever, skipping the default expiration.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [x] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)