### PR TITLE
Parsed signature utils

### DIFF
--- a/starlite/_signature/utils.py
+++ b/starlite/_signature/utils.py
@@ -107,9 +107,7 @@ def get_signature_model(value: Any) -> type[SignatureModel]:
 def _any_attrs_annotation(parsed_signature: ParsedSignature) -> bool:
     for parameter in parsed_signature.parameters.values():
         parsed_type = parameter.parsed_type
-        if any(is_attrs_class(t.annotation) for t in parsed_type.inner_annotations) or is_attrs_class(
-            parsed_type.annotation
-        ):
+        if any(is_attrs_class(t.annotation) for t in parsed_type.inner_types) or is_attrs_class(parsed_type.annotation):
             return True
     return False
 
@@ -120,7 +118,7 @@ def _any_pydantic_annotation(
     for parameter in parsed_signature.parameters.values():
         parsed_type = parameter.parsed_type
         if (
-            any(_is_pydantic_annotation(t.annotation) for t in parsed_type.inner_annotations)
+            any(_is_pydantic_annotation(t.annotation) for t in parsed_type.inner_types)
             or _is_pydantic_annotation(parsed_type.annotation)
             or field_plugin_mappings.get(parameter.name)
         ):
@@ -135,9 +133,7 @@ def _create_field_plugin_mappings(
     for parameter in parsed_signature.parameters.values():
         parsed_type = parameter.parsed_type
         if plugin := get_plugin_for_value(parameter.parsed_type.annotation, plugins):
-            type_value = (
-                parsed_type.inner_annotations[0].annotation if parsed_type.is_collection else parsed_type.annotation
-            )
+            type_value = parsed_type.inner_types[0].annotation if parsed_type.is_collection else parsed_type.annotation
             field_plugin_mappings[parameter.name] = PluginMapping(plugin=plugin, model_class=type_value)
     return field_plugin_mappings
 

--- a/starlite/handlers/asgi_handlers.py
+++ b/starlite/handlers/asgi_handlers.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.handlers.base import BaseRouteHandler
-from starlite.types.builtin_types import NoneType
 from starlite.utils import is_async_callable
 
 __all__ = ("ASGIRouteHandler", "asgi")
@@ -76,7 +75,7 @@ class ASGIRouteHandler(BaseRouteHandler["ASGIRouteHandler"]):
         """Validate the route handler function once it's set by inspecting its return annotations."""
         super()._validate_handler_function()
 
-        if self.parsed_fn_signature.return_type.annotation not in {None, NoneType}:
+        if not self.parsed_fn_signature.return_type.is_subclass_of(type(None)):
             raise ImproperlyConfiguredException("ASGI handler functions should return 'None'")
 
         if any(key not in self.parsed_fn_signature.parameters for key in ("scope", "send", "receive")):

--- a/starlite/handlers/http_handlers/base.py
+++ b/starlite/handlers/http_handlers/base.py
@@ -403,7 +403,8 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
             cookies = self.resolve_response_cookies()
             type_encoders = self.resolve_type_encoders()
 
-            return_annotation = self.parsed_fn_signature.return_type.annotation
+            return_type = self.parsed_fn_signature.return_type
+            return_annotation = return_type.annotation
 
             if before_request_handler := self.resolve_before_request():
                 before_request_handler_signature = Signature.from_callable(before_request_handler)
@@ -417,11 +418,11 @@ class HTTPRouteHandler(BaseRouteHandler["HTTPRouteHandler"]):
                 cookies=cookies, after_request=after_request
             )
 
-            if is_class_and_subclass(return_annotation, Response):
+            if return_type.is_subclass_of(Response):
                 self._response_handler_mapping["default_handler"] = self._response_handler_mapping[
                     "response_type_handler"
                 ]
-            elif is_class_and_subclass(return_annotation, ResponseContainer):  # type: ignore
+            elif return_type.is_subclass_of(ResponseContainer):
                 self._response_handler_mapping["default_handler"] = create_response_container_handler(
                     after_request=after_request,
                     cookies=cookies,

--- a/starlite/handlers/websocket_handlers.py
+++ b/starlite/handlers/websocket_handlers.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.handlers.base import BaseRouteHandler
-from starlite.types.builtin_types import NoneType
 from starlite.utils import is_async_callable
 
 __all__ = ("WebsocketRouteHandler", "websocket")
@@ -74,7 +73,7 @@ class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):
         """Validate the route handler function once it's set by inspecting its return annotations."""
         super()._validate_handler_function()
 
-        if self.parsed_fn_signature.return_type.annotation not in {None, NoneType}:
+        if not self.parsed_fn_signature.return_type.is_subclass_of(type(None)):
             raise ImproperlyConfiguredException("Websocket handler functions should return 'None'")
         if "socket" not in self.parsed_fn_signature.parameters:
             raise ImproperlyConfiguredException("Websocket handlers must set a 'socket' kwarg")

--- a/starlite/types/parsed_signature.py
+++ b/starlite/types/parsed_signature.py
@@ -40,7 +40,7 @@ class ParsedType:
         "is_required",
         "is_not_required",
         "safe_generic_origin",
-        "inner_annotations",
+        "inner_types",
     )
 
     raw: Any
