### PR TITLE
De-duplicates handler `__call__()` method logic.

### DIFF
--- a/starlite/handlers/asgi_handlers.py
+++ b/starlite/handlers/asgi_handlers.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-from inspect import Signature
 from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.handlers.base import BaseRouteHandler
-from starlite.utils import Ref, is_async_callable
+from starlite.utils import is_async_callable
 
 __all__ = ("ASGIRouteHandler", "asgi")
 
 
 if TYPE_CHECKING:
     from starlite.types import (
-        AsyncAnyCallable,
         ExceptionHandlersMap,
         Guard,
         MaybePartial,  # noqa: F401
@@ -72,13 +70,6 @@ class ASGIRouteHandler(BaseRouteHandler["ASGIRouteHandler"]):
             signature_namespace=signature_namespace,
             **kwargs,
         )
-
-    def __call__(self, fn: AsyncAnyCallable) -> ASGIRouteHandler:
-        """Replace a function with itself."""
-        self.fn = Ref["MaybePartial[AsyncAnyCallable]"](fn)
-        self.signature = Signature.from_callable(fn)
-        self._validate_handler_function()
-        return self
 
     def _validate_handler_function(self) -> None:
         """Validate the route handler function once it's set by inspecting its return annotations."""

--- a/starlite/handlers/http_handlers/base.py
+++ b/starlite/handlers/http_handlers/base.py
@@ -45,7 +45,7 @@ from starlite.types import (
     ResponseType,
     TypeEncodersMap,
 )
-from starlite.utils import AsyncCallable, Ref, is_async_callable, is_class_and_subclass
+from starlite.utils import AsyncCallable, is_async_callable, is_class_and_subclass
 
 if TYPE_CHECKING:
     from typing import Any, Awaitable, Callable, Sequence
@@ -274,10 +274,7 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
 
     def __call__(self, fn: AnyCallable) -> HTTPRouteHandler:
         """Replace a function with itself."""
-        self.fn = Ref["MaybePartial[AnyCallable]"](fn)
-        self.signature = Signature.from_callable(fn)
-        self._validate_handler_function()
-
+        super().__call__(fn)
         if not self.media_type:
             if self.signature.return_annotation in {str, bytes, AnyStr, Redirect, File} or any(
                 is_class_and_subclass(self.signature.return_annotation, t_type) for t_type in (str, bytes)  # type: ignore

--- a/starlite/handlers/websocket_handlers.py
+++ b/starlite/handlers/websocket_handlers.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from inspect import Signature
 from typing import TYPE_CHECKING
 
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.handlers.base import BaseRouteHandler
-from starlite.utils import Ref, is_async_callable
+from starlite.utils import is_async_callable
 
 __all__ = ("WebsocketRouteHandler", "websocket")
 
@@ -14,7 +13,6 @@ if TYPE_CHECKING:
     from typing import Any, Mapping
 
     from starlite.types import (
-        AsyncAnyCallable,
         Dependencies,
         ExceptionHandler,
         Guard,
@@ -70,13 +68,6 @@ class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):
             signature_namespace=signature_namespace,
             **kwargs,
         )
-
-    def __call__(self, fn: AsyncAnyCallable) -> WebsocketRouteHandler:
-        """Replace a function with itself."""
-        self.fn = Ref["MaybePartial[AsyncAnyCallable]"](fn)
-        self.signature = Signature.from_callable(fn)
-        self._validate_handler_function()
-        return self
 
     def _validate_handler_function(self) -> None:
         """Validate the route handler function once it's set by inspecting its return annotations."""

--- a/starlite/router.py
+++ b/starlite/router.py
@@ -8,7 +8,6 @@ from starlite._layers.utils import narrow_response_cookies, narrow_response_head
 from starlite.controller import Controller
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.handlers.asgi_handlers import ASGIRouteHandler
-from starlite.handlers.base import BaseRouteHandler
 from starlite.handlers.http_handlers import HTTPRouteHandler
 from starlite.handlers.websocket_handlers import WebsocketRouteHandler
 from starlite.routes import ASGIRoute, HTTPRoute, WebSocketRoute
@@ -286,7 +285,7 @@ class Router:
             value.owner = self
             return value
 
-        if isinstance(value, BaseRouteHandler):
+        if isinstance(value, (ASGIRouteHandler, HTTPRouteHandler, WebsocketRouteHandler)):
             value.owner = self
             return value
 


### PR DESCRIPTION
Same logic was repeated 3 times for each handler type, PR moves common logic into `BaseRouteHandler`.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
