### PR TITLE
Remove hypothesis permutations from test.

### DIFF
--- a/tests/test_option_requests.py
+++ b/tests/test_option_requests.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.parametrize(
     "http_methods",
-    (list(perm) for perm in iter(permutations(["GET", "POST", "PATCH", "DELETE", "HEAD"], r=random.randrange(1, 5)))),
+    (list(perm) for perm in iter(permutations(["GET", "POST", "PATCH", "DELETE", "HEAD"], r=random.randrange(1, 6)))),
 )
 def test_regular_options_request(http_methods: List["Method"]) -> None:
     @route("/", http_method=http_methods)

--- a/tests/test_option_requests.py
+++ b/tests/test_option_requests.py
@@ -1,8 +1,8 @@
+import random
+from itertools import permutations
 from typing import TYPE_CHECKING, List, Mapping, Optional
 
 import pytest
-from hypothesis import given
-from hypothesis.strategies import permutations
 
 from starlite import get, route
 from starlite.config.cors import CORSConfig
@@ -13,13 +13,16 @@ if TYPE_CHECKING:
     from starlite.types import Method
 
 
-@given(http_methods=permutations(["GET", "POST", "POST", "PATCH", "DELETE", "HEAD"]))
+@pytest.mark.parametrize(
+    "http_methods",
+    (list(perm) for perm in iter(permutations(["GET", "POST", "PATCH", "DELETE", "HEAD"], r=random.randrange(1, 5)))),
+)
 def test_regular_options_request(http_methods: List["Method"]) -> None:
     @route("/", http_method=http_methods)
     def handler() -> None:
         return None
 
-    with create_test_client(handler) as client:
+    with create_test_client(handler, openapi_config=None) as client:
         response = client.options("/")
         assert response.status_code == HTTP_204_NO_CONTENT, response.text
         assert response.headers.get("Allow") == ", ".join(sorted({*http_methods, "OPTIONS"}))


### PR DESCRIPTION
This test is responsible for the last couple of hypothesis timing consistency errors.

Replaced using a solution with stdlib components and `pytest.mark.parametrize`.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
