### PR TITLE
Adds `BaseRouteHandler.fn` property.

### DIFF
--- a/tests/handlers/base/test_validations.py
+++ b/tests/handlers/base/test_validations.py
@@ -8,4 +8,4 @@ def test_raise_no_fn_validation() -> None:
     handler = BaseRouteHandler[BaseRouteHandler](path="/")
 
     with pytest.raises(ImproperlyConfiguredException):
-        handler._validate_handler_function()
+        handler.fn


### PR DESCRIPTION
This allows raising `ImproperlyConfiguredException` whenever `BaseRouteHandler.fn` is accessed before having decorated a handler function.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