@@ -64,7 +64,7 @@ class ParsedType:
 
     This is to serve safely rebuilding a generic outer type with different args at runtime.
     """
-    inner_annotations: tuple[ParsedType, ...]
+    inner_types: tuple[ParsedType, ...]
     """The type's generic args parsed as ``ParsedType``, if applicable."""
 
     @property
@@ -103,7 +103,7 @@ class ParsedType:
             is_required=Required in wrappers,
             is_not_required=NotRequired in wrappers,
             safe_generic_origin=get_safe_generic_origin(origin),
-            inner_annotations=tuple(cls.from_annotation(arg) for arg in args),
+            inner_types=tuple(cls.from_annotation(arg) for arg in args),
         )
 
 

--- a/starlite/types/parsed_signature.py
+++ b/starlite/types/parsed_signature.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Collection
 from dataclasses import dataclass
 from inspect import Parameter, Signature
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Union
 
 from typing_extensions import Annotated, NotRequired, Required, get_args, get_origin
 
@@ -15,8 +15,6 @@ from starlite.utils.signature_parsing import get_fn_type_hints
 from starlite.utils.typing import get_safe_generic_origin, unwrap_annotation
 
 if TYPE_CHECKING:
-    from typing import Any
-
     from starlite.types import AnyCallable
 
 __all__ = (
@@ -75,7 +73,34 @@ class ParsedType:
     @property
     def is_collection(self) -> bool:
         """Whether the annotation is a collection type or not."""
-        return self.origin and issubclass(self.origin, Collection)
+        return bool(self.origin and self.origin is not Union and issubclass(self.origin, Collection))
+
+    def is_subclass_of(self, cl: type[Any] | tuple[type[Any], ...]) -> bool:
+        """Whether the annotation is a subclass of the given type.
+
+        Where ``self.annotation`` is a union type, this method will always return ``False``. While this is not
+        strictly correct, we intend on revisiting this once a concrete use-case is to hand.
+
+        Args:
+            cl: The type to check, or tuple of types. Passed as 2nd argument to ``issubclass()``.
+
+        Returns:
+            Whether the annotation is a subtype of the given type(s).
+        """
+        if self.origin:
+            return self.origin not in UNION_TYPES and issubclass(self.origin, cl)
+        return self.annotation is not Any and issubclass(self.annotation, cl)
+
+    def has_inner_subclass_of(self, cl: type[Any] | tuple[type[Any], ...]) -> bool:
+        """Whether any generic args are a subclass of the given type.
+
+        Args:
+            cl: The type to check, or tuple of types. Passed as 2nd argument to ``issubclass()``.
+
+        Returns:
+            Whether any of the type's generic args are a subclass of the given type.
+        """
+        return any(t.is_subclass_of(cl) for t in self.inner_types)
 
     @classmethod
     def from_annotation(cls, annotation: Any) -> ParsedType:

--- a/tests/types/test_parsed_signature.py
+++ b/tests/types/test_parsed_signature.py
@@ -142,6 +142,23 @@ def test_parsed_type_is_optional_predicate() -> None:
     assert ParsedType.from_annotation(Union[int, str]).is_optional is False
 
 
+def test_parsed_type_is_subclass_of() -> None:
+    """Test ParsedType.is_type_of."""
+    assert ParsedType.from_annotation(bool).is_subclass_of(int) is True
+    assert ParsedType.from_annotation(bool).is_subclass_of(str) is False
+    assert ParsedType.from_annotation(Union[int, str]).is_subclass_of(int) is False
+    assert ParsedType.from_annotation(List[int]).is_subclass_of(list) is True
+    assert ParsedType.from_annotation(List[int]).is_subclass_of(int) is False
+    assert ParsedType.from_annotation(Optional[int]).is_subclass_of(int) is False
+
+
+def test_parsed_type_has_inner_subclass_of() -> None:
+    """Test ParsedType.has_type_of."""
+    assert ParsedType.from_annotation(List[int]).has_inner_subclass_of(int) is True
+    assert ParsedType.from_annotation(List[int]).has_inner_subclass_of(str) is False
+    assert ParsedType.from_annotation(List[Union[int, str]]).has_inner_subclass_of(int) is False
+
+
 def test_parsed_parameter() -> None:
     """Test ParsedParameter."""
     param = Parameter("foo", Parameter.POSITIONAL_OR_KEYWORD, annotation=int)


### PR DESCRIPTION
A few utility functions to centralize type identification logic.

## `is_subclass_of()`

Determine if the `ParsedType` is a sub-type of some provided type, e.g, `ParsedType.from_annotation(bool).is_type_of(int) == True`

## `has_inner_subclass_of()`

Does the `is_subclass_of()` check on any inner types held by the `ParsedType`.

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
