### PR TITLE
Fix incorrect handler type annotations

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,6 +83,7 @@ nitpick_ignore = [
     ("py:class", "NoneType"),
     ("py:class", "starlite._signature.field.SignatureField"),
     ("py:class", "types.parsed_signature.ParsedSignature"),
+    ("py:class", "starlite.utils.sync.AsyncCallable"),
 ]
 nitpick_ignore_regex = [
     (r"py:.*", r"starlite\.types.*"),

--- a/starlite/handlers/asgi_handlers.py
+++ b/starlite/handlers/asgi_handlers.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Mapping, Sequence
 
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.handlers.base import BaseRouteHandler
+from starlite.types.builtin_types import NoneType
 from starlite.utils import is_async_callable
 
 __all__ = ("ASGIRouteHandler", "asgi")
@@ -75,7 +76,7 @@ class ASGIRouteHandler(BaseRouteHandler["ASGIRouteHandler"]):
         """Validate the route handler function once it's set by inspecting its return annotations."""
         super()._validate_handler_function()
 
-        if not self.parsed_fn_signature.return_type.is_subclass_of(type(None)):
+        if not self.parsed_fn_signature.return_type.is_subclass_of(NoneType):
             raise ImproperlyConfiguredException("ASGI handler functions should return 'None'")
 
         if any(key not in self.parsed_fn_signature.parameters for key in ("scope", "send", "receive")):

--- a/starlite/handlers/websocket_handlers.py
+++ b/starlite/handlers/websocket_handlers.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from starlite.exceptions import ImproperlyConfiguredException
 from starlite.handlers.base import BaseRouteHandler
+from starlite.types.builtin_types import NoneType
 from starlite.utils import is_async_callable
 
 __all__ = ("WebsocketRouteHandler", "websocket")
@@ -73,7 +74,7 @@ class WebsocketRouteHandler(BaseRouteHandler["WebsocketRouteHandler"]):
         """Validate the route handler function once it's set by inspecting its return annotations."""
         super()._validate_handler_function()
 
-        if not self.parsed_fn_signature.return_type.is_subclass_of(type(None)):
+        if not self.parsed_fn_signature.return_type.is_subclass_of(NoneType):
             raise ImproperlyConfiguredException("Websocket handler functions should return 'None'")
         if "socket" not in self.parsed_fn_signature.parameters:
             raise ImproperlyConfiguredException("Websocket handlers must set a 'socket' kwarg")

--- a/starlite/routes/http.py
+++ b/starlite/routes/http.py
@@ -81,7 +81,7 @@ class HTTPRoute(BaseRoute):
         await response(scope, receive, send)
 
         if after_response_handler := route_handler.resolve_after_response():
-            await after_response_handler(request)  # type: ignore
+            await after_response_handler(request)
 
         if form_data := scope.get("_form", {}):
             await self._cleanup_temporary_files(form_data=cast("dict[str, Any]", form_data))

--- a/starlite/types/builtin_types.py
+++ b/starlite/types/builtin_types.py
@@ -1,21 +1,20 @@
-import sys
-from typing import TYPE_CHECKING, Type, Union
+from __future__ import annotations
 
-from typing_extensions import TypeAlias
+import sys
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
-    from typing_extensions import _TypedDictMeta  # type: ignore
+    from typing import Type
+
+    from typing_extensions import TypeAlias, _TypedDictMeta  # type: ignore
 
 
 if sys.version_info >= (3, 10):
-    from types import NoneType as _NoneType
     from types import UnionType
-
-    NoneType = _NoneType  # type: ignore[valid-type]
 
     UNION_TYPES = {UnionType, Union}
 else:  # pragma: no cover
     UNION_TYPES = {Union}
-    NoneType = type(None)
 
+NoneType: type[None] = type(None)
 TypedDictClass: TypeAlias = "Type[_TypedDictMeta]"

--- a/tests/template/test_template.py
+++ b/tests/template/test_template.py
@@ -109,10 +109,10 @@ def test_media_type_inferred(extension: str, expected_type: MediaType, template_
 
 
 def test_before_request_handler_content_type(template_dir: Path) -> None:
-    (template_dir / "about.html").write_text("about starlite...")
+    template_loc = template_dir / "about.html"
 
-    def before_request_handler(request: "Request") -> None:
-        return None
+    def before_request_handler(_: "Request") -> None:
+        template_loc.write_text("before request")
 
     @get("/", before_request=before_request_handler)
     def index() -> Template:
@@ -124,3 +124,4 @@ def test_before_request_handler_content_type(template_dir: Path) -> None:
         res = client.get("/")
         assert res.status_code == 200
         assert res.headers["content-type"].startswith(MediaType.HTML.value)
+        assert res.text == "before request"

--- a/tests/utils/test_sync.py
+++ b/tests/utils/test_sync.py
@@ -1,3 +1,6 @@
+import pytest
+
+from starlite.exceptions import ImproperlyConfiguredException
 from starlite.utils.sync import AsyncCallable
 
 
@@ -103,3 +106,9 @@ async def test_function_wrapper_wraps_async_class_correctly() -> None:
 
     await wrapped_class(new_value=10)  # type: ignore
     assert instance.value == 10
+
+
+def test_raises_improper_config_if_set_parsed_signature_not_called() -> None:
+    wrapped = AsyncCallable(lambda: None)
+    with pytest.raises(ImproperlyConfiguredException):
+        wrapped.parsed_signature


### PR DESCRIPTION
Fix incorrect handler type annotations.

`HTTPRouteHandler.{resolve_after_response(),resolve_after_request()}` were 
annotated to return their `__init__()` param type, failing to recognise that they
are wrapped with `AsyncCallable` before being assigned to the handler instance.

In addition to correcting the return types of those methods, this PR adds the
ability to optionally generate a `ParsedSignature` for the `AsyncCallable` type,
and does so for `before_request` handlers. The return type annotation handling is
then refactored around this.

TODO: what happens if a `before_request` handler has an optional return type?

Original PR message:

When using a before request handler with a route with  a `Template` response, the return annotation is set to `T` which causes the the response to be serialized as JSON instead .

It seems to stem from this part of the `HTTPRouteHandler` class:

```python
if before_request_handler := self.resolve_before_request():
        before_request_handler_signature = Signature.from_callable(before_request_handler)
        if (
            before_request_handler_signature.return_annotation
            and before_request_handler_signature.return_annotation is not Signature.empty
        ):
            return_annotation = before_request_handler_signature.return_annotation
```

### Pull Request Checklist

[//]: # "Please review the [Starlite contribution guidelines](https://github.com/starlite-api/starlite/blob/main/CONTRIBUTING.rst) for this repository."

- [x] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR

By submitting this issue, you agree to:

- follow Starlite's [Code of Conduct](https://github.com/starlite-api/.github/blob/main/CODE_OF_CONDUCT.md)
- follow Starlite's [Contribution Guidelines](https://starliteproject.dev/community/contribution-guide)

### Description

[//]: # "Please describe your pull request for new release changelog purposes"

### Close Issue(s)

[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"
