### PR TITLE
RFC: Attempt at a `StarliteEncodableType` type alias.

### DIFF
--- a/starlite/types/__init__.py
+++ b/starlite/types/__init__.py
@@ -83,6 +83,7 @@ from .internal_types import (
     RouteHandlerType,
 )
 from .protocols import DataclassProtocol, Logger
+from .serialization import StarliteEncodableType
 
 __all__ = (
     "ASGIApp",
@@ -153,6 +154,7 @@ __all__ = (
     "Scopes",
     "Send",
     "Serializer",
+    "StarliteEncodableType",
     "SyncOrAsyncUnion",
     "TypeEncodersMap",
     "TypedDictClass",

--- a/starlite/types/serialization.py
+++ b/starlite/types/serialization.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeAlias
+
+if TYPE_CHECKING:
+    from collections import deque
+    from datetime import date, datetime, time
+    from decimal import Decimal
+    from enum import Enum, IntEnum
+    from ipaddress import (
+        IPv4Address,
+        IPv4Interface,
+        IPv4Network,
+        IPv6Address,
+        IPv6Interface,
+        IPv6Network,
+    )
+    from pathlib import Path, PurePath
+    from re import Pattern
+    from uuid import UUID
+
+    from msgspec import Raw, Struct
+    from msgspec.msgpack import Ext
+    from pydantic import (
+        BaseModel,
+        ByteSize,
+        ConstrainedBytes,
+        ConstrainedDate,
+        NameEmail,
+        SecretField,
+        StrictBool,
+    )
+    from pydantic.color import Color
+
+    from starlite.types import DataclassProtocol
+
+EncodableBuiltinType: TypeAlias = "None | bool | int | float | str | bytes | bytearray"
+EncodableBuiltinCollectionType: TypeAlias = "list | tuple | set | frozenset | dict"
+EncodableStdLibType: TypeAlias = (
+    "date | datetime | deque | time | UUID | Decimal | Enum | IntEnum | DataclassProtocol | Path | PurePath | Pattern"
+)
+EncodableStdLibIPType: TypeAlias = (
+    "IPv4Address | IPv4Interface | IPv4Network | IPv6Address | IPv6Interface | IPv6Network"
+)
+EncodableMsgSpecType: TypeAlias = "Ext | Raw | Struct"
+EncodablePydanticType: TypeAlias = (
+    "BaseModel | ByteSize | ConstrainedBytes | ConstrainedDate | NameEmail | SecretField | StrictBool | Color"
+)
+
+StarliteEncodableType: TypeAlias = "EncodableBuiltinType | EncodableBuiltinCollectionType | EncodableStdLibType | EncodableStdLibIPType | EncodableMsgSpecType | EncodablePydanticType"

--- a/starlite/types/serialization.py
+++ b/starlite/types/serialization.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, TypeAlias
 
 if TYPE_CHECKING:
     from collections import deque
+    from collections.abc import Collection
     from datetime import date, datetime, time
     from decimal import Decimal
     from enum import Enum, IntEnum
@@ -35,7 +36,7 @@ if TYPE_CHECKING:
     from starlite.types import DataclassProtocol
 
 EncodableBuiltinType: TypeAlias = "None | bool | int | float | str | bytes | bytearray"
-EncodableBuiltinCollectionType: TypeAlias = "list | tuple | set | frozenset | dict"
+EncodableBuiltinCollectionType: TypeAlias = "list | tuple | set | frozenset | dict | Collection"
 EncodableStdLibType: TypeAlias = (
     "date | datetime | deque | time | UUID | Decimal | Enum | IntEnum | DataclassProtocol | Path | PurePath | Pattern"
 )

--- a/starlite/types/serialization.py
+++ b/starlite/types/serialization.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
 
     from starlite.types import DataclassProtocol
 
+__all__ = ("StarliteEncodableType",)
+
 EncodableBuiltinType: TypeAlias = "None | bool | int | float | str | bytes | bytearray"
 EncodableBuiltinCollectionType: TypeAlias = "list | tuple | set | frozenset | dict | Collection"
 EncodableStdLibType: TypeAlias = (

--- a/starlite/types/serialization.py
+++ b/starlite/types/serialization.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections import deque
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
         StrictBool,
     )
     from pydantic.color import Color
+    from typing_extensions import TypeAlias
 
     from starlite.types import DataclassProtocol
 


### PR DESCRIPTION
`AbstractDTOInterface.to_encodable_type()` needs a type for its return value.

Alternative is to just type it `Any`, I don't know if we are tying a rod for our backs trying to strong type this stuff, but then again, maybe it's ok.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
